### PR TITLE
Fix the ipv6 network attachment

### DIFF
--- a/feature-configs/demo/sriov/ipv6-network_attachment_defintion.yaml
+++ b/feature-configs/demo/sriov/ipv6-network_attachment_defintion.yaml
@@ -1,19 +1,24 @@
-apiVersion: k8s.cni.cncf.io/v1
-kind: NetworkAttachmentDefinition
-metadata:
-  annotations:
-    k8s.v1.cni.cncf.io/resourceName: openshift.io/sriovnic
-  name: dual-stack-net-attachment-def
-  namespace: sriov-testing
-spec:
-  config: '{ "cniVersion":"0.3.1", "name":"test", "type":"sriov", "vlan":0,"vlanQoS":0,"ipam": {"type": "host-local","ranges": [[{"subnet": "3ffe:ffff:0:01ff::/64"}], [{"subnet": "10.10.0.0/24"}]  ],"dataDir": "/run/my-orchestrator/container-ipam-state3"}}'
 ---
-apiVersion: k8s.cni.cncf.io/v1
-kind: NetworkAttachmentDefinition
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
 metadata:
-  annotations:
-    k8s.v1.cni.cncf.io/resourceName: openshift.io/sriovnic
   name: ipv6only-net-attachment-def
-  namespace: sriov-testing
+  namespace: openshift-sriov-network-operator
 spec:
-  config: '{ "cniVersion":"0.3.1", "name":"test", "type":"sriov", "vlan":0,"vlanQoS":0,"ipam": {"type": "host-local","ranges": [[{"subnet": "3ffe:ffff:0:01ff::/64"}]],"dataDir": "/run/my-orchestrator/container-ipam-state3"}}'
+  ipam: |
+    {"type": "host-local","ranges": [[{"subnet": "3ffe:ffff:0:01ff::/64"}]],"dataDir": "/run/my-orchestrator/container-ipam-state3"}
+  networkNamespace: sriov-testing
+  resourceName: sriovnic
+  vlan: 0
+---
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: dual-stack-net-attachment-def
+  namespace: openshift-sriov-network-operator
+spec:
+  ipam: |
+    {"type": "host-local","ranges": [[{"subnet": "3ffe:ffff:0:01ff::/64"}], [{"subnet": "10.10.0.0/24"}]  ],"dataDir": "/run/my-orchestrator/container-ipam-state3"}
+  networkNamespace: sriov-testing
+  resourceName: sriovnic
+  vlan: 0

--- a/feature-configs/demo/sriov/kustomization.yaml
+++ b/feature-configs/demo/sriov/kustomization.yaml
@@ -3,7 +3,8 @@ kind: Kustomization
 
 bases:
   - ../../base/sriov
+resources:
+  - ipv6-network_attachment_defintion.yaml
 patchesStrategicMerge:
   - sriov-subscription.yaml
   - sriov-networknodepolicy.yaml
-  - ipv6-network_attachment_defintion.yaml


### PR DESCRIPTION
This PR change the network attachment definition to use the sriov network CR.
Then the sriov operator is the one that creates the attachment.
This is the supported way to create sriov networks.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>