### PR TITLE
Update performance tests to the version that use images hosted on quay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/openshift-kni/performance-addon-operators v0.0.0-20200426170508-edc3e1c8422a
+	github.com/openshift-kni/performance-addon-operators v0.0.0-20200428155145-628af753c182
 	github.com/openshift/api v3.9.1-0.20191213091414-3fbf6bcf78e8+incompatible
 	github.com/openshift/client-go v0.0.0-20191205152420-9faca5198b4f
 	github.com/openshift/cluster-node-tuning-operator v0.0.0-00010101000000-000000000000
@@ -38,6 +38,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.17.3 // indirect
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/klog v1.0.0
 	k8s.io/kubelet v0.18.2
 	k8s.io/kubernetes v1.17.0
 	k8s.io/utils v0.0.0-20200414100711-2df71ebbae66

--- a/go.sum
+++ b/go.sum
@@ -762,8 +762,8 @@ github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pK
 github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.3.0/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openshift-kni/performance-addon-operators v0.0.0-20200426170508-edc3e1c8422a h1:cEbRty8LIQP1V3Y6kTzh4+fwOczVsU3VVCdTWQ7mzEU=
-github.com/openshift-kni/performance-addon-operators v0.0.0-20200426170508-edc3e1c8422a/go.mod h1:cdvCMwouaUgub3PikWYaxSPdNF17ZPh/WV4xKx4hSbI=
+github.com/openshift-kni/performance-addon-operators v0.0.0-20200428155145-628af753c182 h1:lV+Ef6Zt74rd2sIYWHlKS5AsL8chN3zOkPmdGiMfXEw=
+github.com/openshift-kni/performance-addon-operators v0.0.0-20200428155145-628af753c182/go.mod h1:cdvCMwouaUgub3PikWYaxSPdNF17ZPh/WV4xKx4hSbI=
 github.com/openshift/api v0.0.0-20191220175332-378bec237e34 h1:y3A8ipN2Ml44DKw+zC9G/9CooOBPKWMalAhhHdn6YbM=
 github.com/openshift/api v0.0.0-20191220175332-378bec237e34/go.mod h1:dv+J0b/HWai0QnMVb37/H0v36klkLBi2TNpPeWDxX10=
 github.com/openshift/client-go v0.0.0-20191205152420-9faca5198b4f h1:1ak9jgsR7+vJ/nvvXS2RUpBhv4Fi0LPc1Zp+wSbGtqg=

--- a/vendor/github.com/openshift-kni/performance-addon-operators/functests/1_performance/cpu_management.go
+++ b/vendor/github.com/openshift-kni/performance-addon-operators/functests/1_performance/cpu_management.go
@@ -173,7 +173,8 @@ func getStressPod(nodeName string) *corev1.Pod {
 							corev1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					},
-					Args: []string{"-cpus", "1"},
+					Command: []string{"/usr/bin/stresser"},
+					Args:    []string{"-cpus", "1"},
 				},
 			},
 			NodeSelector: map[string]string{

--- a/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/images/images.go
+++ b/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/images/images.go
@@ -23,13 +23,13 @@ func init() {
 	images = map[string]imageLocation{
 		TestUtils: {
 			name:    "cnftest-utils",
-			registy: "quay.io/fpaoline/",
-			version: "v1.0",
+			registy: "quay.io/openshift-kni/",
+			version: "4.5",
 		},
 		Stresser: {
 			name:    "stresser",
-			registy: "quay.io/fpaoline/",
-			version: "v1.0",
+			registy: "quay.io/openshift-kni/",
+			version: "4.5",
 		},
 	}
 }

--- a/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/mcps/mcps.go
+++ b/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/mcps/mcps.go
@@ -3,7 +3,6 @@ package mcps
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/klog"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -46,9 +46,9 @@ func GetByName(name string) (*machineconfigv1.MachineConfigPool, error) {
 	mcp := &machineconfigv1.MachineConfigPool{}
 	key := types.NamespacedName{
 		Name:      name,
-		Namespace: "",
+		Namespace: metav1.NamespaceNone,
 	}
-	err := testclient.Client.Get(context.TODO(), key, mcp)
+	err := testclient.GetWithRetry(context.TODO(), key, mcp)
 	return mcp, err
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -131,7 +131,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift-kni/performance-addon-operators v0.0.0-20200426170508-edc3e1c8422a
+# github.com/openshift-kni/performance-addon-operators v0.0.0-20200428155145-628af753c182
 github.com/openshift-kni/performance-addon-operators/functests/0_config
 github.com/openshift-kni/performance-addon-operators/functests/1_performance
 github.com/openshift-kni/performance-addon-operators/functests/utils


### PR DESCRIPTION
This is to update the performance operator tests to latest image.
Specifically, we need it to take advantage of the change that uses tests image hosted on the quay.io/openshift-kni org.