### PR TITLE
support dpdk tests with ovn-kubernetes share gw

### DIFF
--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -628,6 +628,26 @@ func findDpdkSriovDevice(enabledNodes *sriovcluster.EnabledNodes, nodeName strin
 		return nil, fmt.Errorf("failed to find the default gateway device")
 	}
 
+	// we are using ovn-kubernetes shared gateway we should find the interface connected to it
+	if iface == "br-ex" {
+		buff, err := pods.ExecCommand(client.Client, pod, []string{"bridge", "link"})
+		if err != nil {
+			return nil, err
+		}
+		for _, line := range strings.Split(buff.String(), "\r\n") {
+			if strings.Contains(line, "master ovs-system") {
+				envSplit := strings.Split(line, ": ")
+				if len(envSplit) != 3 {
+					return nil, fmt.Errorf("failed to split the device from the bridge link line: %s", line)
+				}
+
+				iface = strings.Split(envSplit[1], " ")[0]
+				break
+			}
+		}
+
+	}
+
 	for _, itf := range nodeStatus.Status.Interfaces {
 		if itf.Name == iface {
 			return &itf, nil


### PR DESCRIPTION
This commit fix the dpdk test running on an openshift cluster
with ovn-kubernetes on the new shared gateway mode.

we search for the default gateway interface and if the name is `br-ex`
we locate the interface connected to the ovs bridge using the `bridge link`
command

Signed-off-by: Sebastian Sch <sebassch@gmail.com>