### PR TITLE
Have a custom pool that matches two out of three nodes.

### DIFF
--- a/feature-configs/base/sctp/is_ready.sh
+++ b/feature-configs/base/sctp/is_ready.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # no output means that the new machine config wasn't picked by MCO yet
-if [ -z "$(oc get mcp test-pool -o jsonpath='{.spec.configuration.source[?(@.name=="load-sctp-module")].name}')" ]; then
+if [ -z "$(oc get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="load-sctp-module")].name}')" ]; then
     exit 1
 fi
 
-oc wait mcp/test-pool --for condition=updated --timeout 1s
+oc wait mcp/worker-cnf --for condition=updated --timeout 1s

--- a/feature-configs/base/sctp/is_ready.sh
+++ b/feature-configs/base/sctp/is_ready.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # no output means that the new machine config wasn't picked by MCO yet
-if [ -z "$(oc get mcp worker -o jsonpath='{.spec.configuration.source[?(@.name=="load-sctp-module")].name}')" ]; then
+if [ -z "$(oc get mcp test-pool -o jsonpath='{.spec.configuration.source[?(@.name=="load-sctp-module")].name}')" ]; then
     exit 1
 fi
 
-oc wait mcp/worker --for condition=updated --timeout 1s
+oc wait mcp/test-pool --for condition=updated --timeout 1s

--- a/feature-configs/base/sctp/sctp_module_mc.yaml
+++ b/feature-configs/base/sctp/sctp_module_mc.yaml
@@ -2,7 +2,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker-sctp
+    machineconfiguration.openshift.io/role: worker-cnf
   name: load-sctp-module
 spec:
   config:

--- a/feature-configs/e2e-gcp/sctp/sctp_module_mc_patch.yaml
+++ b/feature-configs/e2e-gcp/sctp/sctp_module_mc_patch.yaml
@@ -2,5 +2,5 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker-sctp
+    machineconfiguration.openshift.io/role: worker-cnf
   name: load-sctp-module

--- a/feature-configs/e2e-gcp/sctp/sctp_module_mc_patch.yaml
+++ b/feature-configs/e2e-gcp/sctp/sctp_module_mc_patch.yaml
@@ -2,5 +2,5 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: worker-sctp
   name: load-sctp-module

--- a/functests/sctp/sctp.go
+++ b/functests/sctp/sctp.go
@@ -21,14 +21,21 @@ import (
 const mcYaml = "../sctp/sctp_module_mc.yaml"
 const hostnameLabel = "kubernetes.io/hostname"
 const testNamespace = "sctptest"
-const sctpNodeSelector = "node-role.kubernetes.io/worker-sctp="
 
-var testerImage string
+var (
+	testerImage      string
+	sctpNodeSelector string
+)
 
 func init() {
 	testerImage = os.Getenv("SCTPTEST_IMAGE")
 	if testerImage == "" {
 		testerImage = "fedepaol/sctptest:v1.1"
+	}
+
+	sctpNodeSelector = os.Getenv("SCTPTEST_NODE_SELECTOR")
+	if sctpNodeSelector == "" {
+		sctpNodeSelector = "node-role.kubernetes.io/worker-cnf="
 	}
 }
 

--- a/hack/setup-test-cluster.sh
+++ b/hack/setup-test-cluster.sh
@@ -5,17 +5,12 @@ set -e
 # expect oc to be in PATH by default
 export OC_TOOL="${OC_TOOL:-oc}"
 
-# Label 1 worker node as worker-rt
-echo "[INFO]: Labeling 1 worker node with worker-rt"
-node=$(${OC_TOOL} get nodes --selector='node-role.kubernetes.io/worker' -o name | head -1)
-${OC_TOOL} label $node node-role.kubernetes.io/worker-rt=""
-
-# Label 2 worker node as worker-sctp
-echo "[INFO]: Labeling 2 worker node with worker-sctp"
-nodes=$(${OC_TOOL} get nodes --selector='node-role.kubernetes.io/worker' -o name | sed -n 2,3p)
+# Label 2 worker nodes as worker-cnf
+echo "[INFO]: Labeling 2 worker nodes with worker-cnf"
+nodes=$(${OC_TOOL} get nodes --selector='node-role.kubernetes.io/worker' -o name | sed -n 1,2p)
 for node in $nodes
 do
-    ${OC_TOOL} label $node node-role.kubernetes.io/worker-sctp=""
+    ${OC_TOOL} label $node node-role.kubernetes.io/worker-cnf=""
 done
 
 
@@ -25,22 +20,22 @@ cat <<EOF | ${OC_TOOL} apply -f -
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
-  name: test-pool
+  name: worker-cnf
   labels:
-    test-pool: ""
+    worker-cnf: ""
 spec:
   machineConfigSelector:
     matchExpressions:
       - {
           key: machineconfiguration.openshift.io/role,
           operator: In,
-          values: [worker-sctp, worker],
+          values: [worker-cnf, worker],
         }
   maxUnavailable: null
   paused: false
   nodeSelector:
     matchLabels:
-      node-role.kubernetes.io/worker-sctp: ""
+      node-role.kubernetes.io/worker-cnf: ""
 ---
 EOF
 

--- a/hack/setup-test-cluster.sh
+++ b/hack/setup-test-cluster.sh
@@ -18,6 +18,32 @@ do
     ${OC_TOOL} label $node node-role.kubernetes.io/worker-sctp=""
 done
 
+
+# Note: this is intended to be the only pool we apply all mcs to.
+# Additional mcs must be added to this poll in the selector
+cat <<EOF | ${OC_TOOL} apply -f -
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: test-pool
+  labels:
+    test-pool: ""
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {
+          key: machineconfiguration.openshift.io/role,
+          operator: In,
+          values: [worker-sctp, worker],
+        }
+  maxUnavailable: null
+  paused: false
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-sctp: ""
+---
+EOF
+
 echo "[INFO]: Pausing"
 # TODO patching to prevent https://bugzilla.redhat.com/show_bug.cgi?id=1792749 from happening
 # remove this once the bug is fixed


### PR DESCRIPTION
This allows us to perform negative tests. By adding to the worker pool, we'll have
all no worker without the features installed.

Ideally, once the performance operator can be tied to a pool, we can use this same so we'll test all the features together.

This is also needed as https://github.com/openshift-kni/baremetal-deploy/pull/122 introduces negative tests.