### PR TITLE
DPDK functests: adding a simple sanity test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #TODO add default features here
-export FEATURES?=sctp performance dpdk
+export FEATURES?=sctp performance
 
 # The environment represents the kustomize patches to apply when deploying the features
 export FEATURES_ENVIRONMENT?=e2e-gcp

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #TODO add default features here
-export FEATURES?=sctp performance
+export FEATURES?=sctp performance dpdk
 
 # The environment represents the kustomize patches to apply when deploying the features
 export FEATURES_ENVIRONMENT?=e2e-gcp

--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -1,0 +1,250 @@
+package dpdk
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/execute"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/namespaces"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/nodes"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/pods"
+)
+
+const (
+	dpdkHostRole         = "worker"
+	hostnameLabel         = "kubernetes.io/hostname"
+	dpdkAnnotationNetwork = "dpdk-network"
+	testDpdkNamespace     = "dpdk-testing"
+	testCmdPath           = "/opt/test.sh"
+
+)
+
+var dpdkAppImage string
+
+func init() {
+	// Set DPDK app image
+	dpdkAppImage = os.Getenv("DPDK_APP_IMAGE")
+	if dpdkAppImage == "" {
+		dpdkAppImage = "quay.io/schseba/dpdk-s2i-base:ds"
+	}
+}
+
+var _ = Describe("dpdk", func() {
+	var nList []corev1.Node
+
+	execute.BeforeAll(func() {
+		// create the namespace
+		err := namespaces.Create(testDpdkNamespace, client.Client)
+		Expect(err).ToNot(HaveOccurred())
+
+		// clean up the namespace
+		err = namespaces.Clean(testDpdkNamespace, client.Client)
+		Expect(err).ToNot(HaveOccurred())
+
+		// get nodes
+		nList, err = nodes.GetByRole(client.Client, dpdkHostRole)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(nList)).ShouldNot(Equal(0))
+	})
+
+	var _ = Context("Run a sanity test on each worker", func() {
+		var configMapName string
+		var p *corev1.Pod
+		AfterEach(func() {
+			pods.WaitForDeletion(client.Client,p, 2*time.Minute)
+			deleteTestpmdConfigMap(configMapName)
+		})
+		It("Should forward and receive packets", func() {
+			c := createTestpmdConfigMap(testDpdkNamespace)
+			configMapName = c.Name
+			for _, n := range nList {
+				p = createTestPod(n.Name, testDpdkNamespace, c.Name)
+				pods.WaitForCondition(client.Client, p,corev1.ContainersReady, corev1.ConditionTrue, 2*time.Minute)
+				By(fmt.Sprintf("Executing %s inside the pod %s", testCmdPath, p.Name))
+				out, err := exec.Command("oc", "rsh", "-n", p.Namespace, p.Name, "bash", testCmdPath).CombinedOutput()
+				Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot execute %s inside the pod %s", testCmdPath, p.Name))
+				By("Parsing output from the DPDK application")
+				checkRxTx(string(out))
+			}
+		})
+	})
+})
+
+// creteTestPod creates a pod that will act as a runtime for the DPDK test application
+func createTestPod(nodeName, namespace, configMapName string) *corev1.Pod {
+	defaultMode := int32(0755)
+
+	res := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-dpdk",
+			Labels: map[string]string{
+				"app": "test-dpdk",
+			},
+			Annotations: map[string]string{
+				"k8s.v1.cni.cncf.io/networks": dpdkAnnotationNetwork,
+			},
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:  "test-dpdk",
+					Image: dpdkAppImage,
+					SecurityContext: &corev1.SecurityContext{
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{"IPC_LOCK"},
+						},
+					},
+					Command:         []string{"/bin/bash", "-c", "--"},
+					Args:            []string{"while true; do sleep inf; done;"},
+					ImagePullPolicy: "Always",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:                     resource.MustParse("4"),
+							corev1.ResourceMemory:                  resource.MustParse("1000Mi"),
+							corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("4Gi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:                     resource.MustParse("4"),
+							corev1.ResourceMemory:                  resource.MustParse("1000Mi"),
+							corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("4Gi"),
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "hugepage",
+							MountPath: "/mnt/huge",
+							ReadOnly:  false,
+						},
+						{
+							Name:      "testcmd",
+							MountPath: testCmdPath,
+							SubPath:   "test.sh",
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "hugepage",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMediumHugePages,
+						},
+					},
+				},
+				{
+					Name: "testcmd",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							corev1.LocalObjectReference{Name: configMapName},
+							nil,
+							&defaultMode,
+							nil,
+						},
+					},
+				},
+			},
+
+			NodeSelector: map[string]string{
+				hostnameLabel: nodeName,
+			},
+		},
+	}
+
+	By("Creating a test pod")
+	p, err := client.Client.Pods(namespace).Create(res)
+	Expect(err).ToNot(HaveOccurred(), "cannot create the test pod " + p.Name)
+	return p
+}
+
+// createTestpmdConfigMap creates a ConfigMap that mounts testpmd wrapper script
+// The script is a mix of bash and expect. Expect is required to interact with
+// the testpmd application
+func createTestpmdConfigMap(namespace string) *corev1.ConfigMap {
+	m := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpmd",
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"test.sh": `
+#!/usr/bin/bash
+CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
+echo ${CPU}
+echo ${PCIDEVICE_OPENSHIFT_IO_DPDKNIC}
+
+TMPEXPECT=$(mktemp /tmp/expect.XXXXXX)
+
+/bin/cat<<-EOL > $TMPEXPECT
+  spawn testpmd -l ${CPU} -w ${PCIDEVICE_OPENSHIFT_IO_DPDKNIC}  -- -i --portmask=0x1 --nb-cores=2 --forward-mode=mac --port-topology=loop
+  set timeout 10000
+  expect "testpmd>"
+  send -- "start\r"
+  sleep 10
+  expect "testpmd>"
+  send -- "stop\r"
+  expect "testpmd>"
+  send -- "quit\r"
+  expect eof
+EOL
+
+chmod 700 $TMPEXPECT
+expect -f $TMPEXPECT
+                       `,
+		},
+	}
+
+	By("Create testpmd wrapper script")
+	m, err := client.Client.ConfigMaps(testDpdkNamespace).Create(m)
+	Expect(err).ToNot(HaveOccurred(), "cannot create testpmd wrapper script")
+	return m
+}
+
+// deleteTestpmdConfigMap 
+func deleteTestpmdConfigMap(configMapName string) {
+	By("Deleting configMap " + configMapName)
+	err := client.Client.ConfigMaps(testDpdkNamespace).Delete(configMapName, &metav1.DeleteOptions{})
+	Expect(err).ToNot(HaveOccurred())
+}
+
+// checkRxTx parses the output from the DPDK test application
+// and verifies that packets have passed the NIC TX and RX queues
+func checkRxTx(out string) {
+	str := strings.Split(out, "\n")
+	for i := 0; i < len(str); i++ {
+		if strings.Contains(str[i], "all ports") {
+			i++
+			d := getNumberOfPackets(str, i)
+			Expect(d).Should(BeNumerically(">", 0), "number of received packets should be greater than 0")
+
+			i++
+	        d = getNumberOfPackets(str, i)
+			Expect(d).Should(BeNumerically(">", 0), "number of transferred packets should be greater than 0")
+		}
+	}
+}
+
+// getNumber of packets parses the string (represented as a slice)
+// and returns an element representing the number of packets
+func getNumberOfPackets(s []string, index int) int {
+	r := strings.Fields(s[index])
+	Expect(len(r)).To(Equal(6), "the slice doesn't contain 6 elements")
+	d, err := strconv.Atoi(r[1])
+	Expect(err).ToNot(HaveOccurred())
+    return d
+}
+

--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -1,9 +1,7 @@
 package dpdk
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -36,10 +34,12 @@ var _ = Describe("dpdk", func() {
 	var _ = Context("Run a sanity test on a worker", func() {
 		It("Should forward and receive packets", func() {
 			var out string
-			p := findPod()
+			var err error
+			p := findDPDKWorkloadPod()
 			By("Parsing output from the DPDK application")
 			Eventually(func() string {
-				out = getPodLog(p)
+				out, err = pods.GetLog(p)
+				Expect(err).ToNot(HaveOccurred())
 				return out
 			}, 8*time.Minute, 1*time.Second).Should(ContainSubstring(logEntry),
 				"Cannot find accumulated statistics")
@@ -51,40 +51,38 @@ var _ = Describe("dpdk", func() {
 // checkRxTx parses the output from the DPDK test application
 // and verifies that packets have passed the NIC TX and RX queues
 func checkRxTx(out string) {
-	str := strings.Split(out, "\n")
-	for i := 0; i < len(str); i++ {
-		if strings.Contains(str[i], logEntry) {
-			i++
-			d := getNumberOfPackets(str, i)
-			Expect(d).Should(BeNumerically(">", 0), "number of received packets should be greater than 0")
-
-			i++
-			d = getNumberOfPackets(str, i)
-			Expect(d).Should(BeNumerically(">", 0), "number of transferred packets should be greater than 0")
+	lines := strings.Split(out, "\n")
+	for i, line := range lines {
+		if strings.Contains(line, logEntry) {
+			d := getNumberOfPackets(lines[i+1], "RX")
+			Expect(d).To(BeNumerically(">", 0), "number of received packets should be greater than 0")
+			d = getNumberOfPackets(lines[i+2], "TX")
+			Expect(d).To(BeNumerically(">", 0), "number of transferred packets should be greater than 0")
 			break
 		}
 	}
 }
 
-// getNumber of packets parses the string (represented as a slice)
+// getNumberOfPackets parses the string
 // and returns an element representing the number of packets
-func getNumberOfPackets(s []string, index int) int {
-	r := strings.Fields(s[index])
+func getNumberOfPackets(line, firstFieldSubstr string) int {
+	r := strings.Fields(line)
+	Expect(r[0]).To(ContainSubstring(firstFieldSubstr))
 	Expect(len(r)).To(Equal(6), "the slice doesn't contain 6 elements")
 	d, err := strconv.Atoi(r[1])
 	Expect(err).ToNot(HaveOccurred())
 	return d
 }
 
-// findPod finds a pod running a DPDK application
-func findPod() *corev1.Pod {
+// findDPDKWorkloadPod finds a pod running a DPDK application
+func findDPDKWorkloadPod() *corev1.Pod {
 	listOptions := metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{"deploymentconfig": "s2i-dpdk-app"}).String(),
 	}
 
 	p, err := client.Client.Pods(testDpdkNamespace).List(listOptions)
 	Expect(err).ToNot(HaveOccurred())
-	Expect(len(p.Items)).ShouldNot(Equal(0), "no pods found")
+	Expect(len(p.Items)).ToNot(Equal(0), "no pods found")
 
 	var pod corev1.Pod
 	podReady := false
@@ -95,23 +93,7 @@ func findPod() *corev1.Pod {
 		}
 	}
 
-	Expect(podReady).Should(BeTrue(), fmt.Sprintf("the pod %s is not ready", pod.Name))
+	Expect(podReady).To(BeTrue(), fmt.Sprintf("the pod %s is not ready", pod.Name))
 	pods.WaitForCondition(client.Client, &pod, corev1.ContainersReady, corev1.ConditionTrue, 3*time.Minute)
 	return &pod
-}
-
-// getPodLog connects to a pod and fetches log
-func getPodLog(p *corev1.Pod) string {
-	req := client.Client.Pods(p.Namespace).GetLogs(p.Name, &corev1.PodLogOptions{})
-	log, err := req.Stream()
-	Expect(err).ToNot(HaveOccurred())
-
-	defer log.Close()
-
-	buf := new(bytes.Buffer)
-	_, err = io.Copy(buf, log)
-	Expect(err).ToNot(HaveOccurred())
-	str := buf.String()
-
-	return str
 }

--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -37,7 +37,6 @@ var _ = Describe("dpdk", func() {
 		It("Should forward and receive packets", func() {
 			var out string
 			p := findPod()
-			pods.WaitForCondition(client.Client, p, corev1.ContainersReady, corev1.ConditionTrue, 2*time.Minute)
 			By("Parsing output from the DPDK application")
 			Eventually(func() string {
 				out = getPodLog(p)
@@ -62,6 +61,7 @@ func checkRxTx(out string) {
 			i++
 			d = getNumberOfPackets(str, i)
 			Expect(d).Should(BeNumerically(">", 0), "number of transferred packets should be greater than 0")
+			break
 		}
 	}
 }

--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -1,9 +1,9 @@
 package dpdk
 
 import (
-	"fmt"
+	"bytes"
+	"io"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -12,32 +12,25 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/execute"
-	"github.com/openshift-kni/cnf-features-deploy/functests/utils/namespaces"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/nodes"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/pods"
 )
 
-const (
-	dpdkHostRole         = "worker"
-	hostnameLabel         = "kubernetes.io/hostname"
-	dpdkAnnotationNetwork = "dpdk-network"
-	testDpdkNamespace     = "dpdk-testing"
-	testCmdPath           = "/opt/test.sh"
+// Worker node role
+const dpdkHostRole = "worker-cnf"
 
-)
-
-var dpdkAppImage string
+var testDpdkNamespace string
 
 func init() {
-	// Set DPDK app image
-	dpdkAppImage = os.Getenv("DPDK_APP_IMAGE")
-	if dpdkAppImage == "" {
-		dpdkAppImage = "quay.io/schseba/dpdk-s2i-base:ds"
+	testDpdkNamespace = os.Getenv("DPDK_TEST_NAMESPACE")
+	if testDpdkNamespace == "" {
+		testDpdkNamespace = "dpdk-testing"
 	}
 }
 
@@ -45,181 +38,31 @@ var _ = Describe("dpdk", func() {
 	var nList []corev1.Node
 
 	execute.BeforeAll(func() {
-		// create the namespace
-		err := namespaces.Create(testDpdkNamespace, client.Client)
-		Expect(err).ToNot(HaveOccurred())
-
-		// clean up the namespace
-		err = namespaces.Clean(testDpdkNamespace, client.Client)
-		Expect(err).ToNot(HaveOccurred())
-
 		// get nodes
+		var err error
 		nList, err = nodes.GetByRole(client.Client, dpdkHostRole)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(nList)).ShouldNot(Equal(0))
 	})
 
 	var _ = Context("Run a sanity test on each worker", func() {
-		var configMapName string
-		var p *corev1.Pod
-		AfterEach(func() {
-			pods.WaitForDeletion(client.Client,p, 2*time.Minute)
-			deleteTestpmdConfigMap(configMapName)
-		})
 		It("Should forward and receive packets", func() {
-			c := createTestpmdConfigMap(testDpdkNamespace)
-			configMapName = c.Name
+			const stopMessage = "Accumulated forward statistics for all ports"
+			var out string
 			for _, n := range nList {
-				p = createTestPod(n.Name, testDpdkNamespace, c.Name)
-				pods.WaitForCondition(client.Client, p,corev1.ContainersReady, corev1.ConditionTrue, 2*time.Minute)
-				By(fmt.Sprintf("Executing %s inside the pod %s", testCmdPath, p.Name))
-				out, err := exec.Command("oc", "rsh", "-n", p.Namespace, p.Name, "bash", testCmdPath).CombinedOutput()
-				Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot execute %s inside the pod %s", testCmdPath, p.Name))
+				p := findPod(n.Name)
+				pods.WaitForCondition(client.Client, p, corev1.ContainersReady, corev1.ConditionTrue, 2*time.Minute)
 				By("Parsing output from the DPDK application")
-				checkRxTx(string(out))
+				Eventually(func() string {
+					out = getPodLog(p)
+					return out
+				}, 8*time.Minute, 1*time.Second).Should(ContainSubstring(stopMessage),
+					"Cannot find accumulated statistics")
+				checkRxTx(out)
 			}
 		})
 	})
 })
-
-// creteTestPod creates a pod that will act as a runtime for the DPDK test application
-func createTestPod(nodeName, namespace, configMapName string) *corev1.Pod {
-	defaultMode := int32(0755)
-
-	res := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "test-dpdk",
-			Labels: map[string]string{
-				"app": "test-dpdk",
-			},
-			Annotations: map[string]string{
-				"k8s.v1.cni.cncf.io/networks": dpdkAnnotationNetwork,
-			},
-			Namespace: namespace,
-		},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			Containers: []corev1.Container{
-				{
-					Name:  "test-dpdk",
-					Image: dpdkAppImage,
-					SecurityContext: &corev1.SecurityContext{
-						Capabilities: &corev1.Capabilities{
-							Add: []corev1.Capability{"IPC_LOCK"},
-						},
-					},
-					Command:         []string{"/bin/bash", "-c", "--"},
-					Args:            []string{"while true; do sleep inf; done;"},
-					ImagePullPolicy: "Always",
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:                     resource.MustParse("4"),
-							corev1.ResourceMemory:                  resource.MustParse("1000Mi"),
-							corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("4Gi"),
-						},
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:                     resource.MustParse("4"),
-							corev1.ResourceMemory:                  resource.MustParse("1000Mi"),
-							corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("4Gi"),
-						},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "hugepage",
-							MountPath: "/mnt/huge",
-							ReadOnly:  false,
-						},
-						{
-							Name:      "testcmd",
-							MountPath: testCmdPath,
-							SubPath:   "test.sh",
-						},
-					},
-				},
-			},
-			Volumes: []corev1.Volume{
-				{
-					Name: "hugepage",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{
-							Medium: corev1.StorageMediumHugePages,
-						},
-					},
-				},
-				{
-					Name: "testcmd",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							corev1.LocalObjectReference{Name: configMapName},
-							nil,
-							&defaultMode,
-							nil,
-						},
-					},
-				},
-			},
-
-			NodeSelector: map[string]string{
-				hostnameLabel: nodeName,
-			},
-		},
-	}
-
-	By("Creating a test pod")
-	p, err := client.Client.Pods(namespace).Create(res)
-	Expect(err).ToNot(HaveOccurred(), "cannot create the test pod " + p.Name)
-	return p
-}
-
-// createTestpmdConfigMap creates a ConfigMap that mounts testpmd wrapper script
-// The script is a mix of bash and expect. Expect is required to interact with
-// the testpmd application
-func createTestpmdConfigMap(namespace string) *corev1.ConfigMap {
-	m := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testpmd",
-			Namespace: namespace,
-		},
-		Data: map[string]string{
-			"test.sh": `
-#!/usr/bin/bash
-CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
-echo ${CPU}
-echo ${PCIDEVICE_OPENSHIFT_IO_DPDKNIC}
-
-TMPEXPECT=$(mktemp /tmp/expect.XXXXXX)
-
-/bin/cat<<-EOL > $TMPEXPECT
-  spawn testpmd -l ${CPU} -w ${PCIDEVICE_OPENSHIFT_IO_DPDKNIC}  -- -i --portmask=0x1 --nb-cores=2 --forward-mode=mac --port-topology=loop
-  set timeout 10000
-  expect "testpmd>"
-  send -- "start\r"
-  sleep 10
-  expect "testpmd>"
-  send -- "stop\r"
-  expect "testpmd>"
-  send -- "quit\r"
-  expect eof
-EOL
-
-chmod 700 $TMPEXPECT
-expect -f $TMPEXPECT
-                       `,
-		},
-	}
-
-	By("Create testpmd wrapper script")
-	m, err := client.Client.ConfigMaps(testDpdkNamespace).Create(m)
-	Expect(err).ToNot(HaveOccurred(), "cannot create testpmd wrapper script")
-	return m
-}
-
-// deleteTestpmdConfigMap 
-func deleteTestpmdConfigMap(configMapName string) {
-	By("Deleting configMap " + configMapName)
-	err := client.Client.ConfigMaps(testDpdkNamespace).Delete(configMapName, &metav1.DeleteOptions{})
-	Expect(err).ToNot(HaveOccurred())
-}
 
 // checkRxTx parses the output from the DPDK test application
 // and verifies that packets have passed the NIC TX and RX queues
@@ -232,7 +75,7 @@ func checkRxTx(out string) {
 			Expect(d).Should(BeNumerically(">", 0), "number of received packets should be greater than 0")
 
 			i++
-	        d = getNumberOfPackets(str, i)
+			d = getNumberOfPackets(str, i)
 			Expect(d).Should(BeNumerically(">", 0), "number of transferred packets should be greater than 0")
 		}
 	}
@@ -245,6 +88,47 @@ func getNumberOfPackets(s []string, index int) int {
 	Expect(len(r)).To(Equal(6), "the slice doesn't contain 6 elements")
 	d, err := strconv.Atoi(r[1])
 	Expect(err).ToNot(HaveOccurred())
-    return d
+	return d
 }
 
+// findPod finds a pod running on appropriate node
+func findPod(nodeName string) *corev1.Pod {
+	listOptions := metav1.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}).String(),
+	}
+
+	listOptions.LabelSelector = labels.SelectorFromSet(labels.Set{"deploymentconfig": "s2i-dpdk-app"}).String()
+	p, err := client.Client.Pods(testDpdkNamespace).List(listOptions)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(len(p.Items)).ShouldNot(Equal(0))
+
+	var pod corev1.Pod
+	var i int
+	for i, pod = range p.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			break
+		}
+		i++
+	}
+
+	Expect(i).ShouldNot(Equal(len(p.Items)))
+
+	pods.WaitForCondition(client.Client, &pod, corev1.ContainersReady, corev1.ConditionTrue, 3*time.Minute)
+	return &pod
+}
+
+// getPodLog connects to a pod and fetches log
+func getPodLog(p *corev1.Pod) string {
+	req := client.Client.Pods(p.Namespace).GetLogs(p.Name, &corev1.PodLogOptions{})
+	log, err := req.Stream()
+	Expect(err).ToNot(HaveOccurred())
+
+	defer log.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, log)
+	Expect(err).ToNot(HaveOccurred())
+	str := buf.String()
+
+	return str
+}

--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -52,6 +52,7 @@ var _ = Describe("dpdk", func() {
 // and verifies that packets have passed the NIC TX and RX queues
 func checkRxTx(out string) {
 	lines := strings.Split(out, "\n")
+	Expect(len(lines)).To(BeNumerically(">=", 3))
 	for i, line := range lines {
 		if strings.Contains(line, logEntry) {
 			d := getNumberOfPackets(lines[i+1], "RX")

--- a/functests/test_suite_test.go
+++ b/functests/test_suite_test.go
@@ -12,6 +12,8 @@ import (
 	. "github.com/onsi/gomega"
 	_ "github.com/openshift-kni/cnf-features-deploy/functests/ptp"  // this is needed otherwise the ptp test won't be executed
 	_ "github.com/openshift-kni/cnf-features-deploy/functests/sctp" // this is needed otherwise the sctp test won't be executed
+	_ "github.com/openshift-kni/cnf-features-deploy/functests/dpdk" // this is needed otherwise the dpdk test won't be executed
+
 	testutils "github.com/openshift-kni/cnf-features-deploy/functests/utils"
 	testclient "github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/namespaces"

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -1,6 +1,8 @@
 package pods
 
 import (
+	"bytes"
+	"io"
 	"time"
 
 	testclient "github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
@@ -58,4 +60,18 @@ func WaitForCondition(cs *testclient.ClientSet, pod *corev1.Pod, conditionType c
 		}
 		return false, nil
 	})
+}
+
+// GetLog connects to a pod and fetches log
+func GetLog(p *corev1.Pod) (string, error) {
+	req := testclient.Client.Pods(p.Namespace).GetLogs(p.Name, &corev1.PodLogOptions{})
+	log, err := req.Stream()
+    if err != nil {
+    	return "", err
+	}
+	defer log.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, log)
+	return buf.String(), nil
 }


### PR DESCRIPTION
The test checks whether DPDK stack works properly.
The test spins up a pod running appropriate container bundled with the DPDK utils and required tools. Then, it mounts appropriate bash/expect script as configmap and executes the script. The script starts up testpmd and uses expect to interact with the process. Afterward, the test parses output and makes a decision. 