### PR TITLE
Include the oc binary in the cnf-tests image

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -3,7 +3,11 @@ WORKDIR /go/src/github.com/openshift-kni/cnf-features-deploy
 COPY . .
 RUN make test-bin
 
+FROM quay.io/openshift/origin-oc-rpms:4.5 as oc 
+
 FROM centos:7
 COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests /usr/bin/cnftests
+COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
+
 CMD ["/usr/bin/cnftests"]
 

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -11,8 +11,11 @@ WORKDIR $PKG_PATH
 
 RUN make test-bin
 
+FROM quay.io/openshift/origin-oc-rpms:4.5 as oc 
+
 FROM openshift/origin-base
 COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests /usr/bin/cnftests
+COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
 
 
 LABEL io.openshift.tags="openshift" \


### PR DESCRIPTION
Performance tests need to use the oc binary. This pr is to provide it inside the cnf-tests image.