### PR TITLE
Dump failures of crds on log output instead of stderror.

### DIFF
--- a/functests/utils/k8sreporter/example/main.go
+++ b/functests/utils/k8sreporter/example/main.go
@@ -6,12 +6,19 @@ import (
 	"os"
 	"time"
 
-	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/k8sreporter"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/namespaces"
+
+	perfUtils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	ptpUtils "github.com/openshift/ptp-operator/test/utils"
+	sriovNamespaces "github.com/openshift/sriov-network-operator/test/util/namespaces"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+
+	performancev1alpha1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1alpha1"
+	ptpv1 "github.com/openshift/ptp-operator/pkg/apis/ptp/v1"
+	sriovv1 "github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1"
 )
 
 func main() {
@@ -21,13 +28,39 @@ func main() {
 	flag.Parse()
 
 	addToScheme := func(s *runtime.Scheme) {
+		ptpv1.AddToScheme(s)
 		mcfgv1.AddToScheme(s)
-		promv1.AddToScheme(s)
+		performancev1alpha1.SchemeBuilder.AddToScheme(s)
+		sriovv1.AddToScheme(s)
+
 	}
 
-	filterPods := func(pod *v1.Pod) bool {
-		// never filter
-		return false
+	namespacesToDump := map[string]bool{
+		"openshift-performance-addon":      true,
+		"openshift-ptp":                    true,
+		"openshift-sriov-network-operator": true,
+		"cnf-features-testing":             true,
+		perfUtils.NamespaceTesting:         true,
+		namespaces.DpdkTest:                true,
+		sriovNamespaces.Test:               true,
+		ptpUtils.NamespaceTesting:          true,
+	}
+
+	crds := []k8sreporter.CRData{
+		{Cr: &mcfgv1.MachineConfigPoolList{}},
+		{Cr: &ptpv1.PtpConfigList{}},
+		{Cr: &ptpv1.NodePtpDeviceList{}},
+		{Cr: &ptpv1.PtpOperatorConfigList{}},
+		{Cr: &performancev1alpha1.PerformanceProfileList{}},
+		{Cr: &sriovv1.SriovNetworkNodePolicyList{}},
+		{Cr: &sriovv1.SriovNetworkList{}},
+		{Cr: &sriovv1.SriovNetworkNodePolicyList{}},
+		{Cr: &sriovv1.SriovOperatorConfigList{}},
+	}
+
+	skipPods := func(pod *v1.Pod) bool {
+		found := namespacesToDump[pod.Namespace]
+		return !found
 	}
 
 	f, err := os.OpenFile(*report, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -37,20 +70,7 @@ func main() {
 	}
 	defer f.Close()
 
-	crs := []k8sreporter.CRData{
-		k8sreporter.CRData{
-			Cr: &mcfgv1.MachineConfigPoolList{},
-		},
-		k8sreporter.CRData{
-			Cr: &promv1.ServiceMonitorList{},
-		},
-		k8sreporter.CRData{
-			Cr:        &promv1.ServiceMonitorList{},
-			Namespace: pointer.StringPtr("openshift-multus"),
-		},
-	}
-
-	reporter, err := k8sreporter.New(*kubeconfig, addToScheme, filterPods, f, crs...)
+	reporter, err := k8sreporter.New(*kubeconfig, addToScheme, skipPods, f, crds...)
 	if err != nil {
 		log.Fatalf("Failed to initialize the reporter %s", err)
 	}

--- a/functests/utils/k8sreporter/reporter.go
+++ b/functests/utils/k8sreporter/reporter.go
@@ -134,7 +134,7 @@ func (r *KubernetesReporter) logPods(filterPods func(*corev1.Pod) bool) {
 }
 
 func (r *KubernetesReporter) logNodes() {
-	fmt.Fprintf(r.dumpOutput, "Logging nodes\n")
+	fmt.Fprintf(r.dumpOutput, "Dumping nodes\n")
 
 	nodes, err := r.clients.Nodes().List(metav1.ListOptions{})
 	if err != nil {
@@ -192,13 +192,13 @@ func (r *KubernetesReporter) logCustomCR(cr runtime.Object, namespace *string) {
 
 	if err != nil {
 		// this can be expected if we are reporting a feature we did not install the operator for
-		fmt.Fprintf(os.Stderr, "Failed to fetch %T: %v\n", cr, err)
+		fmt.Fprintf(r.dumpOutput, "Failed to fetch %T: %v\n", cr, err)
 		return
 	}
 
 	j, err := json.MarshalIndent(cr, "", "    ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to marshal %T\n", cr)
+		fmt.Fprintf(r.dumpOutput, "Failed to marshal %T\n", cr)
 		return
 	}
 	fmt.Fprintln(r.dumpOutput, string(j))


### PR DESCRIPTION
Having the error while looking at tests output is misleading. With this we put it 
Rename the node section to "dump" to be consistent to the other sections.

Align the example to the full list of CRDS we dump in tests.
