### PR TITLE
Make the SCTP client server connection waiting time longer.

### DIFF
--- a/functests/sctp/sctp.go
+++ b/functests/sctp/sctp.go
@@ -303,7 +303,7 @@ func testClientServerConnection(cs *client.ClientSet, namespace string, destIP s
 			pod, err := cs.Pods(namespace).Get(serverPodName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return pod.Status.Phase
-		}, 15*time.Second, 1*time.Second).Should(Equal(k8sv1.PodRunning))
+		}, 30*time.Second, 1*time.Second).Should(Equal(k8sv1.PodRunning))
 		return
 	}
 
@@ -311,7 +311,7 @@ func testClientServerConnection(cs *client.ClientSet, namespace string, destIP s
 		pod, err := cs.Pods(namespace).Get(serverPodName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return pod.Status.Phase
-	}, 15*time.Second, 1*time.Second).Should(Equal(k8sv1.PodSucceeded))
+	}, 1*time.Minute, 1*time.Second).Should(Equal(k8sv1.PodSucceeded))
 }
 
 func createSctpService(cs *client.ClientSet, namespace string) *k8sv1.Service {


### PR DESCRIPTION
There are cases where the connection takes up to 30 seconds to establish.
This causes the sctp tests to be flaky.
