### PR TITLE
Bump the git sha only in dockerfile, externally to make test-bin.

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.13 AS builder
 WORKDIR /go/src/github.com/openshift-kni/cnf-features-deploy
 COPY . .
 RUN make test-bin
+RUN git rev-list -1 HEAD > ./cnf-tests/bin/cnftests-sha.txt
 
 FROM quay.io/openshift/origin-oc-rpms:4.5 as oc 
 

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -10,6 +10,7 @@ COPY . $PKG_PATH/
 WORKDIR $PKG_PATH
 
 RUN make test-bin
+RUN git rev-list -1 HEAD > ./cnf-tests/bin/cnftests-sha.txt
 
 FROM quay.io/openshift/origin-oc-rpms:4.5 as oc 
 

--- a/hack/build-test-bin.sh
+++ b/hack/build-test-bin.sh
@@ -27,4 +27,3 @@ mv ./configsuite/configsuite.test ./cnf-tests/bin/configsuite
 mv ./validationsuite/validationsuite.test ./cnf-tests/bin/validationsuite
 
 go build -o ./cnf-tests/bin/mirror cnf-tests/mirror/mirror.go
-git rev-list -1 HEAD > ./cnf-tests/bin/cnftests-sha.txt


### PR DESCRIPTION
This allows the make test-bin to succeed from a download, outside a git checkout.
