### PR TITLE
Added new numa.topologyPolicy to performance profile for CI

### DIFF
--- a/feature-configs/base/performance/performance_profile.yaml
+++ b/feature-configs/base/performance/performance_profile.yaml
@@ -10,3 +10,5 @@ spec:
     defaultHugepagesSize: "1G"
   realTimeKernel:
     enabled: true
+  numa:
+    topologyPolicy: "best-effort"

--- a/feature-configs/e2e-gcp/performance/performance_profile.patch.yaml
+++ b/feature-configs/e2e-gcp/performance/performance_profile.patch.yaml
@@ -11,5 +11,7 @@ spec:
     - size: "1G"
       count: 1
       node: 0
+  numa:
+    topologyPolicy: "single-numa-node"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""


### PR DESCRIPTION
See https://github.com/openshift-kni/performance-addon-operators/pull/117
Fixes the last failing functest in periodic jobs

No backport needed for now