### PR TITLE
compile test-bin only if tests are running locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ deps-update:
 	go mod tidy && \
 	go mod vendor
 
-functests: test-bin
+functests: 
 	@echo "Running Functional Tests"
 	FEATURES="$(FEATURES)" hack/run-functests.sh
 

--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -35,6 +35,7 @@ if [ "$CNF_TESTS_IMAGE" != "" ]; then
   EXEC_TESTS="$CONTAINER_MGMT_CLI run -v $(pwd)/_cache/:/kubeconfig:Z -v $TESTS_REPORTS_PATH:/reports:Z -e KUBECONFIG=/kubeconfig/kubeconfig $CNF_TESTS_IMAGE /usr/bin/test-run.sh \
        -ginkgo.focus $FOCUS -junit /reports/ -report /reports/"
 else
+  hack/build-test-bin.sh
   EXEC_TESTS="cnf-tests/test-run.sh -ginkgo.focus=$FOCUS -junit $TESTS_REPORTS_PATH -report $TESTS_REPORTS_PATH"
 fi
 


### PR DESCRIPTION
Do not compile if running from container because this is not needed, adding time, adding complex prerequisits