### PR TITLE
Add dpdk s2i build script for dpdk deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ All kustomize configs should be entirely declarative in nature. This means no ba
 
 - You need a running OCP 4.4 cluster and a valid KUBECONFIG.
 - You need at least one node with the `node-role.kubernetes.io/worker-cnf=""` label and a `MachineConfigPool` matching `worker-cnf` machine configurations
+- You need to install `jq` (a command line tool for parsing JSON) on the local machine.
 
 You can run `make setup-test-cluster` to have the first two (or the first in case of only one) workers labeled as `worker-cnf` and to have the `MachineConfigPool` created.
 

--- a/feature-configs/deploy/dpdk/post_deploy.sh
+++ b/feature-configs/deploy/dpdk/post_deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+start_build=false
+last_build=$(oc get build -n dpdk -o json | jq '.items[-1].metadata.name' | tr -d '"')
+if [ $last_build == "null" ]; then
+    start_build=true
+else
+    build_status=$(oc get build -n dpdk $last_build -o json | jq '.status.phase' | tr -d '"')
+    if [ $build_status == "Complete" ]; then
+        exit 0
+    elif [ $build_status == "Running" ]; then
+        exit 1
+    elif [ $build_status == "Failed" ]; then
+        start_build=true
+    fi
+fi
+
+if $start_build; then
+    oc start-build -n dpdk s2i-dpdk
+    exit 1
+fi
+

--- a/hack/feature-deploy.sh
+++ b/hack/feature-deploy.sh
@@ -47,7 +47,21 @@ do
     if [[ $? != 0 ]]; then
       echo "[WARN] Deployment of feature '$feature' failed."
       feature_failed=1
+    else
+      deploy_complete=feature-configs/${FEATURES_ENVIRONMENT}/${feature}/post_deploy.sh
+      if [[ ! -f $deploy_complete ]]; then
+        deploy_complete=feature-configs/deploy/${feature}/post_deploy.sh
+        if [[ ! -f $deploy_complete ]]; then
+          continue
+        fi
+      fi
+
+      if ! $deploy_complete; then
+        echo "[WARN] Deployment of feature '$feature' failed."
+        feature_failed=1
+      fi
     fi
+
     set -e
 
   done


### PR DESCRIPTION
If the registry is not ready when downloading the dpdk image the
s2i build running only once and the whole CNF deployment will wait for a timeout.

Retry and build dpdk image until compelte, with a timeout.

This script is not in the Makefile beacuse it doesnt follow the blueprint (kustomize) approach.

Signed-off-by: Sabina Aledort <saledort@redhat.com>