### PR TITLE
Delete dpdk failed build

### DIFF
--- a/feature-configs/deploy/dpdk/post_deploy.sh
+++ b/feature-configs/deploy/dpdk/post_deploy.sh
@@ -11,6 +11,7 @@ else
     elif [ $build_status == "Running" ]; then
         exit 1
     elif [ $build_status == "Failed" ]; then
+        oc delete build -n dpdk $last_build
         start_build=true
     fi
 fi


### PR DESCRIPTION
If a dpdk build status is failed, delete it before creating a new build.