### PR TITLE
Sctp kustomize

### DIFF
--- a/feature-configs/base/sctp/kustomization.yaml
+++ b/feature-configs/base/sctp/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - sctp_module_mc.yaml
+  - sctp_role.yaml

--- a/feature-configs/base/sctp/sctp_module_mc.yaml
+++ b/feature-configs/base/sctp/sctp_module_mc.yaml
@@ -2,7 +2,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: nodename
+    machineconfiguration.openshift.io/role: worker-sctp
   name: load-sctp-module
 spec:
   config:
@@ -17,7 +17,7 @@ spec:
           mode: 420
           path: /etc/modprobe.d/sctp-blacklist.conf
         - contents:
-            source: data:text/plain;charset=utf-8;base64,c2N0cA==
+            source: data:text/plain;charset=utf-8,sctp
           filesystem: root
           mode: 420
           path: /etc/modules-load.d/sctp-load.conf

--- a/feature-configs/base/sctp/sctp_role.yaml
+++ b/feature-configs/base/sctp/sctp_role.yaml
@@ -1,15 +1,16 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
-  name: worker-rt
+  name: sctp-pool
   labels:
-    worker-rt: ""
+    sctp-pool: ""
 spec:
   machineConfigSelector:
     matchExpressions:
-      machineconfiguration.openshift.io/role: "worker-sctp"
+      - {
+          key: machineconfiguration.openshift.io/role,
+          operator: In,
+          values: [worker-sctp, worker],
+        }
   maxUnavailable: null
-  nodeSelector:
-    matchLabels:
-      node-role.kubernetes.io/worker-sctp: ""
   paused: false

--- a/feature-configs/base/sctp/sctp_role.yaml
+++ b/feature-configs/base/sctp/sctp_role.yaml
@@ -1,0 +1,15 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-rt
+  labels:
+    worker-rt: ""
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      machineconfiguration.openshift.io/role: "worker-sctp"
+  maxUnavailable: null
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-sctp: ""
+  paused: false

--- a/feature-configs/demo/sctp/kustomization.yaml
+++ b/feature-configs/demo/sctp/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/sctp
+patchesStrategicMerge:
+  - sctp_machineconfigpool_patch.yaml

--- a/feature-configs/demo/sctp/sctp_machineconfigpool_patch.yaml
+++ b/feature-configs/demo/sctp/sctp_machineconfigpool_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: sctp-pool
+spec:
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-sctp: ""


### PR DESCRIPTION
Kustomize example to deploy sctp.

It adds a new role to the nodes labelled as `node-role.kubernetes.io/worker-sctp: ""`
The choice of the node label to be used for the sctp pool is done via `kustomize`.