### PR TITLE
Activate codeready builder for rhel-8.

### DIFF
--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -16,6 +16,8 @@ LABEL io.k8s.description="Platform for building DPDK workloads" \
       io.k8s.display-name="builder 0.1" \
       io.openshift.tags="builder,dpdk"
 
+RUN subscription-manager repos --enable=codeready-builder-for-rhel-8-x86_64-rpms
+
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y wget \
  numactl \


### PR DESCRIPTION
Dpdk dockerfile FROM is replaced with the base specified in the
release repo. After changing the base to rhel-8, the developer subscription
needs to be explicitly enabled. Without doing that, the yum install command
won't be able to find libpcap-devel (see also https://bugzilla.redhat.com/show_bug.cgi?id=1707919)

