### PR TITLE
PTP Tests: limit the nodes impacted by the tests using the optional selector

### DIFF
--- a/functests/ptp/ptp.go
+++ b/functests/ptp/ptp.go
@@ -36,7 +36,8 @@ var _ = Describe("ptp", func() {
 	execute.BeforeAll(func() {
 		if !discovery.Enabled() {
 			Clean()
-			ptpNodes, err := nodes.GetNodeTopology(client.Client)
+			ptpNodes, err := nodes.PtpEnabled(client.Client)
+
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(ptpNodes)).To(BeNumerically(">", 1), "need at least two nodes with ptp capable nics")
 


### PR DESCRIPTION
By setting NODES_SELECTOR, it's possible to limit the nodes impacted by the ptp tests.
In that case, the configuration is applied to a subset of nodes only.
