### PR TITLE
Add Polarion reporter

### DIFF
--- a/functests/test_suite_test.go
+++ b/functests/test_suite_test.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
 // TODO: we should refactor tests to use client from controller-runtime package
@@ -35,6 +36,9 @@ func TestTest(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	rr := []Reporter{}
+	if ginkgo_reporters.Polarion.Run {
+		rr = append(rr, &ginkgo_reporters.Polarion)
+	}
 	if junitPath != nil {
 		rr = append(rr, reporters.NewJUnitReporter(*junitPath))
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/kubelet v0.17.0
 	k8s.io/utils v0.0.0-20200109141947-94aeca20bf09
+	kubevirt.io/qe-tools v0.1.4
 )
 
 // Pinned to kubernetes-1.17.0

--- a/go.sum
+++ b/go.sum
@@ -1191,6 +1191,8 @@ k8s.io/utils v0.0.0-20190920012459-5008bf6f8cd6/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200109141947-94aeca20bf09 h1:sz6xjn8QP74104YNmJpzLbJ+a3ZtHt0tkD0g8vpdWNw=
 k8s.io/utils v0.0.0-20200109141947-94aeca20bf09/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+kubevirt.io/qe-tools v0.1.4 h1:q4xvpLIyO6Ljl7u4Bu27EM2guNAuPolOqwCYJ2QeIik=
+kubevirt.io/qe-tools v0.1.4/go.mod h1:PJyH/YXC4W0AmxfheDmXWMbLNsMSboVGXKpMAwfKzVE=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/kubevirt.io/qe-tools/LICENSE
+++ b/vendor/kubevirt.io/qe-tools/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters/README.md
+++ b/vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters/README.md
@@ -1,0 +1,34 @@
+# Ginkgo reporters
+
+These reporters will build the xunit xml
+
+
+## Polarion reporter
+This reporter fills in the xunit file the needed fields in order to upload it into Polarion as test run
+
+#### Required parameters:
+- --polarion-execution=true to enable the reporter
+- --project-id="QE" will be set under 'properties'
+- --polarion-custom-plannedin="QE_1_0" will be set under 'properties'
+
+#### Optional parameters:
+- --polarion-report-file the output file will be generated under working directory, the default is polarion_results.xml
+- --test-suite-params="OS=EL8 Storage=NFS Arch=x86" will be set under 'properties' and the values will get concatenated to the test run name 
+- --test-id-prefix="PREFIX" will set "PREFIX" for each test ID in test properties, if this parameter is not passed, the project ID parameter is set to be that prefix by default
+
+### Usage
+
+Include the reporter in the tests entry point
+```
+if ginkgo_reporters.Polarion.Run {
+		reporters = append(reporters, &ginkgo_reporters.Polarion)
+	}
+```
+
+when executing the tests, in addition to your regular execution parameters,
+add the reporter parameters as specified above
+
+``` bash
+go test YOUR_PARAMS --polarion-execution=true --project-id="QE" --polarion-custom-plannedin="QE_1_0" --polarion-report-file="polarion.xml"
+```
+Will generate `polarion.xml` file under the work directory that can be imported into polarion.

--- a/vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters/junit_reporter.go
+++ b/vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters/junit_reporter.go
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package ginkgo_reporters
+
+import (
+	"flag"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+var JunitOutput = ""
+
+func init() {
+	flag.StringVar(&JunitOutput, "junit-output", "", "Set path to Junit report.")
+}
+
+func NewJunitReporter() *reporters.JUnitReporter {
+	return reporters.NewJUnitReporter(JunitOutput)
+}

--- a/vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters/polarion_reporter.go
+++ b/vendor/kubevirt.io/qe-tools/pkg/ginkgo-reporters/polarion_reporter.go
@@ -1,0 +1,249 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package ginkgo_reporters
+
+import (
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"kubevirt.io/qe-tools/pkg/polarion-xml"
+
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+var Polarion = PolarionReporter{}
+
+func init() {
+	flag.BoolVar(&Polarion.Run, "polarion-execution", false, "Run Polarion reporter")
+	flag.StringVar(&Polarion.ProjectId, "polarion-project-id", "", "Set Polarion project ID")
+	flag.StringVar(&Polarion.Filename, "polarion-report-file", "polarion_results.xml", "Set Polarion report file path")
+	flag.StringVar(&Polarion.PlannedIn, "polarion-custom-plannedin", "", "Set Polarion planned-in ID")
+	flag.StringVar(&Polarion.LookupMethod, "polarion-lookup-method", "id", "Set Polarion lookup method - id or name")
+	flag.StringVar(&Polarion.TestSuiteParams, "test-suite-params", "", "Set test suite params in space seperated name=value structure. Note that the values will be appended to the test run ID")
+	flag.StringVar(&Polarion.TestIDPrefix, "test-id-prefix", "", "Set Test ID prefix, in the case it is different than project ID")
+}
+
+type PolarionTestSuite struct {
+	XMLName    xml.Name           `xml:"testsuite"`
+	Tests      int                `xml:"tests,attr"`
+	Failures   int                `xml:"failures,attr"`
+	Time       float64            `xml:"time,attr"`
+	Properties PolarionProperties `xml:"properties"`
+	TestCases  []PolarionTestCase `xml:"testcase"`
+}
+
+type PolarionTestCase struct {
+	Name           string               `xml:"name,attr"`
+	Properties     PolarionProperties   `xml:"properties"`
+	FailureMessage *JUnitFailureMessage `xml:"failure,omitempty"`
+	Skipped        *JUnitSkipped        `xml:"skipped,omitempty"`
+	SystemOut      string               `xml:"system-out,omitempty"`
+}
+
+type JUnitFailureMessage struct {
+	Type    string `xml:"type,attr"`
+	Message string `xml:",chardata"`
+}
+
+type JUnitSkipped struct {
+	XMLName xml.Name `xml:"skipped"`
+}
+
+type PolarionProperties struct {
+	Property []PolarionProperty `xml:"property"`
+}
+
+type PolarionProperty struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type PolarionReporter struct {
+	Suite           PolarionTestSuite
+	Run             bool
+	Filename        string
+	TestSuiteName   string
+	ProjectId       string
+	PlannedIn       string
+	LookupMethod    string
+	TestSuiteParams string
+	TestIDPrefix    string
+}
+
+func (reporter *PolarionReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+
+	reporter.Suite = PolarionTestSuite{
+		Properties: PolarionProperties{},
+		TestCases:  []PolarionTestCase{},
+	}
+
+	valuesString := ""
+	suiteParams := strings.Split(reporter.TestSuiteParams, " ")
+	for _, s := range suiteParams {
+		keyValue := strings.Split(s, "=")
+		if len(keyValue) > 1 {
+			valuesString = valuesString + "_" + keyValue[1]
+			reporter.Suite.Properties.Property = addProperty(
+				reporter.Suite.Properties.Property, "polarion-custom-"+keyValue[0], keyValue[1])
+		}
+	}
+
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-project-id", reporter.ProjectId)
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-lookup-method", reporter.LookupMethod)
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-custom-plannedin", reporter.PlannedIn)
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-testrun-id", reporter.PlannedIn + valuesString)
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-custom-isautomated", "True")
+	reporter.Suite.Properties.Property = addProperty(
+		reporter.Suite.Properties.Property, "polarion-testrun-status-id", "inprogress")
+		
+	reporter.TestSuiteName = summary.SuiteDescription
+}
+
+func (reporter *PolarionReporter) SpecWillRun(specSummary *types.SpecSummary) {
+}
+
+func (reporter *PolarionReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+}
+
+func (reporter *PolarionReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+}
+
+func failureMessage(failure types.SpecFailure) string {
+	return fmt.Sprintf("%s\n%s\n%s", failure.ComponentCodeLocation.String(), failure.Message, failure.Location.String())
+}
+
+func (reporter *PolarionReporter) handleSetupSummary(name string, setupSummary *types.SetupSummary) {
+	if setupSummary.State != types.SpecStatePassed {
+		testCase := PolarionTestCase{
+			Name:       name,
+			Properties: PolarionProperties{},
+		}
+
+		if reporter.TestIDPrefix != "" {
+			testCase.Properties = extractTestID(name, reporter.TestIDPrefix)
+		} else {
+			testCase.Properties = extractTestID(name, reporter.ProjectId)
+		}
+
+		testCase.FailureMessage = &JUnitFailureMessage{
+			Type:    reporter.failureTypeForState(setupSummary.State),
+			Message: failureMessage(setupSummary.Failure),
+		}
+		testCase.SystemOut = setupSummary.CapturedOutput
+		reporter.Suite.TestCases = append(reporter.Suite.TestCases, testCase)
+	}
+}
+
+func (reporter *PolarionReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	testName := fmt.Sprintf(
+		"%s: %s",
+		specSummary.ComponentTexts[1],
+		strings.Join(specSummary.ComponentTexts[2:], " "),
+	)
+	testCase := PolarionTestCase{
+		Name: testName,
+	}
+
+	if reporter.TestIDPrefix != "" {
+		testCase.Properties = extractTestID(testName, reporter.TestIDPrefix)
+	} else {
+		testCase.Properties = extractTestID(testName, reporter.ProjectId)
+	}
+
+	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
+		testCase.FailureMessage = &JUnitFailureMessage{
+			Type:    reporter.failureTypeForState(specSummary.State),
+			Message: failureMessage(specSummary.Failure),
+		}
+		testCase.SystemOut = specSummary.CapturedOutput
+	}
+	if specSummary.State == types.SpecStateSkipped || specSummary.State == types.SpecStatePending {
+		testCase.Skipped = &JUnitSkipped{}
+	}
+	reporter.Suite.TestCases = append(reporter.Suite.TestCases, testCase)
+}
+
+func (reporter *PolarionReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+	if reporter.ProjectId == "" {
+		fmt.Println("Can not create Polarion report without project ID")
+		return
+	}
+	if reporter.PlannedIn == "" {
+		fmt.Println("Can not create Polarion report without planned-in ID")
+		return
+	}
+
+	reporter.Suite.Tests = summary.NumberOfSpecsThatWillBeRun
+	reporter.Suite.Time = summary.RunTime.Seconds()
+	reporter.Suite.Failures = summary.NumberOfFailedSpecs
+
+	// generate polarion test cases XML file
+	polarion_xml.GeneratePolarionXmlFile(reporter.Filename, reporter.Suite)
+
+}
+
+func (reporter *PolarionReporter) failureTypeForState(state types.SpecState) string {
+	switch state {
+	case types.SpecStateFailed:
+		return "Failure"
+	case types.SpecStateTimedOut:
+		return "Timeout"
+	case types.SpecStatePanicked:
+		return "Panic"
+	default:
+		return ""
+	}
+}
+
+func extractTestID(testname string, testPrefix string) PolarionProperties {
+	var re = regexp.MustCompile(`test_id:\d+`)
+	properties := PolarionProperties{}
+	testID := re.FindString(testname)
+	if testID != "" {
+		testID = strings.Replace(testID, "test_id:", "", 1)
+		properties = PolarionProperties{
+			Property: []PolarionProperty{
+				{
+					Name:  "polarion-testcase-id",
+					Value: testPrefix + "-" + testID,
+				},
+			},
+		}
+	}
+	return properties
+}
+
+func addProperty(properties []PolarionProperty, key string, value string) []PolarionProperty {
+	properties = append(
+		properties, PolarionProperty{
+			Name:  key,
+			Value: value,
+	})
+	return properties
+}

--- a/vendor/kubevirt.io/qe-tools/pkg/polarion-xml/polarion_xml.go
+++ b/vendor/kubevirt.io/qe-tools/pkg/polarion-xml/polarion_xml.go
@@ -1,0 +1,105 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package polarion_xml
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+)
+
+type TestCases struct {
+	Properties PolarionProperties `xml:"properties"`
+	XMLName    xml.Name           `xml:"testcases"`
+	TestCases  []TestCase         `xml:"testcase"`
+	ProjectID  string             `xml:"project-id,attr"`
+}
+
+type TestCase struct {
+	ID                      string                  `xml:"id,attr,omitempty"`
+	Title                   Title                   `xml:"title"`
+	Description             Description             `xml:"description"`
+	TestCaseCustomFields    TestCaseCustomFields    `xml:"custom-fields"`
+	TestCaseSteps           *TestCaseSteps          `xml:"test-steps,omitempty"`
+	TestCaseLinkedWorkItems TestCaseLinkedWorkItems `xml:"linked-work-items"`
+}
+
+type Title struct {
+	Content string `xml:",chardata"`
+}
+
+type Description struct {
+	Content string `xml:",chardata"`
+}
+
+type TestCaseCustomFields struct {
+	CustomFields []TestCaseCustomField `xml:"custom-field"`
+}
+
+type TestCaseCustomField struct {
+	Content string `xml:"content,attr"`
+	ID      string `xml:"id,attr"`
+}
+
+type TestCaseSteps struct {
+	Steps []TestCaseStep `xml:"test-step"`
+}
+
+type TestCaseStep struct {
+	StepColumn []TestCaseStepColumn `xml:"test-step-column"`
+}
+
+type TestCaseStepColumn struct {
+	Content string `xml:",chardata"`
+	ID      string `xml:"id,attr"`
+}
+
+type PolarionProperties struct {
+	Property []PolarionProperty `xml:"property"`
+}
+
+type PolarionProperty struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type TestCaseLinkedWorkItems struct {
+	LinkedWorkItems []TestCaseLinkedWorkItem `xml:"linked-work-item"`
+}
+
+type TestCaseLinkedWorkItem struct {
+	ID   string `xml:"workitem-id,attr"`
+	Role string `xml:"role-id,attr"`
+}
+
+func GeneratePolarionXmlFile(outputFile string, testCases interface{}) {
+	file, err := os.Create(outputFile)
+	if err != nil {
+		panic(fmt.Errorf("Failed to create Polarion report file: %s\n\t%s", outputFile, err.Error()))
+	}
+	defer file.Close()
+	file.WriteString(xml.Header)
+	encoder := xml.NewEncoder(file)
+	encoder.Indent("  ", "    ")
+	err = encoder.Encode(testCases)
+	if err != nil {
+		panic(fmt.Errorf("Failed to generate Polarion report\n\t%s", err.Error()))
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,6 +307,9 @@ k8s.io/kubelet/config/v1beta1
 # k8s.io/utils v0.0.0-20200109141947-94aeca20bf09
 k8s.io/utils/integer
 k8s.io/utils/pointer
+# kubevirt.io/qe-tools v0.1.4
+kubevirt.io/qe-tools/pkg/ginkgo-reporters
+kubevirt.io/qe-tools/pkg/polarion-xml
 # sigs.k8s.io/controller-runtime v0.2.0
 sigs.k8s.io/controller-runtime/pkg/runtime/scheme
 sigs.k8s.io/controller-runtime/pkg/scheme


### PR DESCRIPTION
This tool allows us to export results of testing to polarion.

For example, running this command will start tests and create polarion_results.xml file that can be imported to polarion:

GOFLAGS=-mod=vendor ginkgo functests -- -polarion-execution=true -polarion-custom-plannedin=OCP_4_4_Code_Freeze -polarion-project-id=OSE -polarion-report-file=/tmp/polarion_results.xml --test-id-prefix=CNF_4_4_Compute