### PR TITLE
Run the origin tests as part of the external tests

### DIFF
--- a/external-tests/clone_repo.sh
+++ b/external-tests/clone_repo.sh
@@ -14,7 +14,7 @@ fi
 # detect latest master hash of the target repo if we're not pinned to a specific commit hash
 if [ -z "$TESTS_TARGET_HASH" ]; then
     echo "Using latest master branch commit for $TESTS_REPO"
-    TESTS_TARGET_HASH=$(git ls-remote "$TESTS_REPO" | grep "refs/heads/master$" | cut -f 1)
+    TESTS_TARGET_HASH=$(git ls-remote "$TESTS_REPO" | grep refs/heads/master$ | cut -f 1)
 fi
 
 echo "$TESTS_REPO commit hash: $TESTS_TARGET_HASH"

--- a/external-tests/clone_repo.sh
+++ b/external-tests/clone_repo.sh
@@ -14,7 +14,7 @@ fi
 # detect latest master hash of the target repo if we're not pinned to a specific commit hash
 if [ -z "$TESTS_TARGET_HASH" ]; then
     echo "Using latest master branch commit for $TESTS_REPO"
-    TESTS_TARGET_HASH=$(git ls-remote "$TESTS_REPO" | grep refs/heads/master | cut -f 1)
+    TESTS_TARGET_HASH=$(git ls-remote "$TESTS_REPO" | grep "refs/heads/master$" | cut -f 1)
 fi
 
 echo "$TESTS_REPO commit hash: $TESTS_TARGET_HASH"

--- a/external-tests/origintests/test.sh
+++ b/external-tests/origintests/test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+which skopeo
+if [ $? -ne 0 ]; then
+	echo "skopeo not available, exiting"
+    exit 1
+fi
+
+OSETESTS_IMAGE="${OSETESTS_IMAGE:-quay.io/openshift/origin-tests:4.4}"
+
+function get_ose_tests_binary {
+    # As CI runs in a pod, we can't directly use the image.
+    # For this reason, we download the image and fetch the binary from the right layer
+    skopeo copy docker://"$OSETESTS_IMAGE" oci:osetests 
+    echo "Fetching openshift-tests binary from $OSETESTS_IMAGE"
+    for layer in osetests/blobs/sha256/*; do
+        testsbin=$(tar -t -f "$layer" | grep openshift-tests)
+        if [[ $testsbin ]]; then 
+            echo "Found $testsbin on $layer"
+            tar xfv "$layer" "$testsbin"
+            mv "$testsbin" _cache/tools/openshift-tests
+            chmod +x _cache/tools/openshift-tests
+            rm -rf osetests
+            break
+        fi
+    done
+}
+
+
+if [ -f _cache/tools/openshift-tests ]; then 
+    echo "openshift-tests binary already present"
+else
+    get_ose_tests_binary
+fi
+
+echo "Provider: $TEST_PROVIDER"
+kubectl version
+_cache/tools/openshift-tests run openshift/conformance/parallel --provider "${TEST_PROVIDER:-}" -o /tmp/artifacts/e2e.log --junit-dir /tmp/artifacts/junit

--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -8,7 +8,6 @@ fi
 
 GOPATH="${GOPATH:-~/go}"
 export PATH=$PATH:$GOPATH/bin
-
 export failed=false
 export failures=()
 
@@ -31,7 +30,14 @@ if ! GOFLAGS=-mod=vendor ginkgo --focus=$FOCUS functests -- -junit /tmp/artifact
   failures+=( "Tier 2 tests for $FEATURES" )
 fi
 
-for feature in $FEATURES; do
+if [[ ! $RUN_ORIGIN_TESTS ]]; then
+  EXTERNALS="$FEATURES"
+else
+  echo "[INFO] Adding origin tests to be run"
+  EXTERNALS="$FEATURES origintests"
+fi
+
+for feature in $EXTERNALS; do
   test_entry_point=external-tests/${feature}/test.sh
   if [[ ! -f $test_entry_point ]]; then
     echo "[INFO] Feature '$feature' does not have external tests entry point"

--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -8,6 +8,7 @@ fi
 
 GOPATH="${GOPATH:-~/go}"
 export PATH=$PATH:$GOPATH/bin
+
 export failed=false
 export failures=()
 


### PR DESCRIPTION
This PR is to extract the ose tests binary from the ose tests image and then running the acceptance tests.
We can't consume the container as under CI, the tests are being executed in a pod and docker in docker require having privileges we don't have there.

So the not so pleasant way we do that is to use skopeo to fetch the image, look for the binary and then extract it.