### PR TITLE
Add a comment to the dpdk deployment

### DIFF
--- a/feature-configs/demo/dpdk/kustomization.yaml
+++ b/feature-configs/demo/dpdk/kustomization.yaml
@@ -1,6 +1,6 @@
-# Note: This feature request to deploy the sriov feature also in the cluster
+# Note: This feature request to deploy the sriov feature and the performance also in the cluster
 # For example:
-# FEATURES_ENVIRONMENT=demo FEATURES="sriov dpdk" make feature-deploy
+# FEATURES_ENVIRONMENT=demo FEATURES="performance sriov dpdk" make feature-deploy
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
This PR add a comment to the dpdk deployment feature.
For a dpdk workload to work we need huge-pages and cpu pinning, these two features are provided by the performance operator.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>