### PR TITLE
Update perf operator deployment to correct 4.6 image

### DIFF
--- a/feature-configs/deploy/performance/operator_catalogsource.yaml
+++ b/feature-configs/deploy/performance/operator_catalogsource.yaml
@@ -8,6 +8,6 @@ spec:
   icon:
     base64data: ""
     mediatype: ""
-  image: quay.io/openshift-kni/performance-addon-operator-registry:latest
+  image: quay.io/openshift-kni/performance-addon-operator-registry:4.6-snapshot
   publisher: Red Hat
   sourceType: grpc

--- a/feature-configs/deploy/performance/operator_subscription.yaml
+++ b/feature-configs/deploy/performance/operator_subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: performance-addon-operator
   namespace: openshift-performance-addon
 spec:
-  channel: 0.0.1
+  channel: 4.5.0
   name: performance-addon-operator
   source: performance-addon-operator
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Note: 4.6.0 channel does not exist yet