### PR TITLE
Fix deployment and tests

### DIFF
--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -64,11 +64,13 @@ func ExecCommandOnMachineConfigDaemon(cs *testclient.ClientSet, node *corev1.Nod
 	}
 
 	initialArgs := []string{
-		"rsh",
+		"exec",
+		"-i",
 		"-n", testutils.NamespaceMachineConfigOperator,
 		"-c", testutils.ContainerMachineConfigDaemon,
 		"--timeout", "30",
 		mcd.Name,
+		"--",
 	}
 	initialArgs = append(initialArgs, command...)
 	return exec.Command("oc", initialArgs...).CombinedOutput()

--- a/hack/feature-deploy.sh
+++ b/hack/feature-deploy.sh
@@ -37,9 +37,17 @@ do
     set +e
     # be verbose on last iteration only
     if [[ $iterations -eq $((max_iterations - 1)) ]] || [[ -n "${VERBOSE}" ]]; then
-      ${OC_TOOL} apply -k "$feature_dir"
+      # WORKAROUND for https://github.com/kubernetes/kubernetes/pull/89539:
+      # oc / kubectl reject multiple manifests atm as soon as one "kind" in them does not exist yet
+      # so we need to apply one manifest by one
+      # since xargs' delimiter is limited to one char only or a control code, we replace the manifest delimiter "---"
+      # with a "vertical tab (\v)", which should never be used in (at least our) manifests.
+      # revert the sed | xargs steps when the fix landed in oc (don't forget the "else" code branch)
+      ${OC_TOOL} kustomize $feature_dir | sed "s|---|\v|g" | xargs -d '\v' -I {} bash -c "echo '{}' | ${OC_TOOL} apply -f -"
+      #${OC_TOOL} apply -k "$feature_dir"
     else
-      ${OC_TOOL} apply -k "$feature_dir" &> /dev/null
+      ${OC_TOOL} kustomize $feature_dir | sed "s|---|\v|g" | xargs -d '\v' -I {} bash -c "echo '{}' | ${OC_TOOL} apply -f - &> /dev/null"
+      #${OC_TOOL} apply -k "$feature_dir" &> /dev/null
     fi
 
     # shellcheck disable=SC2181


### PR DESCRIPTION
We are running into 2 issues after OCP has been rebased on k8s 1.18:

1. `ocp apply -f` fails to deploy ANY resource if ONE of them has an unknown kind. So apply all one by one, else our loop-until-succeed deployment doesn't work (profile can't be deployed because CRD doesn't exist in 1st iteration(s). This is a known and fixed bug in kubectl, so a temporary workaround only until the fix landed in OCP. See [0].

2. `oc rsh` aka `kubectl exec` write a deprecation note now to stderr:
`kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.`
So let's add add "--". But it didn't work with "oc rsh", so also switch to "oc exec -i"

[0] https://github.com/kubernetes/kubernetes/pull/89539