### PR TITLE
performance profile: consume api v1

### DIFF
--- a/cnf-tests/README.md
+++ b/cnf-tests/README.md
@@ -330,7 +330,7 @@ The resource needed by the dpdk tests are higher than those required by the perf
 To do that, a profile like the following one can be mounted inside the container, and the performance tests can be instructed to deploy it.
 
 ```yaml
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: performance

--- a/feature-configs/demo/performance/performance_profile.yaml
+++ b/feature-configs/demo/performance/performance_profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: performance

--- a/feature-configs/integration-base/performance/performance_profile.yaml
+++ b/feature-configs/integration-base/performance/performance_profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: performance

--- a/feature-configs/integration-kni1/performance/performance_profile_patch.yaml
+++ b/feature-configs/integration-kni1/performance/performance_profile_patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: performance

--- a/feature-configs/integration-u08/performance/performance_profile_patch.yaml
+++ b/feature-configs/integration-u08/performance/performance_profile_patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: performance

--- a/feature-configs/integration-vms/performance/performance_profile_patch.yaml
+++ b/feature-configs/integration-vms/performance/performance_profile_patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: performance

--- a/feature-configs/integration-wl4-d17u01b05/performance/performance_profile_patch.yaml
+++ b/feature-configs/integration-wl4-d17u01b05/performance/performance_profile_patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: performance

--- a/feature-configs/typical-baremetal/performance/performance_profile.patch.yaml
+++ b/feature-configs/typical-baremetal/performance/performance_profile.patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: performance

--- a/functests/utils/discovery/discovery.go
+++ b/functests/utils/discovery/discovery.go
@@ -8,7 +8,7 @@ import (
 
 	testclient "github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/nodes"
-	perfv1alpha1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1alpha1"
+	perfv1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
 	sriovv1 "github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1"
 	sriovtestclient "github.com/openshift/sriov-network-operator/test/util/client"
 	sriovcluster "github.com/openshift/sriov-network-operator/test/util/cluster"
@@ -18,7 +18,7 @@ import (
 
 // DpdkResources contains discovered dpdk resources
 type DpdkResources struct {
-	Profile  *perfv1alpha1.PerformanceProfile
+	Profile  *perfv1.PerformanceProfile
 	Resource string
 	Device   *sriovv1.InterfaceExt
 }
@@ -32,7 +32,7 @@ func Enabled() bool {
 // DiscoverPerformanceProfileAndPolicyWithAvailableNodes finds a profile/sriovPolicy match for which a node with
 // allocatable resources is available. It will return a profile/sriovPolicy for a policy with resource name
 // "dpdknic", or a pair with the most available resource on node
-func DiscoverPerformanceProfileAndPolicyWithAvailableNodes(client *testclient.ClientSet, sriovclient *sriovtestclient.ClientSet, operatorNamespace string, resourceName string, performanceProfiles []*perfv1alpha1.PerformanceProfile, nodeSelector map[string]string,
+func DiscoverPerformanceProfileAndPolicyWithAvailableNodes(client *testclient.ClientSet, sriovclient *sriovtestclient.ClientSet, operatorNamespace string, resourceName string, performanceProfiles []*perfv1.PerformanceProfile, nodeSelector map[string]string,
 ) (discoveredDpdkResources DpdkResources, err error) {
 	currentResourceCount := 0
 	var sriovInfos *sriovcluster.EnabledNodes

--- a/functests/utils/k8sreporter/example/main.go
+++ b/functests/utils/k8sreporter/example/main.go
@@ -16,7 +16,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	performancev1alpha1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1alpha1"
+	performancev1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
 	ptpv1 "github.com/openshift/ptp-operator/pkg/apis/ptp/v1"
 	sriovv1 "github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1"
 )
@@ -30,7 +30,7 @@ func main() {
 	addToScheme := func(s *runtime.Scheme) {
 		ptpv1.AddToScheme(s)
 		mcfgv1.AddToScheme(s)
-		performancev1alpha1.SchemeBuilder.AddToScheme(s)
+		performancev1.SchemeBuilder.AddToScheme(s)
 		sriovv1.AddToScheme(s)
 
 	}
@@ -51,7 +51,7 @@ func main() {
 		{Cr: &ptpv1.PtpConfigList{}},
 		{Cr: &ptpv1.NodePtpDeviceList{}},
 		{Cr: &ptpv1.PtpOperatorConfigList{}},
-		{Cr: &performancev1alpha1.PerformanceProfileList{}},
+		{Cr: &performancev1.PerformanceProfileList{}},
 		{Cr: &sriovv1.SriovNetworkNodePolicyList{}},
 		{Cr: &sriovv1.SriovNetworkList{}},
 		{Cr: &sriovv1.SriovNetworkNodePolicyList{}},

--- a/functests/utils/reporter.go
+++ b/functests/utils/reporter.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/k8sreporter"
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils/namespaces"
 
-	performancev1alpha1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1alpha1"
+	performancev1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	ptpv1 "github.com/openshift/ptp-operator/pkg/apis/ptp/v1"
 	sriovv1 "github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1"
@@ -23,7 +23,7 @@ func NewReporter(reportPath string) (*k8sreporter.KubernetesReporter, *os.File, 
 	addToScheme := func(s *runtime.Scheme) {
 		ptpv1.AddToScheme(s)
 		mcfgv1.AddToScheme(s)
-		performancev1alpha1.SchemeBuilder.AddToScheme(s)
+		performancev1.SchemeBuilder.AddToScheme(s)
 		sriovv1.AddToScheme(s)
 
 	}
@@ -44,7 +44,7 @@ func NewReporter(reportPath string) (*k8sreporter.KubernetesReporter, *os.File, 
 		{Cr: &ptpv1.PtpConfigList{}},
 		{Cr: &ptpv1.NodePtpDeviceList{}},
 		{Cr: &ptpv1.PtpOperatorConfigList{}},
-		{Cr: &performancev1alpha1.PerformanceProfileList{}},
+		{Cr: &performancev1.PerformanceProfileList{}},
 		{Cr: &sriovv1.SriovNetworkNodePolicyList{}},
 		{Cr: &sriovv1.SriovNetworkList{}},
 		{Cr: &sriovv1.SriovNetworkNodeStateList{}},


### PR DESCRIPTION
For 4.6, performance profile api is becoming stable, introducing v1.
Update everything to consume the stable API, which is also more
future proof.

Signed-off-by: Francesco Romani <fromani@redhat.com>