### PR TITLE
Check for having at least one node so tests won't panic.

### DIFF
--- a/functests/sctp/sctp.go
+++ b/functests/sctp/sctp.go
@@ -52,6 +52,7 @@ var _ = Describe("sctp", func() {
 			nodes, err := client.Client.Nodes().List(metav1.ListOptions{
 				LabelSelector: sctpNodeSelector,
 			})
+			Expect(len(nodes.Items)).To(BeNumerically(">", 0))
 			Expect(err).ToNot(HaveOccurred())
 			clientNode = nodes.Items[0].ObjectMeta.Labels[hostnameLabel]
 			serverNode = nodes.Items[0].ObjectMeta.Labels[hostnameLabel]

--- a/functests/test_suite_test.go
+++ b/functests/test_suite_test.go
@@ -36,7 +36,7 @@ func TestTest(t *testing.T) {
 	if junitPath != nil {
 		rr = append(rr, reporters.NewJUnitReporter(*junitPath))
 	}
-	RunSpecsWithDefaultAndCustomReporters(t, "CNF Features e2e integratoin tests", rr)
+	RunSpecsWithDefaultAndCustomReporters(t, "CNF Features e2e integration tests", rr)
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
Let's check if we have at least one available node and if not let's fail gracefully.