### PR TITLE
Revert "Temporarily disable RT kernel"

### DIFF
--- a/feature-configs/e2e-gcp/performance/performance_profile.patch.yaml
+++ b/feature-configs/e2e-gcp/performance/performance_profile.patch.yaml
@@ -11,7 +11,5 @@ spec:
     - size: "1G"
       count: 1
       node: 0
-  realTimeKernel:
-    enabled: false
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""


### PR DESCRIPTION
Reverts openshift-kni/cnf-features-deploy#109

RT kernel RPMs are back, see https://github.com/openshift-kni/performance-addon-operators/pull/136