### PR TITLE
fix: use resources for dpdk demo environment

### DIFF
--- a/feature-configs/demo/dpdk/kustomization.yaml
+++ b/feature-configs/demo/dpdk/kustomization.yaml
@@ -5,7 +5,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
   - sriov-networknodepolicy-dpdk.yaml
   - dpdk-network.yaml
   - scc.yaml


### PR DESCRIPTION
* Using resources allows to create overlays and still permits to deploy
it directly.

Signed-off-by: Sergi Jimenez <sjr@redhat.com>