### PR TITLE
Fix tester dockerfile as it will be executed from project root in CI.

### DIFF
--- a/tools/sctptester/Dockerfile
+++ b/tools/sctptester/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM golang:1.13 AS builder
 WORKDIR /gotest
-COPY . .
+COPY ./tools/sctptester .
 RUN go mod init github.com/openshift-kni/cnf-features-deploy/sctptester
 RUN go get
 RUN go build -o sctptest


### PR DESCRIPTION
We want to COPY only the sctptester folder and not the whole prj folder.

This is needed to fix failures of rehearsals in https://github.com/openshift/release/pull/6793