### PR TITLE
Set the $GOPATH/bin variable to path when running tests

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 
+which go
+if [ $? -ne 0 ]; then
+  echo "No go command available"
+  exit 1
+fi
+
+GOPATH="${GOPATH:-~/go}"
+export PATH=$PATH:$GOPATH/bin
+
 which ginkgo
 if [ $? -ne 0 ]; then
 	echo "Downloading ginkgo tool"
 	go install github.com/onsi/ginkgo/ginkgo
 fi
+
 
 FOCUS=$(echo "$FEATURES" | tr ' ' '|') 
 echo "Focusing on $FOCUS"


### PR DESCRIPTION
Our tests (and probably others we are going to import) depend on the fact that ginkgo is available.
We already download it, but it also has to be in the path

