### PR TITLE
Update the CI performance profile

### DIFF
--- a/feature-configs/typical-baremetal/performance/performance_profile.patch.yaml
+++ b/feature-configs/typical-baremetal/performance/performance_profile.patch.yaml
@@ -3,8 +3,17 @@ kind: PerformanceProfile
 metadata:
   name: performance
 spec:
+  additionalKernelArgs:
+    - nmi_watchdog=0
+    - audit=0
+    - mce=off
+    - processor.max_cstate=1
+    - idle=poll
+    - intel_idle.max_cstate=0
+    - nosmt
+    - tsc=reliable
   cpu:
-    isolated: 8-15
+    isolated: 2-15
     reserved: 0-1
   hugepages:
     pages:


### PR DESCRIPTION
The latency test requires additional kernel arguments to
be configured and to have sequency of the isolated CPUs
that the CPU manager can allocate for the pod.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>