### PR TITLE
Use mirrored upstream repo for performance images

### DIFF
--- a/feature-configs/e2e-gcp/performance/operator_catalogsource.patch.yaml
+++ b/feature-configs/e2e-gcp/performance/operator_catalogsource.patch.yaml
@@ -4,4 +4,4 @@ metadata:
   name: performance-addon-operator-catalogsource
   namespace: openshift-marketplace
 spec:
-  image: quay.io/slintes/performance-addon-operator-registry:20200121-1756
+  image: quay.io/openshift-kni/performance-addon-operator-registry:latest


### PR DESCRIPTION
the performance-addon-operator images are being mirrored to the quay.io/openshift-kni org. For the e2e tests, we can use the latest images to ensure we stay in sync. 

The other environments, like demo for instance, shouldn't use floating tags. 