### PR TITLE
manifest: use *addon-operator (singular form)

### DIFF
--- a/feature-configs/base/performance/operator_catalogsource.yaml
+++ b/feature-configs/base/performance/operator_catalogsource.yaml
@@ -1,13 +1,13 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: performance-addon-operators-catalogsource
+  name: performance-addon-operator-catalogsource
   namespace: openshift-marketplace
 spec:
   displayName: Openshift Performance Addon Operators
   icon:
     base64data: ""
     mediatype: ""
-  image: quay.io/openshift/performance-addon-operators-registry
+  image: quay.io/openshift/performance-addon-operator-registry
   publisher: Red Hat
   sourceType: grpc

--- a/feature-configs/base/performance/operator_subscription.yaml
+++ b/feature-configs/base/performance/operator_subscription.yaml
@@ -1,10 +1,10 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: performance-addon-operators-subscription
+  name: performance-addon-operator-subscription
   namespace: openshift-performance-addon
 spec:
   channel: alpha
-  name: performance-addon-operators
-  source: performance-addon-operators-catalogsource
+  name: performance-addon-operator
+  source: performance-addon-operator-catalogsource
   sourceNamespace: openshift-marketplace

--- a/feature-configs/demo/performance/operator_catalogsource.patch.yaml
+++ b/feature-configs/demo/performance/operator_catalogsource.patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: performance-addon-operators-catalogsource
+  name: performance-addon-operator-catalogsource
   namespace: openshift-marketplace
 spec:
-  image: quay.io/slintes/performance-addon-operators-registry
+  image: quay.io/slintes/performance-addon-operator-registry

--- a/feature-configs/e2e-gcp/performance/operator_catalogsource.patch.yaml
+++ b/feature-configs/e2e-gcp/performance/operator_catalogsource.patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: performance-addon-operators-catalogsource
+  name: performance-addon-operator-catalogsource
   namespace: openshift-marketplace
 spec:
-  image: quay.io/slintes/performance-addon-operators-registry
+  image: quay.io/slintes/performance-addon-operator-registry


### PR DESCRIPTION
We are moving towards the singular form `performance-addon-operator`
to comply with the stricter linting, hence fix all the relevant
manifests.

Signed-off-by: Francesco Romani <fromani@redhat.com>