### PR TITLE
Fixed MCP by removing null value

### DIFF
--- a/hack/setup-test-cluster.sh
+++ b/hack/setup-test-cluster.sh
@@ -42,7 +42,6 @@ spec:
           operator: In,
           values: [worker-cnf, worker],
         }
-  maxUnavailable: null
   paused: false
   nodeSelector:
     matchLabels:


### PR DESCRIPTION
Fails now because MCO added openAPIV3Schema to their CRDs

Signed-off-by: Marc Sluiter <msluiter@redhat.com>