### PR TITLE
Make sure the registry terminates with /

### DIFF
--- a/cnf-tests/mirror/mirror.go
+++ b/cnf-tests/mirror/mirror.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"strings"
 )
 
 type image struct {
@@ -37,7 +38,12 @@ func main() {
 		log.Fatalf("Failed to read %s - %v", *imagesFile, err)
 	}
 
+	registryURL := *targetRegistry
+	if !strings.HasSuffix(*targetRegistry, "/") {
+		registryURL += "/"
+	}
+
 	for _, img := range images {
-		fmt.Printf("%s%s:%s %s%s:%s\n", img.Registry, img.Name, img.Version, *targetRegistry, img.Name, img.Version)
+		fmt.Printf("%s%s:%s %s%s:%s\n", img.Registry, img.Name, img.Version, registryURL, img.Name, img.Version)
 	}
 }

--- a/cnf-tests/test-run.sh
+++ b/cnf-tests/test-run.sh
@@ -6,6 +6,9 @@ set -e
 suites=(validationsuite configsuite cnftests)
 SUITES_PATH="${SUITES_PATH:-~/usr/bin}"
 
+if [ "$IMAGE_REGISTRY" != "" ] && [[ "$IMAGE_REGISTRY" != */ ]]; then
+    export IMAGE_REGISTRY="$IMAGE_REGISTRY/"
+fi
 
 for suite in "${suites[@]}"; do
     echo running "$SUITES_PATH/$suite" "$@"


### PR DESCRIPTION
This pr enforces the addition of / to the registry name, both when mirroring and when running the tests.
Users will tend to add the base url without the separator.