### PR TITLE
Fix dpdk demo env deployment

### DIFF
--- a/feature-configs/demo/dpdk/scc.yaml
+++ b/feature-configs/demo/dpdk/scc.yaml
@@ -10,9 +10,9 @@ allowHostPorts: false
 allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities:
-  - '*'
+  - "*"
 allowedUnsafeSysctls:
-  - '*'
+  - "*"
 defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny
@@ -22,8 +22,8 @@ runAsUser:
 seLinuxContext:
   type: RunAsAny
 seccompProfiles:
-  - '*'
+  - "*"
 users:
   - system:serviceaccount:dpdk:deployer
 volumes:
-  - '*'
+  - "*"


### PR DESCRIPTION
This commit fix the dpdk deployment using the demo environment.

Before this fix we had this error:

```
error: no objects passed to apply
error: error parsing STDIN: error converting YAML to JSON: yaml: line 14: did not find expected alphabetic or numeric character
```

That was because when we run the workaround for the kustomize apply we remove the `'`.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>