### PR TITLE
will not search for go in run-functests

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -2,14 +2,6 @@
 
 . $(dirname "$0")/common.sh
 
-which go
-if [ $? -ne 0 ]; then
-  echo "No go command available"
-  exit 1
-fi
-
-GOPATH="${GOPATH:-~/go}"
-
 export CONTAINER_MGMT_CLI="${CONTAINER_MGMT_CLI:-docker}"
 export PATH=$PATH:$GOPATH/bin
 export TESTS_REPORTS_PATH="${TESTS_REPORTS_PATH:-/tmp/artifacts/}"


### PR DESCRIPTION
tests can run from container image, in which case, no need for go.
build-test-bin alread take care of making sure go is available for builds.