### PR TITLE
Add support for disconnected environment through mirroring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,4 +68,8 @@ test-bin:
 
 cnf-tests-local:
 	@echo "Making cnf-tests local"
-	$(IMAGE_BUILD_CMD) build --no-cache -f cnf-tests/Dockerfile -t cnf-tests-local . 
+	$(IMAGE_BUILD_CMD) build --no-cache -f cnf-tests/Dockerfile -t cnf-tests-local .
+	$(IMAGE_BUILD_CMD) build --no-cache -f cnf-tests/testimages/sctptester/Dockerfile -t sctptester .
+	$(IMAGE_BUILD_CMD) build --no-cache -f cnf-tests/testimages/cnftests-utils/Dockerfile -t cnftests-utils .
+	$(IMAGE_BUILD_CMD) build --no-cache -f cnf-tests/testimages/stresser/Dockerfile -t stresser .
+

--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -6,8 +6,13 @@ RUN make test-bin
 FROM quay.io/openshift/origin-oc-rpms:4.5 as oc 
 
 FROM centos:7
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests /usr/bin/cnftests
+
+RUN mkdir -p /usr/local/etc/cnf
+
 COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
+COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests /usr/bin/cnftests
+COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/mirror /usr/bin/mirror
+COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/testimages/images.json /usr/local/etc/cnf
+COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests-sha.txt /usr/local/etc/cnf
 
 CMD ["/usr/bin/cnftests"]
-

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -14,9 +14,14 @@ RUN make test-bin
 FROM quay.io/openshift/origin-oc-rpms:4.5 as oc 
 
 FROM openshift/origin-base
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests /usr/bin/cnftests
-COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
+RUN mkdir -p /usr/local/etc/cnf
 
+
+COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
+COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests /usr/bin/cnftests
+COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/mirror /usr/bin/mirror
+COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/testimages/images.json /usr/local/etc/cnf
+COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests-sha.txt /usr/local/etc/cnf
 
 LABEL io.openshift.tags="openshift" \
       maintainer="Federico Paolinelli <fpaoline@redhat.com>"

--- a/cnf-tests/mirror/mirror.go
+++ b/cnf-tests/mirror/mirror.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+)
+
+type image struct {
+	Name     string `json:"name"`
+	Registry string `json:"registry"`
+	Version  string `json:"version"`
+}
+
+// TODO in a second step this could even do the mirror itself
+func main() {
+	imagesFile := flag.String("images", "/usr/local/etc/cnf/images.json", "the json file containing the images")
+	targetRegistry := flag.String("registry", "", "the target registry we want to mirror to")
+
+	flag.Parse()
+
+	if *imagesFile == "" || *targetRegistry == "" {
+		flag.Usage()
+		log.Fatal("Missing mandatory fields")
+	}
+
+	bytes, err := ioutil.ReadFile(*imagesFile)
+	if err != nil {
+		log.Fatalf("Failed to read %s - %v", *imagesFile, err)
+	}
+
+	var images []image
+	err = json.Unmarshal(bytes, &images)
+	if err != nil {
+		log.Fatalf("Failed to read %s - %v", *imagesFile, err)
+	}
+
+	for _, img := range images {
+		fmt.Printf("%s%s:%s %s%s:%s\n", img.Registry, img.Name, img.Version, *targetRegistry, img.Name, img.Version)
+	}
+}

--- a/cnf-tests/testimages/cnftests-utils/Dockerfile
+++ b/cnf-tests/testimages/cnftests-utils/Dockerfile
@@ -1,0 +1,3 @@
+FROM centos:7
+
+RUN yum update -y && yum install -y iproute libhugetlbfs-utils libhugetlbfs tmux ethtool

--- a/cnf-tests/testimages/cnftests-utils/Dockerfile.openshift
+++ b/cnf-tests/testimages/cnftests-utils/Dockerfile.openshift
@@ -1,0 +1,6 @@
+# This dockerfile is specific to building the OpenShift CNF tests utils image
+FROM openshift/origin-base
+RUN yum update -y && yum install -y iproute libhugetlbfs-utils libhugetlbfs tmux ethtool
+
+LABEL io.openshift.tags="openshift" \
+      maintainer="Federico Paolinelli <fpaoline@redhat.com>"

--- a/cnf-tests/testimages/images.json
+++ b/cnf-tests/testimages/images.json
@@ -1,0 +1,17 @@
+[
+    {
+        "name": "sctptester",
+        "registry": "quay.io/fpaoline/",
+        "version": "v1.0"
+    },
+    {
+        "name": "cnftest-utils",
+        "registry": "quay.io/fpaoline/",
+        "version": "v1.0"
+    },
+    {
+        "name": "stresser",
+        "registry": "quay.io/fpaoline/",
+        "version": "v1.0"
+    }
+]

--- a/cnf-tests/testimages/sctptester/Dockerfile
+++ b/cnf-tests/testimages/sctptester/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.13 AS builder
+ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_PATH=/go/src/$PKG_NAME
+ENV TESTER_PATH=$PKG_PATH/cnf-tests/testimages/sctptester
+
+RUN mkdir -p $PKG_PATH
+
+COPY . $PKG_PATH/
+WORKDIR $TESTER_PATH
+
+RUN go build -mod=vendor -o /sctptest
+
+FROM centos:7
+COPY --from=builder /sctptest /usr/bin/sctptest
+RUN yum install -y lksctp-tools
+CMD ["/usr/bin/sctptest"]

--- a/cnf-tests/testimages/sctptester/Dockerfile.openshift
+++ b/cnf-tests/testimages/sctptester/Dockerfile.openshift
@@ -1,0 +1,24 @@
+# This dockerfile is specific to building the OpenShift CNF sctp tester image
+FROM openshift/origin-release:golang-1.13 as builder
+
+# Add everything
+ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_PATH=/go/src/$PKG_NAME
+ENV TESTER_PATH=$PKG_PATH/cnf-tests/testimages/sctptester
+
+RUN mkdir -p $PKG_PATH
+
+COPY . $PKG_PATH/
+WORKDIR $TESTER_PATH
+
+RUN go build -mod=vendor -o /sctptest
+
+FROM openshift/origin-base
+
+COPY --from=builder /sctptest /usr/bin/sctptest
+RUN dnf install -y lksctp-tools
+
+LABEL io.openshift.tags="openshift" \
+      maintainer="Federico Paolinelli <fpaoline@redhat.com>"
+
+CMD ["/usr/bin/sctptest"]

--- a/cnf-tests/testimages/sctptester/main.go
+++ b/cnf-tests/testimages/sctptester/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+
+	"github.com/ishidawataru/sctp"
+)
+
+func main() {
+	var server = flag.Bool("server", false, "")
+	var ip = flag.String("ip", "0.0.0.0", "")
+	var port = flag.Int("port", 0, "")
+	var lport = flag.Int("lport", 0, "")
+
+	flag.Parse()
+
+	if *server {
+		doServer(*ip, *port)
+	} else {
+		doClient(*ip, *port, *lport)
+	}
+
+}
+
+func doClient(serverAddr string, port int, localport int) {
+	address, err := net.ResolveIPAddr("ip", serverAddr)
+
+	server := &sctp.SCTPAddr{
+		IPAddrs: []net.IPAddr{*address},
+		Port:    port,
+	}
+
+	var laddr *sctp.SCTPAddr
+	if localport != 0 {
+		laddr = &sctp.SCTPAddr{
+			Port: localport,
+		}
+	}
+	conn, err := sctp.DialSCTP("sctp", laddr, server)
+	if err != nil {
+		log.Fatalf("failed to dial: %v", err)
+	}
+
+	log.Printf("Dail LocalAddr: %s; RemoteAddr: %s", conn.LocalAddr(), conn.RemoteAddr())
+	info := sctp.SndRcvInfo{
+		Stream: uint16(0),
+		PPID:   uint32(0),
+	}
+
+	n, err := conn.SCTPWrite([]byte("hello"), &info)
+	if err != nil {
+		log.Fatalf("failed to write: %v", err)
+	}
+	log.Printf("write: len %d", n)
+
+}
+
+func doServer(serverAddr string, port int) {
+	address, err := net.ResolveIPAddr("ip", serverAddr)
+
+	listenAddr := &sctp.SCTPAddr{
+		IPAddrs: []net.IPAddr{*address},
+		Port:    port,
+	}
+	ln, err := sctp.ListenSCTP("sctp", listenAddr)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	log.Printf("Listen on %s", ln.Addr())
+
+	conn, err := ln.Accept()
+	if err != nil {
+		log.Fatalf("failed to accept: %v", err)
+	}
+	log.Printf("Accepted Connection from RemoteAddr: %s", conn.RemoteAddr())
+	buf := make([]byte, 512)
+	n, err := conn.Read(buf)
+	if err != nil {
+		log.Fatalf("read failed: %v", err)
+	}
+	log.Printf("Received: %s", string(buf[:n]))
+}

--- a/cnf-tests/testimages/stresser/Dockerfile
+++ b/cnf-tests/testimages/stresser/Dockerfile
@@ -1,0 +1,16 @@
+
+FROM golang:1.13 AS builder
+ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_PATH=/go/src/$PKG_NAME
+ENV TESTER_PATH=$PKG_PATH/cnf-tests/testimages/stresser
+
+RUN mkdir -p $PKG_PATH
+
+COPY . $PKG_PATH/
+WORKDIR $TESTER_PATH
+
+RUN go build -mod=vendor -o /stresser
+
+FROM centos:7
+COPY --from=builder /stresser /usr/bin/stresser
+ENTRYPOINT ["/usr/bin/stresser", "-logtostderr"]

--- a/cnf-tests/testimages/stresser/Dockerfile.openshift
+++ b/cnf-tests/testimages/stresser/Dockerfile.openshift
@@ -1,0 +1,23 @@
+# This dockerfile is specific to building the OpenShift CNF stresser image
+FROM openshift/origin-release:golang-1.13 as builder
+
+# Add everything
+ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_PATH=/go/src/$PKG_NAME
+ENV STRESSER_PATH=$PKG_PATH/cnf-tests/testimages/stresser
+
+RUN mkdir -p $PKG_PATH
+
+COPY . $PKG_PATH/
+WORKDIR $STRESSER_PATH
+
+RUN go build -mod=vendor -o /stresser
+
+FROM openshift/origin-base
+
+COPY --from=builder /stresser /usr/bin/stresser
+
+LABEL io.openshift.tags="openshift" \
+      maintainer="Federico Paolinelli <fpaoline@redhat.com>"
+
+CMD ["/usr/bin/stresser"]

--- a/cnf-tests/testimages/stresser/main.go
+++ b/cnf-tests/testimages/stresser/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func main() {
+	totalMem := flag.String("mem-total", "0", "memory that will be consumed")
+	memStep := flag.String("mem-alloc-size", "4Ki", "amount of memory to be consumed in each allocation")
+	memSleep := flag.Duration("mem-alloc-sleep", time.Millisecond, "sleep time between allocations")
+	cpus := flag.Int("cpus", 0, "cpus to burn")
+	flag.Parse()
+	total := resource.MustParse(*totalMem)
+	stepSize := resource.MustParse(*memStep)
+	glog.Infof("Allocating %q memory, in %q chunks, with a %v sleep between allocations", total.String(), stepSize.String(), memSleep)
+	takeMemory(stepSize, total, *memSleep)
+	consumeCpus(*cpus)
+	log.Printf("Allocated %q memory", total.String())
+	select {}
+}
+
+func takeMemory(step, total resource.Quantity, howLong time.Duration) {
+	var buffer [][]byte
+	for i := int64(1); i*step.Value() <= total.Value(); i++ {
+		newBuffer := make([]byte, step.Value())
+		for i := range newBuffer {
+			newBuffer[i] = 0
+		}
+		buffer = append(buffer, newBuffer)
+		time.Sleep(howLong)
+	}
+}
+
+func consumeCpus(howMany int) error {
+	src, err := os.Open("/dev/zero")
+	if err != nil {
+		return err
+	}
+	for i := 0; i < howMany; i++ {
+		log.Print("Spawning a go routine to consume CPU")
+		go func() {
+			_, err := io.Copy(ioutil.Discard, src)
+			if err != nil {
+				panic(err)
+			}
+		}()
+	}
+
+	return nil
+}

--- a/functests/sctp/sctp.go
+++ b/functests/sctp/sctp.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/execute"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/images"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/namespaces"
 
 	"k8s.io/utils/pointer"
@@ -30,7 +31,6 @@ const testNamespace = "sctptest"
 const defaultNamespace = "default"
 
 var (
-	testerImage      string
 	sctpNodeSelector string
 	hasNonCnfWorkers bool
 )
@@ -42,11 +42,6 @@ type nodesInfo struct {
 }
 
 func init() {
-	testerImage = os.Getenv("SCTPTEST_IMAGE")
-	if testerImage == "" {
-		testerImage = "quay.io/fpaoline/sctptester:v1.0"
-	}
-
 	sctpNodeSelector = os.Getenv("SCTPTEST_NODE_SELECTOR")
 	if sctpNodeSelector == "" {
 		sctpNodeSelector = "node-role.kubernetes.io/worker-cnf="
@@ -360,7 +355,7 @@ func sctpTestPod(name, node, app, namespace string, args []string) *k8sv1.Pod {
 			Containers: []k8sv1.Container{
 				{
 					Name:    name,
-					Image:   testerImage,
+					Image:   images.For(images.SctpTester),
 					Command: []string{"/usr/bin/sctptest"},
 					Args:    args,
 				},
@@ -388,7 +383,7 @@ func jobForNode(name, node, app string, cmd []string, args []string) *k8sv1.Pod 
 			Containers: []k8sv1.Container{
 				{
 					Name:    name,
-					Image:   testerImage,
+					Image:   images.For(images.SctpTester),
 					Command: cmd,
 					Args:    args,
 				},

--- a/functests/utils/images/images.go
+++ b/functests/utils/images/images.go
@@ -1,0 +1,52 @@
+package images
+
+import (
+	"fmt"
+	"os"
+
+	gomega "github.com/onsi/gomega"
+)
+
+var registry string
+var images map[string]imageLocation
+
+const (
+	// TestUtils is the image name to be used to retrieve the test utils image
+	TestUtils = "testutils"
+	// SctpTester is the image name to be used to retrieve the sctptester image
+	SctpTester = "sctptester"
+)
+
+func init() {
+	registry = os.Getenv("IMAGE_REGISTRY")
+
+	images = map[string]imageLocation{
+		SctpTester: {
+			name:    "sctptester",
+			registy: "quay.io/fpaoline/",
+			version: "v1.0",
+		},
+		TestUtils: {
+			name:    "cnftest-utils",
+			registy: "quay.io/fpaoline/",
+			version: "v1.0",
+		},
+	}
+}
+
+type imageLocation struct {
+	name    string
+	registy string
+	version string
+}
+
+// For returns the image to be used for the given key
+func For(name string) string {
+	img, ok := images[name]
+	gomega.Expect(ok).To(gomega.BeTrue(), "Image not found")
+
+	if registry != "" {
+		return fmt.Sprintf("%s%s:%s", registry, img.name, img.version)
+	}
+	return fmt.Sprintf("%s%s:%s", img.registy, img.name, img.version)
+}

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/images"
+
 	testclient "github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,27 +25,6 @@ import (
 
 const hugePageCommand = "yum install -y libhugetlbfs python3 && echo -e \"import time\nwhile True:\n\tprint('ABCD'*%s)\n\ttime.sleep(0.5)\" > printer.py && cat printer.py && LD_PRELOAD=libhugetlbfs.so HUGETLB_VERBOSE=10 HUGETLB_MORECORE=yes HUGETLB_FORCE_ELFMAP=yes python3 printer.py > /dev/null"
 
-// GetBusybox returns pod with the busybox image
-func GetBusybox() *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "test-",
-			Labels: map[string]string{
-				"test": "",
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:    "test",
-					Image:   "busybox",
-					Command: []string{"sleep", "10h"},
-				},
-			},
-		},
-	}
-}
-
 func getDefinition(namespace string) *corev1.Pod {
 	podObject := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -52,7 +33,7 @@ func getDefinition(namespace string) *corev1.Pod {
 		Spec: corev1.PodSpec{
 			TerminationGracePeriodSeconds: pointer.Int64Ptr(0),
 			Containers: []corev1.Container{{Name: "test",
-				Image:   "quay.io/schseba/utility-container:latest",
+				Image:   images.For(images.TestUtils),
 				Command: []string{"/bin/bash", "-c", "sleep INF"}}}}}
 
 	return podObject

--- a/go.sum
+++ b/go.sum
@@ -752,6 +752,7 @@ github.com/opencontainers/runc v0.0.0-20190425234816-dae70e8efea4/go.mod h1:qT5X
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190827142921-dd075602f158/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
+github.com/opencontainers/runc v1.0.0-rc9 h1:/k06BMULKF5hidyoZymkoDCzdJzltZpz/UU4LguQVtc=
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190618234442-a950415649c7/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -897,6 +898,7 @@ github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjM
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/hack/build-test-bin.sh
+++ b/hack/build-test-bin.sh
@@ -20,3 +20,6 @@ fi
 ginkgo build ./functests
 mkdir -p cnf-tests/bin
 mv ./functests/functests.test ./cnf-tests/bin/cnftests
+
+go build -o ./cnf-tests/bin/mirror cnf-tests/mirror/mirror.go
+git rev-list -1 HEAD > ./cnf-tests/bin/cnftests-sha.txt


### PR DESCRIPTION
Make the local tests registry configurable.
Add local dockerfiles for container to be used.
Add a mirror command that returns the list of images we use, and
their corresponding version to a custom registry.

It can be used in pipe with oc image mirror with something like 

`docker run cnf-tests /usr/bin/mirror -registry targetregistry:5000/ | oc image mirror -f -`

