### PR TITLE
Add sleep time before checking last dpdk s2i build

### DIFF
--- a/feature-configs/deploy/dpdk/post_deploy.sh
+++ b/feature-configs/deploy/dpdk/post_deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+sleep 10
+
 start_build=false
 last_build=$(oc get build -n dpdk -o json | jq '.items[-1].metadata.name' | tr -d '"')
 if [ $last_build == "null" ]; then


### PR DESCRIPTION
When deploying dpdk it takes few seconds before the build is created.
Therefore, we should wait before checking if a build exist.