### PR TITLE
Add longer sriov waiting time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/openshift/cluster-node-tuning-operator v0.0.0-00010101000000-000000000000
 	github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible
 	github.com/openshift/ptp-operator v0.0.0-20200511111616-3d72fdb1c731
-	github.com/openshift/sriov-network-operator v0.0.0-20200512234214-8079cf03e552
+	github.com/openshift/sriov-network-operator v0.0.0-20200515104142-a566f73713af
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/procfs v0.0.6 // indirect
 	go.uber.org/atomic v1.5.0 // indirect
@@ -88,5 +88,5 @@ replace (
 replace (
 	github.com/openshift-kni/performance-addon-operators => github.com/openshift-kni/performance-addon-operators v0.0.0-20200514145830-82baa38e9b10 // release-4.5
 	github.com/openshift/ptp-operator => github.com/openshift/ptp-operator v0.0.0-20200511111616-3d72fdb1c731 // release-4.5
-	github.com/openshift/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20200512234214-8079cf03e552 // release-4.5
+	github.com/openshift/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20200515104142-a566f73713af // release-4.5
 )

--- a/go.sum
+++ b/go.sum
@@ -840,8 +840,6 @@ github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pK
 github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.3.0/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openshift-kni/performance-addon-operators v0.0.0-20200512134518-4819029dd5a0 h1:6cndRwKG81qOYnuLa5P6eZFL98IWmQCZctv3UjojhKc=
-github.com/openshift-kni/performance-addon-operators v0.0.0-20200512134518-4819029dd5a0/go.mod h1:cdvCMwouaUgub3PikWYaxSPdNF17ZPh/WV4xKx4hSbI=
 github.com/openshift-kni/performance-addon-operators v0.0.0-20200514145830-82baa38e9b10 h1:0ggSgldarO8GDYdBILdYg+UAFXQLIUYUeUpANlLC1RY=
 github.com/openshift-kni/performance-addon-operators v0.0.0-20200514145830-82baa38e9b10/go.mod h1:cdvCMwouaUgub3PikWYaxSPdNF17ZPh/WV4xKx4hSbI=
 github.com/openshift/api v0.0.0-20191220175332-378bec237e34 h1:y3A8ipN2Ml44DKw+zC9G/9CooOBPKWMalAhhHdn6YbM=
@@ -867,8 +865,8 @@ github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mo
 github.com/openshift/ptp-operator v0.0.0-20200511111616-3d72fdb1c731 h1:ebPqMldysfByIEOupZN9l8Lo5Vq7FCXFCc+S6zC8jUg=
 github.com/openshift/ptp-operator v0.0.0-20200511111616-3d72fdb1c731/go.mod h1:LHEPSSUNwOlkCSwaup+9WAEa0Omqg+uDrZVGnJJ/oxY=
 github.com/openshift/runtime-utils v0.0.0-20191011150825-9169de69ebf6/go.mod h1:5gDRVvQwesU7cfwlpuMivdv3Dz/oslvv2qTBHCy4wqQ=
-github.com/openshift/sriov-network-operator v0.0.0-20200512234214-8079cf03e552 h1:vFJ+hTOHxCM+Ai651qNUVyUOkb1yrvAJDe9bBYBVHZo=
-github.com/openshift/sriov-network-operator v0.0.0-20200512234214-8079cf03e552/go.mod h1:RxKxBOXa/qTQSI5mwP6VwVv6WGnUfKsTWx5+njJVn40=
+github.com/openshift/sriov-network-operator v0.0.0-20200515104142-a566f73713af h1:Iv8o3uUF/KadE/BsWd+nAk2caLM2mltsJBOi922xtm0=
+github.com/openshift/sriov-network-operator v0.0.0-20200515104142-a566f73713af/go.mod h1:RxKxBOXa/qTQSI5mwP6VwVv6WGnUfKsTWx5+njJVn40=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/operator-framework/api v0.0.0-20200120235816-80fd2f1a09c9 h1:HfxMEPJ0djo/RNfrmli3kI2oKS6IeuIZWu1Q5Rewt/o=

--- a/vendor/github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1/sriovnetworknodepolicy_types.go
+++ b/vendor/github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1/sriovnetworknodepolicy_types.go
@@ -37,11 +37,9 @@ type SriovNetworkNodePolicySpec struct {
 
 // +k8s:openapi-gen=false
 type SriovNetworkNicSelector struct {
-	// +kubebuilder:validation:Enum={"8086","15b3"}
 	// The vendor hex code of SR-IoV device. Allowed value "8086", "15b3".
 	Vendor string `json:"vendor,omitempty"`
-	// The device hex code of SR-IoV device. Allowed value "1583", "158b", "10fb", "1015", "1017".
-	// +kubebuilder:validation:Enum={"1583","158b","10fb","1015","1017"}
+	// The device hex code of SR-IoV device. Allowed value "158b", "1015", "1017".
 	DeviceID string `json:"deviceID,omitempty"`
 	// PCI address of SR-IoV PF.
 	RootDevices []string `json:"rootDevices,omitempty"`

--- a/vendor/github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1/sriovoperatorconfig_types.go
+++ b/vendor/github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1/sriovoperatorconfig_types.go
@@ -16,7 +16,9 @@ type SriovOperatorConfigSpec struct {
 	EnableInjector *bool `json:"enableInjector,omitempty"`
 	// Flag to control whether the operator admission controller webhook shall be deployed
 	EnableOperatorWebhook *bool `json:"enableOperatorWebhook,omitempty"`
-	// Flag to control the log verbose level of the operator
+	// Flag to control the log verbose level of the operator. Set to '0' to show only the basic logs. And set to '2' to show all the available logs.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=2
 	LogLevel int `json:"logLevel,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,7 +167,7 @@ github.com/openshift/ptp-operator/test/utils/client
 github.com/openshift/ptp-operator/test/utils/execute
 github.com/openshift/ptp-operator/test/utils/nodes
 github.com/openshift/ptp-operator/test/utils/pods
-# github.com/openshift/sriov-network-operator v0.0.0-20200512234214-8079cf03e552 => github.com/openshift/sriov-network-operator v0.0.0-20200512234214-8079cf03e552
+# github.com/openshift/sriov-network-operator v0.0.0-20200515104142-a566f73713af => github.com/openshift/sriov-network-operator v0.0.0-20200515104142-a566f73713af
 github.com/openshift/sriov-network-operator/pkg/apis/k8s/v1
 github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1
 github.com/openshift/sriov-network-operator/pkg/client/clientset/versioned/scheme


### PR DESCRIPTION
Here we vendor the latest sr-iov tests with configurable (and longer) timeouts and we apply the same logic to the dpdk test.