### PR TITLE
Fix demo ptp kustomization

### DIFF
--- a/feature-configs/demo/ptp/kustomization.yaml
+++ b/feature-configs/demo/ptp/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 bases:
   - ../../base/ptp
+resources:
   - ptpconfig-grandmaster.yaml
 patchesStrategicMerge:
   - subscription.yaml


### PR DESCRIPTION
This PR fixes the following issue

```
FEATURES_ENVIRONMENT=demo FEATURES="ptp" hack/feature-deploy.sh
[INFO] Deploying feature 'ptp' for environment 'demo'
error: couldn't make loader for ptpconfig-grandmaster.yaml: got file 'ptpconfig-grandmaster.yaml', but '/home/sscheink/Documents/GolangProjects/src/github.com/openshift-kni/cnf-features-deploy/feature-configs/demo/ptp/ptpconfig-grandmaster.yaml' must be a directory to be a root
```

After this PR: https://github.com/openshift-kni/cnf-features-deploy/pull/52

The `base` field is used only for folders.

In the kustomize version integrated with `oc` using the `-k` flag the resources field is for files only so we need to use both `base` and `resources` in the ptp configuration.


Signed-off-by: Sebastian Sch <sebassch@gmail.com>