### PR TITLE
deploy: fix channel rename

### DIFF
--- a/feature-configs/deploy/performance/operator_subscription.yaml
+++ b/feature-configs/deploy/performance/operator_subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: performance-addon-operator
   namespace: openshift-performance-addon
 spec:
-  channel: 4.5.0
+  channel: "4.5"
   name: performance-addon-operator
   source: performance-addon-operator
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
On performance-operator side this happened in the PR
https://github.com/openshift-kni/performance-addon-operators/pull/344
The rename was needed to enable the Z-stream releases.

Signed-off-by: Francesco Romani <fromani@redhat.com>