### PR TITLE
Add network policy in demo for dpdk

### DIFF
--- a/feature-configs/demo/sriov/dpdk-network.yaml
+++ b/feature-configs/demo/sriov/dpdk-network.yaml
@@ -1,0 +1,18 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: dpdk-network
+  namespace: openshift-sriov-network-operator
+spec:
+  ipam: |
+    {
+      "type": "dhcp"
+    }
+  networkNamespace: dpdk-testing
+  resourceName: dpdknic
+  vlan: 0
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dpdk-testing

--- a/feature-configs/demo/sriov/kustomization.yaml
+++ b/feature-configs/demo/sriov/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 
 resources:
   - ../../base/sriov
+  - sriov-networknodepolicy-dpdk.yaml
+  - dpdk-network.yaml
 patchesStrategicMerge:
   - sriov-subscription.yaml
   - sriov-networknodepolicy.yaml

--- a/feature-configs/demo/sriov/sriov-networknodepolicy-dpdk.yaml
+++ b/feature-configs/demo/sriov/sriov-networknodepolicy-dpdk.yaml
@@ -1,14 +1,16 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: sriov-network-node-policy
+  name: dpdk-network-node-policy
   namespace: openshift-sriov-network-operator
 spec:
-  deviceType: netdevice
+  deviceType: vfio-pci
   isRdma: false
   nicSelector:
     pfNames:
-      - eno1
+      - eno2
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
   numVfs: 5
+  priority: 10
+  resourceName: dpdknic


### PR DESCRIPTION
This PR adds the requested yamls to configure the second interface in the demo environment to use vfio for dpdk.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>