### PR TITLE
Consume sriov tests from the sriov-operator repository.

### DIFF
--- a/external-tests/sriov/test.sh
+++ b/external-tests/sriov/test.sh
@@ -2,10 +2,10 @@
 
 source "$(dirname "$0")/../setup.sh"
 
-export TESTS_REPO=https://github.com/openshift/sriov-tests
+export TESTS_REPO=https://github.com/openshift/sriov-network-operator
 export TESTS_LOCATION=/tmp/sriov-tests
 export REMOTE_BRANCH=$SRIOV_TESTS_BRANCH
 
 external-tests/clone_repo.sh
 cd $TESTS_LOCATION
-make conformance
+make test-e2e-conformance


### PR DESCRIPTION
Sriov tests have been moved to the sriov operator repository.
This PR changes the way we consume them, fetching from the new place.