### PR TITLE
Fix test-pmd build

### DIFF
--- a/tools/s2i-dpdk/test/test-app/build.sh
+++ b/tools/s2i-dpdk/test/test-app/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-make -C test-pmd
+make -e -C test-pmd
 
 cp test-pmd/testpmd ./customtestpmd
 


### PR DESCRIPTION
This commit add the "-e" to the make command.
This will load the container environment variables to find the right RTE_SDK

Signed-off-by: Sebastian Sch <sebassch@gmail.com>