### PR TITLE
Fix error copying s2i/bin folder

### DIFF
--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -72,7 +72,7 @@ RUN chmod -R 777 /opt/app-root
 
 # TODO: Copy the S2I scripts to /usr/libexec/s2i, since openshift/base-centos7 image
 # sets io.openshift.s2i.scripts-url label that way, or update that label
-COPY ./s2i/bin/ /usr/libexec/s2i
+COPY ./tools/s2i-dpdk/s2i/bin/ /usr/libexec/s2i
 
 RUN setcap cap_sys_resource,cap_ipc_lock=+ep /usr/libexec/s2i/run
 


### PR DESCRIPTION
When building the dpdk image found that s2i/bin folder could not be found. Just adapt the Dockerfile to the correct path. Looks like the current pwd matches the root of the cloned repository not the contextDir.

This fix solves the issue when building the dpdk base from OpenShift using the [build-config.yaml](https://github.com/openshift-kni/cnf-features-deploy/blob/master/tools/s2i-dpdk/base-image/build-config.yaml) object 

Signed-off-by: Alberto Losada <alosadag@redhat.com>