### PR TITLE
Make the wait for the checksctp pod longer.

### DIFF
--- a/functests/sctp/sctp.go
+++ b/functests/sctp/sctp.go
@@ -277,7 +277,7 @@ func checkForSctpReady(cs *client.ClientSet) {
 			}
 		}
 		return true
-	}, 3*time.Minute, 10*time.Second).Should(Equal(true))
+	}, 10*time.Minute, 10*time.Second).Should(Equal(true))
 }
 
 func testClientServerConnection(cs *client.ClientSet, namespace string, destIP string, port int32, clientNode string, serverPodName string) {


### PR DESCRIPTION
This is to remove flakes we are seeing in CI.
Sometimes, the first `checkForSctpReady` fails and I have the feeling is because it's the first time we use the tester image.