### PR TITLE
Updated operator, create worker-rt MCP manually

### DIFF
--- a/feature-configs/base/performance/operator_catalogsource.yaml
+++ b/feature-configs/base/performance/operator_catalogsource.yaml
@@ -4,10 +4,10 @@ metadata:
   name: performance-addon-operators-catalogsource
   namespace: openshift-marketplace
 spec:
-  displayName: Openshift Performance Addon Operators
+  displayName: Openshift Performance Addon Operator
   icon:
     base64data: ""
     mediatype: ""
-  image: quay.io/openshift/performance-addon-operators-registry
+  image: quay.io/openshift/performance-addon-operator-registry
   publisher: Red Hat
   sourceType: grpc

--- a/feature-configs/base/performance/operator_subscription.yaml
+++ b/feature-configs/base/performance/operator_subscription.yaml
@@ -1,10 +1,10 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: performance-addon-operators-subscription
+  name: performance-addon-operator-subscription
   namespace: openshift-performance-addon
 spec:
   channel: alpha
-  name: performance-addon-operators
-  source: performance-addon-operators-catalogsource
+  name: performance-addon-operator
+  source: performance-addon-operator-catalogsource
   sourceNamespace: openshift-marketplace

--- a/feature-configs/demo/performance/kustomization.yaml
+++ b/feature-configs/demo/performance/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../base/performance
+  - machine_config_pool.yaml
 
 patchesStrategicMerge:
   - operator_catalogsource.patch.yaml

--- a/feature-configs/demo/performance/machine_config_pool.yaml
+++ b/feature-configs/demo/performance/machine_config_pool.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-rt
+  namespace: openshift-machine-config-operator
+  labels:
+    machineconfiguration.openshift.io/role: worker-rt
+spec:
+  paused: true
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [worker,worker-rt]
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-rt: ""

--- a/feature-configs/demo/performance/operator_catalogsource.patch.yaml
+++ b/feature-configs/demo/performance/operator_catalogsource.patch.yaml
@@ -4,4 +4,4 @@ metadata:
   name: performance-addon-operators-catalogsource
   namespace: openshift-marketplace
 spec:
-  image: quay.io/slintes/performance-addon-operators-registry
+  image: quay.io/slintes/performance-addon-operator-registry:20200121-1756

--- a/feature-configs/e2e-gcp/performance/kustomization.yaml
+++ b/feature-configs/e2e-gcp/performance/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../base/performance
+  - machine_config_pool.yaml
 
 patchesStrategicMerge:
   - operator_catalogsource.patch.yaml

--- a/feature-configs/e2e-gcp/performance/machine_config_pool.yaml
+++ b/feature-configs/e2e-gcp/performance/machine_config_pool.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-rt
+  namespace: openshift-machine-config-operator
+  labels:
+    machineconfiguration.openshift.io/role: worker-rt
+spec:
+  paused: true
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [worker,worker-rt]
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-rt: ""

--- a/feature-configs/e2e-gcp/performance/operator_catalogsource.patch.yaml
+++ b/feature-configs/e2e-gcp/performance/operator_catalogsource.patch.yaml
@@ -4,4 +4,4 @@ metadata:
   name: performance-addon-operators-catalogsource
   namespace: openshift-marketplace
 spec:
-  image: quay.io/slintes/performance-addon-operators-registry
+  image: quay.io/slintes/performance-addon-operator-registry:20200121-1756


### PR DESCRIPTION
Updated to the new operator, which does not create the MCP anymore. So create the MCP manually with kustomize.

TODO: decide what to do about official upstream images (at least I use a specific tag now)

Supersedes #13 

@davidvossel @fedepaol @fromanirh 