### PR TITLE
Change the FEATURES example as we expect it to be a string in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ All the Makefile rules depend on two environment variable, either for deploying,
 
 ##### FEATURES
 
-i.e. `FEATURES=(sctp ptp sriov)`, drives what features are going to be deployed using kustomize, and what tests are going to be run.
+i.e. `FEATURES="sctp ptp sriov"`, drives what features are going to be deployed using kustomize, and what tests are going to be run.
 
-The current default values is `(sctp performace)`
+The current default values is `"sctp performace"`
 
 ##### FEATURES_ENVIRONMENT
 


### PR DESCRIPTION
We can't have env variables as array as https://unix.stackexchange.com/questions/393091/unable-to-use-an-array-as-environment-variable so we rely on the string and we iterate over its values.

