### PR TITLE
Updated operator

### DIFF
--- a/feature-configs/demo/performance/operator_catalogsource.patch.yaml
+++ b/feature-configs/demo/performance/operator_catalogsource.patch.yaml
@@ -4,4 +4,4 @@ metadata:
   name: performance-addon-operator-catalogsource
   namespace: openshift-marketplace
 spec:
-  image: quay.io/slintes/performance-addon-operator-registry:20200121-1756
+  image: quay.io/slintes/performance-addon-operator-registry:20200124-2215

--- a/feature-configs/e2e-gcp/performance/operator_catalogsource.patch.yaml
+++ b/feature-configs/e2e-gcp/performance/operator_catalogsource.patch.yaml
@@ -4,4 +4,4 @@ metadata:
   name: performance-addon-operator-catalogsource
   namespace: openshift-marketplace
 spec:
-  image: quay.io/slintes/performance-addon-operator-registry:20200121-1756
+  image: quay.io/slintes/performance-addon-operator-registry:20200124-2215


### PR DESCRIPTION
Updated operator

- it uses MCO for RT kernel now
- needs latest OCP 4.4 cluster!

Signed-off-by: Marc Sluiter <msluiter@redhat.com>