### PR TITLE
Add an example on how to build a UBI8 sctp application relying on OCP builds 

### DIFF
--- a/tools/buildingsctp/README.md
+++ b/tools/buildingsctp/README.md
@@ -1,0 +1,72 @@
+# SCTP Application building example
+
+This repo showcases how to build a simple C sctp application using [docker build strategies](https://docs.openshift.com/container-platform/4.3/builds/understanding-image-builds.html#builds-strategy-docker-build_understanding-image-builds).
+The C client application is just a small sctp client that will send what is passed from the command line, but should be fine for the purpouse of this example.
+
+## Consuming a ubi8 image
+
+Using `ubi8` images (and installing additional dependencies), requires a working subscription.
+
+The process of doing that is described in the [OpenShift docs](https://docs.openshift.com/container-platform/4.3/builds/running-entitled-builds.html).
+
+### Quick guide
+
+#### Start up
+
+Create an ImageStream to reference the universal base image (UBI):
+
+```bash
+oc tag --source=docker registry.redhat.io/ubi8/ubi:latest ubi:latest
+```
+
+In order to install the required dependencies a working subscription is needed, as described in [this documentation](https://docs.openshift.com/container-platform/4.3/builds/running-entitled-builds.html).
+
+Here below we try to sum up what's needed.
+
+Fetch your subscription manager's subscription's entitlement and create a secret with them:
+
+```bash
+oc create secret generic etc-pki-entitlement --from-file entitlement-key.pem --from-file entitlement.pem
+```
+
+The public / private entitlement keys can be found under `/etc/pki/entitlement/`
+
+Add your subscription manager's configuration and certificate authority as config maps:
+
+```bash
+oc create configmap rhsm-conf --from-file rhsm.conf
+oc create configmap rhsm-ca --from-file redhat-uep.pem
+```
+
+`redhat-uep.pem` can be found under `/etc/rhsm/ca/redhat-uep.pem`
+`rhsm.conf` can be found under `/etc/rhsm/rhsm.conf`
+
+Empty files can be found under [setup_sample](setup_sample).
+
+#### Configuring the build
+
+A sample build configuration leveraging the secrets / config maps just created can be found in [buildconfig](buildconfig/buildconfig.yaml).
+
+Docker build strategies are described [in the official OpenShift doc](https://docs.openshift.com/container-platform/4.3/builds/build-strategies.html#builds-strategy-docker-build_build-strategies).
+
+### Launch the build
+
+An `imagestream` matching the one we are building must be created, like
+
+```bash
+oc create imagestream sctp-sample
+```
+
+Once the build configuration is applied, we can start a new build:
+
+```bash
+oc start-build --build-loglevel 5 sctp-sample-build
+```
+
+and track it:
+
+```bash
+oc logs -f bc/sctp-sample-build
+```
+
+If everything goes fine, the new image will be ready to be used.

--- a/tools/buildingsctp/buildconfig.yaml
+++ b/tools/buildingsctp/buildconfig.yaml
@@ -1,0 +1,31 @@
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: "sctp-sample-build"
+spec:
+  runPolicy: "Serial"
+  triggers:
+    - type: "ImageChange"
+  source:
+    git:
+      uri: "https://github.com/openshift-kni/cnf-features-deploy"
+      ref: "master"
+      contextDir: "tools/buildingsctp/example"
+    secrets:
+      - secret:
+          name: etc-pki-entitlement
+        destinationDir: etc-pki-entitlement
+    configMaps:
+      - configMap:
+          name: rhsm-conf
+        destinationDir: rhsm-conf
+      - configMap:
+          name: rhsm-ca
+        destinationDir: rhsm-ca
+  strategy:
+    dockerStrategy:
+      dockerfilePath: "samplebuild/src/Dockerfile.sctp"
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "sctp-sample:latest"

--- a/tools/buildingsctp/src/Dockerfile.sctp
+++ b/tools/buildingsctp/src/Dockerfile.sctp
@@ -1,0 +1,23 @@
+FROM registry.access.redhat.com/ubi8/ubi AS builder
+USER root
+# Copy entitlements
+COPY ./etc-pki-entitlement /etc/pki/entitlement
+# Copy subscription manager configurations
+COPY ./rhsm-conf /etc/rhsm
+COPY ./rhsm-ca /etc/rhsm/ca
+# Delete /etc/rhsm-host to use entitlements from the build container
+RUN rm /etc/rhsm-host && \
+    yum -y update && \
+    yum -y install lksctp-tools-devel gcc lksctp-tools kernel-modules-extra && \
+    # Remove entitlements and Subscription Manager configs
+    rm -rf /etc/pki/entitlement && \
+    rm -rf /etc/rhsm
+# OpenShift requires images to run as non-root by default
+USER 1001
+COPY samplebuild/src/* /src/
+RUN gcc /src/sctp.c -o /src/sctpclient -lsctp
+
+FROM registry.access.redhat.com/ubi8/ubi
+COPY --from=builder /src/sctpclient /usr/local/bin/sctpclient
+CMD ["/usr/bin/sctptest"]
+

--- a/tools/buildingsctp/src/sctp.c
+++ b/tools/buildingsctp/src/sctp.c
@@ -1,0 +1,67 @@
+// To compile - gcc sctpclt.c -o client -lsctp
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <netinet/sctp.h>
+#include <arpa/inet.h>
+#define MAX_BUFFER 1024
+#define MY_PORT_NUM 62324 /* This can be changed to suit the need and should be same in server and client */
+
+int main(int argc, char *argv[])
+{
+  int connSock, in, i, ret, flags;
+  struct sockaddr_in servaddr;
+  struct sctp_status status;
+  char buffer[MAX_BUFFER + 1];
+  int datalen = 0;
+
+  /*Get the input from user*/
+  printf("Enter data to send: ");
+  fgets(buffer, MAX_BUFFER, stdin);
+  /* Clear the newline or carriage return from the end*/
+  buffer[strcspn(buffer, "\r\n")] = 0;
+  /* Sample input */
+  datalen = strlen(buffer);
+
+  connSock = socket(AF_INET, SOCK_STREAM, IPPROTO_SCTP);
+
+  if (connSock == -1)
+  {
+    printf("Socket creation failed\n");
+    perror("socket()");
+    exit(1);
+  }
+
+  bzero((void *)&servaddr, sizeof(servaddr));
+  servaddr.sin_family = AF_INET;
+  servaddr.sin_port = htons(MY_PORT_NUM);
+  servaddr.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+  ret = connect(connSock, (struct sockaddr *)&servaddr, sizeof(servaddr));
+
+  if (ret == -1)
+  {
+    printf("Connection failed\n");
+    perror("connect()");
+    close(connSock);
+    exit(1);
+  }
+
+  ret = sctp_sendmsg(connSock, (void *)buffer, (size_t)datalen,
+                     NULL, 0, 0, 0, 0, 0, 0);
+  if (ret == -1)
+  {
+    printf("Error in sctp_sendmsg\n");
+    perror("sctp_sendmsg()");
+  }
+  else
+    printf("Successfully sent %d bytes data to server\n", ret);
+
+  close(connSock);
+
+  return 0;
+}


### PR DESCRIPTION
Here we provide instructions and a working example on how to ship a ubi8 based image using OCP docker build strategy.