### PR TITLE
Align PATH to the new go location

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -3,8 +3,8 @@ FROM fedora:31
 ENV GOPATH /go
 ENV GOBIN /go/bin
 ENV GOCACHE /go/.cache
-ENV PATH=$PATH:$GOPATH/bin
 ENV GOVERSION 1.13.5
+ENV PATH=$PATH:/root/.gimme/versions/go"$GOVERSION".linux.amd64/bin
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/cnf-features-deploy
 
 # rpms required for building and running test suites


### PR DESCRIPTION
As we are now using gimme to provide the go binary, and the entry point is being executed via `/bin/sh`