### PR TITLE
Add pod filter namespaces

### DIFF
--- a/functests/test_suite_test.go
+++ b/functests/test_suite_test.go
@@ -134,6 +134,15 @@ func newTestsReporter(reportPath string) (*k8sreporter.KubernetesReporter, *os.F
 		if pod.Namespace == "openshift-ptp" {
 			return false
 		}
+		if pod.Namespace == "openshift-performance-addon" {
+			return false
+		}
+		if pod.Namespace == "dpdk-testing" {
+			return false
+		}
+		if pod.Namespace == "dpdk" {
+			return false
+		}
 		return true
 	}
 

--- a/validationsuite/test_suite_test.go
+++ b/validationsuite/test_suite_test.go
@@ -82,6 +82,12 @@ func newTestsReporter(reportPath string) (*k8sreporter.KubernetesReporter, *os.F
 		if pod.Namespace == "openshift-performance-addon" {
 			return false
 		}
+		if pod.Namespace == "dpdk-testing" {
+			return false
+		}
+		if pod.Namespace == "dpdk" {
+			return false
+		}
 		return true
 	}
 


### PR DESCRIPTION
This commit add the dpdk and performance namespaces to the report filters

Signed-off-by: Sebastian Sch <sebassch@gmail.com>