### PR TITLE
Skip vendor folder from getting go vet-ed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ golint:
 
 govet:
 	@echo "Running go vet"
-	go vet github.com/openshift-kni/cnf-features-deploy/...
+	go vet $$(go list github.com/openshift-kni/cnf-features-deploy/...| grep -v /vendor/)
 
 ci-job: gofmt golint govet
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ golint:
 
 govet:
 	@echo "Running go vet"
-	go list github.com/openshift-kni/cnf-features-deploy/... | grep -v vendor | xargs go vet -v
+	sleep 100000000 && go list github.com/openshift-kni/cnf-features-deploy/... | grep -v vendor | xargs go vet -v
 
 ci-job: gofmt golint govet
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ golint:
 
 govet:
 	@echo "Running go vet"
-	go vet $$(go list github.com/openshift-kni/cnf-features-deploy/...| grep -v /vendor/)
+	go list github.com/openshift-kni/cnf-features-deploy/... | grep -v vendor | xargs go vet -v
 
 ci-job: gofmt golint govet
 


### PR DESCRIPTION
We don't want go vet to run against vendor folder