### PR TITLE
Add discovery of performance profile in dpdk tests

### DIFF
--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -32,6 +32,7 @@ import (
 	sriovnetwork "github.com/openshift/sriov-network-operator/test/util/network"
 
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/discovery"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/execute"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/images"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/machineconfigpool"
@@ -48,8 +49,9 @@ const (
 )
 
 var (
-	machineConfigPoolName  string
-	performanceProfileName string
+	machineConfigPoolName          string
+	performanceProfileName         string
+	enforcedPerformanceProfileName string
 
 	sriovclient *sriovtestclient.ClientSet
 
@@ -68,6 +70,8 @@ func init() {
 	performanceProfileName = os.Getenv("PERF_TEST_PROFILE")
 	if performanceProfileName == "" {
 		performanceProfileName = "performance"
+	} else {
+		enforcedPerformanceProfileName = performanceProfileName
 	}
 
 	OriginalSriovPolicies = make([]*sriovv1.SriovNetworkNodePolicy, 0)
@@ -88,6 +92,8 @@ func init() {
 
 var _ = Describe("dpdk", func() {
 	var dpdkWorkloadPod *corev1.Pod
+	var discoverySuccessful bool
+	discoveryFailedReason := "Can not run tests in discovery mode. Failed to discover required resources"
 
 	execute.BeforeAll(func() {
 		var exist bool
@@ -95,11 +101,37 @@ var _ = Describe("dpdk", func() {
 		if exist {
 			return
 		}
+		nodeSelector, _ := nodes.PodLabelSelector()
 
-		findOrOverridePerformanceProfile()
+		if discovery.Enabled() {
+			var performanceProfiles []*perfv1alpha1.PerformanceProfile
+			discoverySuccessful, discoveryFailedReason, performanceProfiles = discoverPerformanceProfiles()
+
+			if !discoverySuccessful {
+				return
+			}
+			performanceProfiles = filterPerformanceProfilesWithAvailableNodes(performanceProfiles, nodeSelector)
+			if len(performanceProfiles) == 0 {
+				discoverySuccessful, discoveryFailedReason = false, "Can not run tests in discovery mode. Failed to find a matching node"
+				return
+			}
+			// TODO: use the first matching profile for now. When sriov discovery is added, a profile with
+			// an available sriov node should be chosen
+			nodeSelector = performanceProfiles[0].Spec.NodeSelector
+
+		} else {
+			findOrOverridePerformanceProfile()
+		}
+
 		findOrOverrideSriovNetwork()
 
-		dpdkWorkloadPod = createPod()
+		dpdkWorkloadPod = createPod(nodeSelector)
+	})
+
+	BeforeEach(func() {
+		if discovery.Enabled() && discoverySuccessful {
+			Skip(discoveryFailedReason)
+		}
 	})
 
 	Context("Validate the build and deployment configuration", func() {
@@ -239,8 +271,10 @@ var _ = Describe("dpdk", func() {
 	// This will not work if we use a random order running
 	Context("restoring configuration", func() {
 		It("should restore the cluster to the original status", func() {
-			By("restore performance profile")
-			RestorePerformanceProfile()
+			if !discovery.Enabled() {
+				By(" restore performance profile")
+				RestorePerformanceProfile()
+			}
 
 			By("cleaning the sriov test configuration")
 			CleanSriov()
@@ -299,10 +333,56 @@ func tryToFindDPDKPod() (*corev1.Pod, bool) {
 	return nil, false
 }
 
-func findOrOverridePerformanceProfile() {
-	performanceProfile, valid, err := ValidatePerformanceProfile()
-	Expect(err).ToNot(HaveOccurred())
+func discoverPerformanceProfiles() (bool, string, []*perfv1alpha1.PerformanceProfile) {
+	if enforcedPerformanceProfileName != "" {
+		performanceProfile, err := findDefaultPerformanceProfile()
+		if err != nil {
+			return false, fmt.Sprintf("Can not run tests in discovery mode. Failed to find a valid perfomance profile. %s", err), nil
+		}
+		valid, err := validatePerformanceProfile(performanceProfile)
+		if !valid || err != nil {
+			return false, fmt.Sprintf("Can not run tests in discovery mode. Failed to find a valid perfomance profile. %s", err), nil
+		}
+		return true, "", []*perfv1alpha1.PerformanceProfile{performanceProfile}
+	}
 
+	performanceProfileList := &perfv1alpha1.PerformanceProfileList{}
+	var profiles []*perfv1alpha1.PerformanceProfile
+	err := client.Client.List(context.TODO(), performanceProfileList)
+	if err != nil {
+		return false, fmt.Sprintf("Can not run tests in discovery mode. Failed to find a valid perfomance profile. %s", err), nil
+	}
+	for _, performanceProfile := range performanceProfileList.Items {
+		valid, err := validatePerformanceProfile(&performanceProfile)
+		if valid && err == nil {
+			profiles = append(profiles, &performanceProfile)
+		}
+	}
+	if len(profiles) > 0 {
+		return true, "", profiles
+	}
+	return false, fmt.Sprintf("Can not run tests in discovery mode. Failed to find a valid perfomance profile. %s", err), nil
+}
+
+func findDefaultPerformanceProfile() (*perfv1alpha1.PerformanceProfile, error) {
+	performanceProfile := &perfv1alpha1.PerformanceProfile{}
+	err := client.Client.Get(context.TODO(), goclient.ObjectKey{Name: performanceProfileName}, performanceProfile)
+	return performanceProfile, err
+}
+
+func findOrOverridePerformanceProfile() {
+	var valid = true
+	performanceProfile, err := findDefaultPerformanceProfile()
+	if err != nil {
+		if errors.IsNotFound(err) {
+			valid = false
+		}
+		Expect(err).ToNot(HaveOccurred())
+	}
+	if valid {
+		valid, err = validatePerformanceProfile(performanceProfile)
+		Expect(err).ToNot(HaveOccurred())
+	}
 	if !valid {
 		if performanceProfile != nil {
 			OriginalPerformanceProfile = performanceProfile.DeepCopy()
@@ -362,56 +442,47 @@ func findOrOverrideSriovNetwork() {
 
 }
 
-func createPod() *corev1.Pod {
-	pod, err := CreateDPDKWorkload()
+func createPod(nodeSelector map[string]string) *corev1.Pod {
+	pod, err := createDPDKWorkload(nodeSelector)
 	Expect(err).ToNot(HaveOccurred())
 
 	return pod
 }
 
-func ValidatePerformanceProfile() (*perfv1alpha1.PerformanceProfile, bool, error) {
-	performanceProfile := &perfv1alpha1.PerformanceProfile{}
-	err := client.Client.Get(context.TODO(), goclient.ObjectKey{Name: performanceProfileName}, performanceProfile)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, false, nil
-		}
-
-		return nil, false, err
-	}
+func validatePerformanceProfile(performanceProfile *perfv1alpha1.PerformanceProfile) (bool, error) {
 
 	// Check we have more then two isolated CPU
 	cpuSet, err := cpuset.Parse(string(*performanceProfile.Spec.CPU.Isolated))
 	if err != nil {
-		return performanceProfile, false, err
+		return false, err
 	}
 
 	cpuSetSlice := cpuSet.ToSlice()
 	if len(cpuSetSlice) < 6 {
-		return performanceProfile, false, nil
+		return false, nil
 	}
 
 	if performanceProfile.Spec.HugePages == nil {
-		return performanceProfile, false, nil
+		return false, nil
 	}
 
 	if *performanceProfile.Spec.HugePages.DefaultHugePagesSize != "1G" {
-		return performanceProfile, false, nil
+		return false, nil
 	}
 
 	if len(performanceProfile.Spec.HugePages.Pages) == 0 {
-		return performanceProfile, false, nil
+		return false, nil
 	}
 
 	if performanceProfile.Spec.HugePages.Pages[0].Count < 4 {
-		return performanceProfile, false, nil
+		return false, nil
 	}
 
 	if performanceProfile.Spec.HugePages.Pages[0].Size != "1G" {
-		return performanceProfile, false, nil
+		return false, nil
 	}
 
-	return performanceProfile, true, nil
+	return true, nil
 }
 
 func CleanPerformanceProfiles() error {
@@ -575,7 +646,7 @@ func CreateSriovNetwork(sriovDevice *sriovv1.InterfaceExt, sriovNetworkName stri
 
 }
 
-func CreateDPDKWorkload() (*corev1.Pod, error) {
+func createDPDKWorkload(nodeSelector map[string]string) (*corev1.Pod, error) {
 	resources := map[corev1.ResourceName]resource.Quantity{
 		corev1.ResourceName("hugepages-1Gi"): resource.MustParse("2Gi"),
 		corev1.ResourceMemory:                resource.MustParse("1Gi"),
@@ -666,9 +737,17 @@ sleep INF
 		},
 	}
 
-	selector, ok := nodes.PodLabelSelector()
-	if ok {
-		dpdkPod.Spec.NodeSelector = selector
+	if len(nodeSelector) > 0 {
+		dpdkPod.Spec.NodeSelector = nodeSelector
+	}
+
+	if nodeSelector != nil && len(nodeSelector) > 0 {
+		if dpdkPod.Spec.NodeSelector == nil {
+			dpdkPod.Spec.NodeSelector = make(map[string]string)
+		}
+		for k, v := range nodeSelector {
+			dpdkPod.Spec.NodeSelector[k] = v
+		}
 	}
 
 	dpdkPod, err := client.Client.Pods(namespaces.DpdkTest).Create(context.Background(), dpdkPod, metav1.CreateOptions{})
@@ -919,4 +998,16 @@ func waitForSRIOVStable() {
 		Expect(err).ToNot(HaveOccurred())
 		return isClusterReady
 	}, waitingTime, 1*time.Second).Should(BeTrue())
+}
+
+func filterPerformanceProfilesWithAvailableNodes(performanceProfiles []*perfv1alpha1.PerformanceProfile, nodeSelector map[string]string) []*perfv1alpha1.PerformanceProfile {
+	availableProfiles := make([]*perfv1alpha1.PerformanceProfile, 0)
+	for _, profile := range performanceProfiles {
+		profileNodeSelector := nodes.NodesSelectorUnion(nodeSelector, profile.Spec.NodeSelector)
+		nodesAvailable := nodes.ValidateNodeIsAvailableForSelector(profileNodeSelector)
+		if nodesAvailable {
+			availableProfiles = append(availableProfiles, profile)
+		}
+	}
+	return availableProfiles
 }

--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -277,3 +277,37 @@ func MatchingOptionalSelectorPTP(toFilter []ptpv1.NodePtpDevice) ([]ptpv1.NodePt
 	}
 	return res, nil
 }
+
+// ValidateNodeIsAvailableForSelector check if any nodes are available for given nodeSelector
+func ValidateNodeIsAvailableForSelector(nodeSelector map[string]string) bool {
+	nodes, err := client.Client.Nodes().List(context.Background(), metav1.ListOptions{
+		LabelSelector: nodeSelectorAsString(nodeSelector),
+	})
+	return err != nil || len(nodes.Items) > 0
+}
+
+// NodesSelectorUnion returns a union of 2 node selectors
+func NodesSelectorUnion(nodeSelector1 map[string]string, nodeSelector2 map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range nodeSelector1 {
+		result[k] = v
+	}
+	for k, v := range nodeSelector2 {
+		result[k] = v
+	}
+	return result
+}
+
+func nodeSelectorAsString(nodeSelector map[string]string) string {
+	result := ""
+	first := true
+	for k, v := range nodeSelector {
+		if !first {
+			first = false
+			result = result + ", "
+		}
+		result = result + fmt.Sprintf("%s=%s", k, v)
+
+	}
+	return result
+}


### PR DESCRIPTION
This PR adds discovery of performance profile in dpdk tests.
If discovery mode is enabled, the tests will attempt to reuse an existing performance profile.
Following PR's will add discovery of sriov policy.