### PR TITLE
[release 4.5] Bug 1858849: Use right driver for dpdk 4.5

### DIFF
--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -535,12 +535,12 @@ func CreateSriovPolicy(sriovDevice *sriovv1.InterfaceExt, testNode string, numVf
 	}
 
 	// Mellanox device
-	if sriovDevice.DeviceID == "1015" {
+	if sriovDevice.Vendor == "15b3" {
 		nodePolicy.Spec.IsRdma = true
 	}
 
 	// Intel device
-	if sriovDevice.DeviceID == "8086" {
+	if sriovDevice.Vendor == "8086" {
 		nodePolicy.Spec.DeviceType = "vfio-pci"
 	}
 


### PR DESCRIPTION
This commit fix the sriov policy creation on the dpdk test.
We need to use the vendor ID an not the Device ID.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>