### PR TITLE
Fix a nil pointer exception in the dpdk tests

### DIFF
--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -133,13 +133,13 @@ var _ = Describe("dpdk", func() {
 
 	Context("Validate the build", func() {
 		It("Should forward and receive packets from a pod running dpdk base on a image created by building config", func() {
+			Expect(dpdkWorkloadPod).ToNot(BeNil(), "No dpdk workload pod found")
 			var out string
 			var err error
 
 			if dpdkWorkloadPod.Spec.Containers[0].Image == images.For(images.Dpdk) {
 				Skip("skip test as we can't find a dpdk workload running with a s2i build")
 			}
-			Expect(dpdkWorkloadPod).ToNot(BeNil(), "No dpdk workload pod found")
 
 			By("Parsing output from the DPDK application")
 			Eventually(func() string {
@@ -154,13 +154,13 @@ var _ = Describe("dpdk", func() {
 
 	Context("Validate a DPDK workload running inside a pod", func() {
 		It("Should forward and receive packets", func() {
+			Expect(dpdkWorkloadPod).ToNot(BeNil(), "No dpdk workload pod found")
 			var out string
 			var err error
 
 			if dpdkWorkloadPod.Spec.Containers[0].Image != images.For(images.Dpdk) {
 				Skip("skip test as we find a dpdk workload running with a s2i build")
 			}
-			Expect(dpdkWorkloadPod).ToNot(BeNil(), "No dpdk workload pod found")
 
 			By("Parsing output from the DPDK application")
 			Eventually(func() string {


### PR DESCRIPTION
Example:

```
•! Panic [0.001 seconds]
dpdk
/remote-source/app/functests/dpdk/dpdk.go:88
  Validate a DPDK workload running inside a pod
  /remote-source/app/functests/dpdk/dpdk.go:155
    Should forward and receive packets [It]
    /remote-source/app/functests/dpdk/dpdk.go:156

    Test Panicked
    runtime error: invalid memory address or nil pointer dereference
    /opt/rh/go-toolset-1.13/root/usr/lib/go-toolset-1.13-golang/src/runtime/panic.go:199

    Full Stack Trace
    github.com/openshift-kni/cnf-features-deploy/functests/dpdk.glob..func1.4.1()
    	/remote-source/app/functests/dpdk/dpdk.go:160 +0x93
    github.com/openshift-kni/cnf-features-deploy/functests_test.TestTest(0xc0009ca900)
    	/remote-source/app/functests/test_suite_test.go:78 +0xf3
    testing.tRunner(0xc0009ca900, 0x1a34cc0)
    	/opt/rh/go-toolset-1.13/root/usr/lib/go-toolset-1.13-golang/src/testing/testing.go:909 +0xc9
    created by testing.(*T).Run
    	/opt/rh/go-toolset-1.13/root/usr/lib/go-toolset-1.13-golang/src/testing/testing.go:960 +0x350
```
Signed-off-by: Sebastian Sch <sebassch@gmail.com>