### PR TITLE
Replaced centos7 base image byt centos8 in s2i-dpdk build

### DIFF
--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -1,5 +1,5 @@
 # dpdk-centos7
-FROM registry.centos.org/centos/centos:8
+FROM docker.io/centos:centos8
 #FROM centos:7
 
 LABEL maintainer="Sebastian Scheinkman <sebassch@gmail.com>"

--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -1,5 +1,5 @@
 # dpdk-centos7
-FROM openshift/base-centos7
+FROM registry.centos.org/centos/centos:8
 #FROM centos:7
 
 LABEL maintainer="Sebastian Scheinkman <sebassch@gmail.com>"
@@ -17,6 +17,8 @@ LABEL io.k8s.description="Platform for building DPDK workloads" \
       io.openshift.tags="builder,dpdk"
 
 RUN yum groupinstall -y "Development Tools"
+RUN yum install dnf-plugins-core -y 
+RUN yum config-manager --set-enabled PowerTools -y 
 RUN yum install -y wget \
  numactl \
  numactl-devel \
@@ -72,7 +74,7 @@ RUN chmod -R 777 /opt/app-root
 
 # TODO: Copy the S2I scripts to /usr/libexec/s2i, since openshift/base-centos7 image
 # sets io.openshift.s2i.scripts-url label that way, or update that label
-COPY ./s2i/bin/ /usr/libexec/s2i
+COPY ./tools/s2i-dpdk/s2i/bin/ /usr/libexec/s2i
 
 RUN setcap cap_sys_resource,cap_ipc_lock=+ep /usr/libexec/s2i/run
 


### PR DESCRIPTION
Replaced openshift/centos7 with centos/centos8 which requires installing PowerTool repo where libpcap-devel is placed in new CentOS release.

Also, modified the S2i scripts COPY PATH since I was facing "not found" issues during the building 
process.

CC/ @SchSeba since he is the maintainer of the built/Dockerfile.