### PR TITLE
Disable PTP offset test when not running in discovery mode.

### DIFF
--- a/functests/ptp/ptp.go
+++ b/functests/ptp/ptp.go
@@ -99,13 +99,7 @@ var _ = Describe("ptp", func() {
 		slaveLabel := ptpSlaveNodeLabel
 		BeforeEach(func() {
 			if !discovery.Enabled() {
-				nodes, err := client.Client.Nodes().List(context.Background(), metav1.ListOptions{
-					LabelSelector: ptpSlaveNodeLabel,
-				})
-				Expect(err).ToNot(HaveOccurred())
-				if len(nodes.Items) < 1 {
-					Skip(fmt.Sprintf("PTP Nodes with label %s are not deployed on cluster", ptpSlaveNodeLabel))
-				}
+				Skip("Offset test is enabled only in discovery mode, assuming the grandmaster is external to the cluster")
 			}
 			_, slaveConfigs := getPTPConfigs(ptpLinuxDaemonNamespace)
 			if len(slaveConfigs) == 0 {


### PR DESCRIPTION
If we run in "configuration" mode, we configure a master on one of the nodes of the cluster.
This ends up in flaky offsets given the infrastructure is not reliable.

