### PR TITLE
Change the sriov network config in demo

### DIFF
--- a/feature-configs/demo/sriov/sriov-networknodepolicy-dpdk.yaml
+++ b/feature-configs/demo/sriov/sriov-networknodepolicy-dpdk.yaml
@@ -4,8 +4,8 @@ metadata:
   name: dpdk-network-node-policy
   namespace: openshift-sriov-network-operator
 spec:
-  deviceType: vfio-pci
-  isRdma: false
+  deviceType: netdevice
+  isRdma: true
   nicSelector:
     pfNames:
       - eno2

--- a/feature-configs/demo/sriov/sriov-networknodepolicy.yaml
+++ b/feature-configs/demo/sriov/sriov-networknodepolicy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   deviceType: netdevice
-  isRdma: false
+  isRdma: true
   nicSelector:
     pfNames:
       - eno1


### PR DESCRIPTION
This PR change the network config CR to work with mellanox

For mellanox cards the driver needs to by netdevice for both dpdk
workload or regular network card.

We also need to mark the RDMA as true for mellanox cards

Signed-off-by: Sebastian Sch <sebassch@gmail.com>