### PR TITLE
Add performance test without RT kernel

### DIFF
--- a/external-tests/performance/test.sh
+++ b/external-tests/performance/test.sh
@@ -5,4 +5,4 @@ export TESTS_LOCATION=/tmp/performance-operators
 
 external-tests/clone_repo.sh
 cd $TESTS_LOCATION
-ROLE_WORKER_RT=worker-cnf PERF_TEST_PROFILE=performance make functests-only
+ROLE_WORKER_NO_RT=worker-cnf-no-rt ROLE_WORKER_RT=worker-cnf PERF_TEST_PROFILE=performance make functests-only

--- a/feature-configs/base/performance/kustomization.yaml
+++ b/feature-configs/base/performance/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - operator_catalogsource.yaml
   - operator_subscription.yaml
   - performance_profile.yaml
+  - performance_profile_rt_disabled.yaml

--- a/feature-configs/base/performance/performance_profile_rt_disabled.yaml
+++ b/feature-configs/base/performance/performance_profile_rt_disabled.yaml
@@ -1,0 +1,16 @@
+apiVersion: performance.openshift.io/v1alpha1
+kind: PerformanceProfile
+metadata:
+  name: performance_rt_disabled
+spec:
+  cpu:
+    isolated: "1-3"
+    nonIsolated: "0"
+    reserved: "0-1"
+  hugepages:
+    defaultHugepagesSize: "1G"
+    pages:
+    - size: "1G"
+      count: 1
+  realTimeKernel:
+    enabled: false

--- a/feature-configs/e2e-gcp/performance/kustomization.yaml
+++ b/feature-configs/e2e-gcp/performance/kustomization.yaml
@@ -6,3 +6,4 @@ bases:
 
 patchesStrategicMerge:
   - performance_profile.patch.yaml
+  - performance_profile_rt_disabled.patch.yaml

--- a/feature-configs/e2e-gcp/performance/performance_profile_rt_disabled.patch.yaml
+++ b/feature-configs/e2e-gcp/performance/performance_profile_rt_disabled.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: performance.openshift.io/v1alpha1
+kind: PerformanceProfile
+metadata:
+  name: performance_rt_disabled
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf-no-rt: ""


### PR DESCRIPTION
Performance tunings could be applied also on nodes without real time kernel.
For that reason there is a need to enhance the testing framework to check these tunings that should be applied even if we don't install a real-time kernel version on the node. 

A new config pool and a label `node-role.kubernetes.io/worker-cnf-no-rt=""` were added to mark a node that should have this kind of a setup (+ tests)

Note: An additional PR is needed to compliment that on https://github.com/openshift-kni/performance-addon-operators

