### PR TITLE
Remove the default path for junit

### DIFF
--- a/cnf-tests/README.md
+++ b/cnf-tests/README.md
@@ -300,6 +300,8 @@ A junit compliant xml is produced by passing the `--junit` parameter together wi
     docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig quay.io/openshift-kni/cnf-tests /usr/bin/test-run.sh --junit /path/to/junit
 ```
 
+*note:* file name is `cnftests-junit.xml`
+
 ### Test Failure Report
 
 A report with informations about the cluster state (and resources) for troubleshooting can be produced by passing the `--report` parameter together with the path where the report is dumped:
@@ -307,6 +309,8 @@ A report with informations about the cluster state (and resources) for troublesh
 ```bash
     docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig quay.io/openshift-kni/cnf-tests /usr/bin/test-run.sh --report /path/to/report
 ```
+
+*note:* file name is `cnftests_failure_report.log`
 
 ### A note on podman
 

--- a/functests/test_suite_test.go
+++ b/functests/test_suite_test.go
@@ -50,8 +50,8 @@ var (
 )
 
 func init() {
-	junitPath = flag.String("junit", "junit.xml", "the path for the junit format report")
-	reportPath = flag.String("report", "", "the path of the report file containing details for failed tests")
+	junitPath = flag.String("junit", "", "the path for the junit format report")
+	reportPath = flag.String("report", "", "the path for the report file containing details on failed tests")
 }
 
 func TestTest(t *testing.T) {


### PR DESCRIPTION
This commit remove the default path for the junit report.

Before this change we always create a folder with a file name.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>