### PR TITLE
Use different junit filename than external tests.

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -25,7 +25,7 @@ fi
 
 FOCUS=$(echo "$FEATURES" | tr ' ' '|') 
 echo "Focusing on $FOCUS"
-if ! GOFLAGS=-mod=vendor ginkgo --focus=$FOCUS functests -- -junit /tmp/artifacts/unit_report.xml; then
+if ! GOFLAGS=-mod=vendor ginkgo --focus=$FOCUS functests -- -junit /tmp/artifacts/unit_report_local.xml; then
   failed=true
   failures+=( "Tier 2 tests for $FEATURES" )
 fi
@@ -50,6 +50,9 @@ for feature in $EXTERNALS; do
     failed=true
   fi
   set -e
+  if [[ -f /tmp/artifacts/unit_report.xml ]]; then
+    mv /tmp/artifacts/unit_report.xml "/tmp/artifacts/unit_report_external_${feature}.xml"
+  fi
 done
 
 if $failed; then


### PR DESCRIPTION
Currently the `unit_report.xml` junit test result file of local tests will be overwritten by the performance external tests.

With this PR
- the filename of the local tests is modified so it won't be overwritten
- the junit file of external tests will be renamed after running in case they use `unit_report.xml`, in order to prevent multiple external tests overwriting their junit files.

@fedepaol 