### PR TITLE
Make the branch of externally consumed tests configurable.

### DIFF
--- a/external-tests/clone_repo.sh
+++ b/external-tests/clone_repo.sh
@@ -11,10 +11,12 @@ if [ "$TESTS_LOCATION" == "" ]; then
     exit 1
 fi
 
+REMOTE_BRANCH="${REMOTE_BRANCH:-master}"
+
 # detect latest master hash of the target repo if we're not pinned to a specific commit hash
 if [ -z "$TESTS_TARGET_HASH" ]; then
-    echo "Using latest master branch commit for $TESTS_REPO"
-    TESTS_TARGET_HASH=$(git ls-remote "$TESTS_REPO" | grep refs/heads/master$ | cut -f 1)
+    echo "Using latest $REMOTE_BRANCH branch commit for $TESTS_REPO"
+    TESTS_TARGET_HASH=$(git ls-remote "$TESTS_REPO" | grep refs/heads/"$REMOTE_BRANCH"$ | cut -f 1)
 fi
 
 echo "$TESTS_REPO commit hash: $TESTS_TARGET_HASH"

--- a/external-tests/origintests/test.sh
+++ b/external-tests/origintests/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "$(dirname "$0")/../setup.sh"
+
 which skopeo
 if [ $? -ne 0 ]; then
 	echo "skopeo not available, exiting"

--- a/external-tests/performance/test.sh
+++ b/external-tests/performance/test.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+source "$(dirname "$0")/../setup.sh"
+
 export TESTS_REPO=https://github.com/openshift-kni/performance-addon-operators
 export TESTS_LOCATION=/tmp/performance-operators
+export REMOTE_BRANCH=$PERF_OPERATOR_BRANCH
 
 external-tests/clone_repo.sh
 cd $TESTS_LOCATION

--- a/external-tests/setup.sh
+++ b/external-tests/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Version of the ose tests image
+export OSE_TESTS_VERSION=latest
+
+# Branch of the performance addons operator to be used for tests
+export PERF_OPERATOR_BRANCH=master


### PR DESCRIPTION
Also, make the version of the ose tests image configurable as well.

This is needed for handling 4.4 branching.