### PR TITLE
Move the pause / unpause logic in feature_deploy.sh

### DIFF
--- a/hack/feature-wait.sh
+++ b/hack/feature-wait.sh
@@ -11,20 +11,6 @@ if [ "$FEATURES" == "" ]; then
 	exit 1
 fi
 
-echo "[INFO]: Sleeping before unpausing"
-
-sleep 2m
-
-echo "[INFO]: Unpausing"
-
-# TODO patching to prevent https://bugzilla.redhat.com/show_bug.cgi?id=1792749 from happening
-# remove this once the bug is fixed
-mcps=$(oc get mcp --no-headers -o custom-columns=":metadata.name")
-for mcp in $mcps
-do
-    oc patch mcp "${mcp}" -p '{"spec":{"paused":false}}' --type=merge
-done
-
 ELAPSED=0
 TIMEOUT=120
 export all_ready=false

--- a/hack/setup-test-cluster.sh
+++ b/hack/setup-test-cluster.sh
@@ -39,11 +39,3 @@ spec:
 ---
 EOF
 
-echo "[INFO]: Pausing"
-# TODO patching to prevent https://bugzilla.redhat.com/show_bug.cgi?id=1792749 from happening
-# remove this once the bug is fixed
-mcps=$(${OC_TOOL} get mcp --no-headers -o custom-columns=":metadata.name")
-for mcp in $mcps
-do
-    ${OC_TOOL} patch mcp "${mcp}" -p '{"spec":{"paused":true}}' --type=merge
-done


### PR DESCRIPTION
That's more clear and reduces the "critical section" to the same file.

In this way we can run make setup-test-cluster and make features-deploy
without being forced to call make feature-wait.
