### PR TITLE
fix ptp labels to skip virtual machines

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,18 @@
+# hack GuideLines
+
+This document describes how you can use the scripts from [`hack`](.) directory
+and gives a bried introduction and explanation of these scripts.
+
+## Overview
+
+The [`hack`](.) directory contains many scripts that ensure continuous development of cnf features,
+enhance the robustness of the code, improve development efficiency, etc.
+The explanations and descriptions of these scripts are helpful for contributors.
+
+## setup-test-cluster.sh
+This script does all the cluster setup parts that are expected to be done by admins, like labelling nodes and creating the MachineConfigPool resource, etc.  
+It does not install CNF.
+
+For PTP it is possible to label nodes as non ptp capable either by  
+```kubectl label <node> node-role.kubernetes.io/virtual```  
+or pass a different NON_PTP_LABEL as environment variable

--- a/hack/setup-test-cluster.sh
+++ b/hack/setup-test-cluster.sh
@@ -5,6 +5,8 @@ set -e
 # expect oc to be in PATH by default
 export OC_TOOL="${OC_TOOL:-oc}"
 
+export NON_PTP_LABEL="${NON_PTP_LABEL:-node-role.kubernetes.io/virtual}"
+
 # Label worker nodes as worker-cnf
 nodes=$(${OC_TOOL} get nodes --selector='node-role.kubernetes.io/worker' \
   --selector='!node-role.kubernetes.io/master' -o name | sed -n 1,2p)
@@ -15,11 +17,11 @@ do
 done
 
 echo "[INFO]: Labeling first node as the ptp grandmaster"
-node=$(${OC_TOOL} get nodes -o name | sed -n 1p)
+node=$(${OC_TOOL} get nodes -o name --selector "!${NON_PTP_LABEL}" | sed -n 1p)
 ${OC_TOOL} label --overwrite $node ptp/grandmaster=""
 
 echo "[INFO]: Labeling all the other nodes as ptp slaves"
-nodes=$(${OC_TOOL} get nodes -o name | sed 1d)
+nodes=$(${OC_TOOL} get nodes -o name --selector "!${NON_PTP_LABEL}" | sed 1d)
 for node in $nodes
 do
     ${OC_TOOL} label --overwrite $node ptp/slave=""


### PR DESCRIPTION
this is currently done by manually pre-labeling those with 'virtual-machine'

Signed-off-by: Yuval Kashtan <yuvalkashtan@gmail.com>

in our env this will be done by cluster deployment

note: I tried to use ironic introspection data, but that is included only for workers ...