### PR TITLE
Adjust performance profile for CI

### DIFF
--- a/feature-configs/e2e-gcp/performance/performance_profile.patch.yaml
+++ b/feature-configs/e2e-gcp/performance/performance_profile.patch.yaml
@@ -4,6 +4,7 @@ metadata:
   name: performance
 spec:
   cpu:
+    balanceIsolated: false
     isolated: "1-3"
     nonIsolated: "0"
     reserved: "0"


### PR DESCRIPTION
Set performance profile cpu's value for balanceIsolated as false to match CPU management tests.
After CPU management functional tests will be properly adapted to cover all aspects of this new value (added in https://github.com/openshift-kni/performance-addon-operators/pull/73) this could be changed accordingly  