### PR TITLE
Consume the openshift sriov tests as external tests.

### DIFF
--- a/external-tests/setup.sh
+++ b/external-tests/setup.sh
@@ -5,3 +5,6 @@ export OSE_TESTS_VERSION=latest
 
 # Branch of the performance addons operator to be used for tests
 export PERF_OPERATOR_BRANCH=master
+
+# Branch of the SRIOV operator tests
+export SRIOV_TESTS_BRANCH=master

--- a/external-tests/sriov/test.sh
+++ b/external-tests/sriov/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+source "$(dirname "$0")/../setup.sh"
+
+export TESTS_REPO=https://github.com/openshift/sriov-tests
+export TESTS_LOCATION=/tmp/sriov-tests
+export REMOTE_BRANCH=$SRIOV_TESTS_BRANCH
+
+external-tests/clone_repo.sh
+cd $TESTS_LOCATION
+make conformance


### PR DESCRIPTION
This will allow us to run openshift conformance tests against our deployment.