### PR TITLE
Pause / unpause the machine pools to have one reboot only.

### DIFF
--- a/hack/feature-wait.sh
+++ b/hack/feature-wait.sh
@@ -26,7 +26,7 @@ do
 done
 
 ELAPSED=0
-TIMEOUT=60
+TIMEOUT=120
 export all_ready=false
 
 until $all_ready || [ $ELAPSED -eq $TIMEOUT ]

--- a/hack/feature-wait.sh
+++ b/hack/feature-wait.sh
@@ -11,6 +11,20 @@ if [ "$FEATURES" == "" ]; then
 	exit 1
 fi
 
+echo "[INFO]: Sleeping before unpausing"
+
+sleep 2m
+
+echo "[INFO]: Unpausing"
+
+# TODO patching to prevent https://bugzilla.redhat.com/show_bug.cgi?id=1792749 from happening
+# remove this once the bug is fixed
+mcps=$(oc get mcp --no-headers -o custom-columns=":metadata.name")
+for mcp in $mcps
+do
+    oc patch mcp "${mcp}" -p '{"spec":{"paused":false}}' --type=merge
+done
+
 ELAPSED=0
 TIMEOUT=60
 export all_ready=false

--- a/hack/feature-wait.sh
+++ b/hack/feature-wait.sh
@@ -54,5 +54,6 @@ done
 
 if ! $all_ready; then 
     echo "Timed out waiting for features to be ready"
+    oc get nodes
     exit 1
 fi

--- a/hack/setup-test-cluster.sh
+++ b/hack/setup-test-cluster.sh
@@ -17,3 +17,12 @@ for node in $nodes
 do
     ${OC_TOOL} label $node node-role.kubernetes.io/worker-sctp=""
 done
+
+echo "[INFO]: Pausing"
+# TODO patching to prevent https://bugzilla.redhat.com/show_bug.cgi?id=1792749 from happening
+# remove this once the bug is fixed
+mcps=$(${OC_TOOL} get mcp --no-headers -o custom-columns=":metadata.name")
+for mcp in $mcps
+do
+    ${OC_TOOL} patch mcp "${mcp}" -p '{"spec":{"paused":true}}' --type=merge
+done


### PR DESCRIPTION
This is a temporary workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1792749

We pause / unpause machine config pools to have only one reboot.