### PR TITLE
Reduce performance profile hugepages from 8 to 4

### DIFF
--- a/feature-configs/typical-baremetal/performance/performance_profile.patch.yaml
+++ b/feature-configs/typical-baremetal/performance/performance_profile.patch.yaml
@@ -18,5 +18,5 @@ spec:
   hugepages:
     pages:
     - size: "1G"
-      count: 8
+      count: 4
       node: 0


### PR DESCRIPTION
When having a cluster with virtual machines as workers, there is not enough memory for all the pods
and the disruption budget will not allow us to drain the baremetal machine.