### PR TITLE
Replaced kustomize with oc apply -k

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ export FEATURES_ENVIRONMENT?=e2e-gcp
 	golint \
 	govet \
 	ci-job \
-	kustomize \
 	feature-deploy
 
 TARGET_GOOS=linux
@@ -18,12 +17,6 @@ TARGET_GOARCH=amd64
 
 CACHE_DIR="_cache"
 TOOLS_DIR="$(CACHE_DIR)/tools"
-
-KUSTOMIZE_VERSION="v3.5.3"
-KUSTOMIZE_PLATFORM ?= "linux_amd64"
-KUSTOMIZE_BIN="kustomize"
-KUSTOMIZE_TAR="$(KUSTOMIZE_BIN)_$(KUSTOMIZE_VERSION)_$(KUSTOMIZE_PLATFORM).tar.gz"
-KUSTOMIZE="$(TOOLS_DIR)/$(KUSTOMIZE_BIN)"
 
 # Export GO111MODULE=on to enable project to be built from within GOPATH/src
 export GO111MODULE=on
@@ -53,20 +46,8 @@ govet:
 
 ci-job: gofmt golint govet
 
-kustomize:
-	@if [ ! -x "$(KUSTOMIZE)" ]; then\
-		echo "Downloading kustomize $(KUSTOMIZE_VERSION)";\
-		mkdir -p $(TOOLS_DIR);\
-		curl -JL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/$(KUSTOMIZE_VERSION)/$(KUSTOMIZE_TAR) -o $(TOOLS_DIR)/$(KUSTOMIZE_TAR);\
-		tar -xvf $(TOOLS_DIR)/$(KUSTOMIZE_TAR) -C $(TOOLS_DIR);\
-		rm -rf $(TOOLS_DIR)/$(KUSTOMIZE_TAR);\
-		chmod +x $(KUSTOMIZE);\
-	else\
-		echo "Using kustomize cached at $(KUSTOMIZE)";\
-	fi
-
-feature-deploy: kustomize
-	KUSTOMIZE=$(KUSTOMIZE) FEATURES_ENVIRONMENT=$(FEATURES_ENVIRONMENT) FEATURES="$(FEATURES)" hack/feature-deploy.sh
+feature-deploy:
+	FEATURES_ENVIRONMENT=$(FEATURES_ENVIRONMENT) FEATURES="$(FEATURES)" hack/feature-deploy.sh
 
 setup-test-cluster:
 	@echo "Setting up test cluster"

--- a/feature-configs/demo/performance/kustomization.yaml
+++ b/feature-configs/demo/performance/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
+bases:
   - ../../base/performance
 
 patchesStrategicMerge:

--- a/feature-configs/demo/ptp/kustomization.yaml
+++ b/feature-configs/demo/ptp/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
+bases:
   - ../../base/ptp
   - ptpconfig-grandmaster.yaml
 patchesStrategicMerge:

--- a/feature-configs/demo/sctp/kustomization.yaml
+++ b/feature-configs/demo/sctp/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
+bases:
   - ../../base/sctp
 patchesStrategicMerge:
   - sctp_module_mc_patch.yaml

--- a/feature-configs/demo/sriov/kustomization.yaml
+++ b/feature-configs/demo/sriov/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
+bases:
   - ../../base/sriov
   - sriov-networknodepolicy-dpdk.yaml
   - dpdk-network.yaml

--- a/feature-configs/e2e-gcp/performance/kustomization.yaml
+++ b/feature-configs/e2e-gcp/performance/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
+bases:
   - ../../base/performance
 
 patchesStrategicMerge:

--- a/feature-configs/e2e-gcp/sctp/kustomization.yaml
+++ b/feature-configs/e2e-gcp/sctp/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
+bases:
   - ../../base/sctp
 patchesStrategicMerge:
   - sctp_module_mc_patch.yaml

--- a/hack/feature-deploy.sh
+++ b/hack/feature-deploy.sh
@@ -15,9 +15,6 @@ fi
 # expect oc to be in PATH by default
 export OC_TOOL="${OC_TOOL:-oc}"
 
-# expect kustomize to be in PATH by default
-KUSTOMIZE="${KUSTOMIZE:-kustomize}"
-
 echo "[INFO]: Pausing"
 # TODO patching to prevent https://bugzilla.redhat.com/show_bug.cgi?id=1792749 from happening
 # remove this once the bug is fixed
@@ -55,7 +52,7 @@ do
 
     echo "[INFO] Deploying feature '$feature' for environment '$FEATURES_ENVIRONMENT'"
     set +e
-    if ! ${KUSTOMIZE} build $feature_dir | ${OC_TOOL} apply -f -
+    if ! ${OC_TOOL} apply -k $feature_dir
     then
       echo "[WARN] Deployment of feature '$feature' failed."
       feature_failed=1

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -34,11 +34,7 @@ RUN mkdir ~/bin && \
     tar -xzvf oc.tar.gz && \
     mv oc /usr/local/bin/oc && \
     ln -s /usr/local/bin/oc /usr/local/bin/kubectl && \
-    rm -f oc.tar.gz && \
-    curl -JL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.3/kustomize_v3.5.3_linux_amd64.tar.gz -o kustomize.tar.gz && \
-    tar -xzvf kustomize.tar.gz && \
-    mv kustomize /usr/local/bin/kustomize && \
-    rm -f kustomize.tar.gz
+    rm -f oc.tar.gz
 
 RUN export TMP_BIN=$(mktemp -d) && \
     mv $GOBIN/* $TMP_BIN/ && \


### PR DESCRIPTION
Since `oc` comes with an older `kustomize` version, overrides need to use
`bases` instead `resources`
