### PR TITLE
Remove the dependency to dpdk on the reporter.

### DIFF
--- a/functests/test_suite_test.go
+++ b/functests/test_suite_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/cnf-features-deploy/functests/dpdk"
 	_ "github.com/openshift-kni/cnf-features-deploy/functests/dpdk" // this is needed otherwise the dpdk test won't be executed
 	_ "github.com/openshift-kni/cnf-features-deploy/functests/ptp"  // this is needed otherwise the ptp test won't be executed
 	_ "github.com/openshift-kni/cnf-features-deploy/functests/sctp" // this is needed otherwise the sctp test won't be executed
@@ -92,7 +91,7 @@ var _ = BeforeSuite(func() {
 
 	ns = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: dpdk.TestDpdkNamespace,
+			Name: namespaces.DpdkTest,
 		},
 	}
 	_, err = testclient.Client.Namespaces().Create(ns)
@@ -110,8 +109,8 @@ var _ = AfterSuite(func() {
 	err = namespaces.WaitForDeletion(testclient.Client, perfUtils.NamespaceTesting, 5*time.Minute)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = testclient.Client.Namespaces().Delete(dpdk.TestDpdkNamespace, &metav1.DeleteOptions{})
+	err = testclient.Client.Namespaces().Delete(namespaces.DpdkTest, &metav1.DeleteOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	err = namespaces.WaitForDeletion(testclient.Client, dpdk.TestDpdkNamespace, 5*time.Minute)
+	err = namespaces.WaitForDeletion(testclient.Client, namespaces.DpdkTest, 5*time.Minute)
 	Expect(err).ToNot(HaveOccurred())
 })

--- a/functests/utils/namespaces/namespaces.go
+++ b/functests/utils/namespaces/namespaces.go
@@ -1,6 +1,7 @@
 package namespaces
 
 import (
+	"os"
 	"time"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -12,6 +13,16 @@ import (
 
 	testclient "github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
 )
+
+// DpdkTest is the namespace of dpdk test suite
+var DpdkTest string
+
+func init() {
+	DpdkTest = os.Getenv("DPDK_TEST_NAMESPACE")
+	if DpdkTest == "" {
+		DpdkTest = "dpdk-testing"
+	}
+}
 
 // WaitForDeletion waits until the namespace will be removed from the cluster
 func WaitForDeletion(cs *testclient.ClientSet, nsName string, timeout time.Duration) error {

--- a/functests/utils/reporter.go
+++ b/functests/utils/reporter.go
@@ -9,8 +9,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/openshift-kni/cnf-features-deploy/functests/dpdk"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/k8sreporter"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/namespaces"
 
 	performancev1alpha1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1alpha1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -34,7 +34,7 @@ func NewReporter(reportPath string) (*k8sreporter.KubernetesReporter, *os.File, 
 		"openshift-sriov-network-operator": true,
 		NamespaceTesting:                   true,
 		perfUtils.NamespaceTesting:         true,
-		dpdk.TestDpdkNamespace:             true,
+		namespaces.DpdkTest:                true,
 		sriovNamespaces.Test:               true,
 		ptpUtils.NamespaceTesting:          true,
 	}


### PR DESCRIPTION
The side effect of this is that dpdk tests are running in all the suites.
This needs to move the namespace on a different package.
