### PR TITLE
add xt_u32 as a feature

### DIFF
--- a/feature-configs/demo/xt_u32/kustomization.yaml
+++ b/feature-configs/demo/xt_u32/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../deploy/xt_u32

--- a/feature-configs/deploy/xt_u32/is_ready.sh
+++ b/feature-configs/deploy/xt_u32/is_ready.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# no output means that the new machine config wasn't picked by MCO yet
+if [ -z "$(oc get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="load-xt_u32-module")].name}')" ]; then
+    exit 1
+fi
+
+oc wait mcp/worker-cnf --for condition=updated --timeout 1s

--- a/feature-configs/deploy/xt_u32/kustomization.yaml
+++ b/feature-configs/deploy/xt_u32/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - xt_u32_module_mc.yaml

--- a/feature-configs/deploy/xt_u32/xt_u32_module_mc.yaml
+++ b/feature-configs/deploy/xt_u32/xt_u32_module_mc.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+  name: load-xt_u32-module
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8,xt_u32
+          filesystem: root
+          mode: 420
+          path: /etc/modules-load.d/xt_u32-load.conf

--- a/feature-configs/typical-baremetal/xt_u32/kustomization.yaml
+++ b/feature-configs/typical-baremetal/xt_u32/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../deploy/xt_u32


### PR DESCRIPTION
xt_u32 is an iptables filtering kernel module.
The module was removed from RHEL8 and brought back to life becasue there are some important CNFs that relay upon it. It will be removed again for RHEL9,
but till then we wanna have a documented way of enabling it and attesting it works.

This is basically a copy of sctp feature (minus the unblacklisting which isnt required for xt_u32).