### PR TITLE
Always create TOOLS_DIR.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ TARGET_GOARCH=amd64
 CACHE_DIR="_cache"
 TOOLS_DIR="$(CACHE_DIR)/tools"
 
+$(shell mkdir -p $(TOOLS_DIR))
+
 # Export GO111MODULE=on to enable project to be built from within GOPATH/src
 export GO111MODULE=on
 


### PR DESCRIPTION
Before it was begin created by the `kustomize` rule, now removed.

