### PR TITLE
Fix the s2i build

### DIFF
--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -76,4 +76,8 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 
 RUN setcap cap_sys_resource,cap_ipc_lock=+ep /usr/libexec/s2i/run
 
+# This is needed for the s2i to work
+# in the pod yaml we still use the runAsUser:0 we w/a the ulimit issue
+USER 1001
+
 CMD ["/usr/libexec/s2i/usage"]


### PR DESCRIPTION
This change fix the error in build time for the s2i

```
error: build error: image "0" must specify a user that is numeric and within the range of allowed users
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>