### PR TITLE
remove unused references to worker-rt label

### DIFF
--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -10,13 +10,6 @@ const (
 )
 
 const (
-	// RoleWorker contains the worker role
-	RoleWorker = "worker"
-	// RoleWorkerRT contains the worker-rt role
-	RoleWorkerRT = "worker-rt"
-)
-
-const (
 	// ResourceSRIOV contains the name of SRIOV resource under the node
 	ResourceSRIOV = corev1.ResourceName("openshift.io/sriovnic")
 )


### PR DESCRIPTION
These unused constants still point to worker-rt and worker roles. I'm just removing them so they don't get referenced again somewhere later on now that we're not converging on the worker-rt label. 