### PR TITLE
Fix dpdk workload when using version 18.11

### DIFF
--- a/tools/s2i-dpdk/test/test-app/test-template.sh
+++ b/tools/s2i-dpdk/test/test-app/test-template.sh
@@ -1,4 +1,4 @@
-spawn testpmd -l ${CPU} -w ${PCIDEVICE_OPENSHIFT_IO_DPDKNIC}  -- -i --portmask=0x1 --nb-cores=2 --forward-mode=mac --port-topology=loop
+spawn testpmd -l ${CPU} -w ${PCIDEVICE_OPENSHIFT_IO_DPDKNIC} --iova-mode=va -- -i --portmask=0x1 --nb-cores=2 --forward-mode=mac --port-topology=loop
 set timeout 10000
 expect "testpmd>"
 send -- "start\r"


### PR DESCRIPTION
This PR add the --iova-mode=va flag.
This flag is must when running dpdk version 18.11 on a netdevice driver like mellanox.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1785933

Signed-off-by: Sebastian Sch <sebassch@gmail.com>