### PR TITLE
Fix dpdk test application

### DIFF
--- a/tools/s2i-dpdk/test/test-app/test-template.sh
+++ b/tools/s2i-dpdk/test/test-app/test-template.sh
@@ -1,4 +1,4 @@
-spawn ./customtestpmd -l ${CPU} -w ${PCIDEVICE_OPENSHIFT_IO_DPDKNIC} --iova-mode=va --no-mlockall -- -i --portmask=0x1 --nb-cores=2 --forward-mode=mac --port-topology=loop
+spawn ./customtestpmd -l ${CPU} -w ${PCIDEVICE_OPENSHIFT_IO_DPDKNIC} --iova-mode=va -- -i --portmask=0x1 --nb-cores=2 --forward-mode=mac --port-topology=loop --no-mlockall
 set timeout 10000
 expect "testpmd>"
 send -- "start\r"


### PR DESCRIPTION
```
./customtestpmd: unrecognized option '--no-mlockall'
EAL: Detected 80 lcore(s)
EAL: Detected 2 NUMA nodes
```

there is no `--no-mlockall` option in the testpmd binary

Signed-off-by: Sebastian Sch <sebassch@gmail.com>