### PR TITLE
Dump single pod instead of pod list.

### DIFF
--- a/functests/utils/k8sreporter/reporter.go
+++ b/functests/utils/k8sreporter/reporter.go
@@ -124,7 +124,7 @@ func (r *KubernetesReporter) logPods(filterPods func(*corev1.Pod) bool) {
 		if filterPods(&pod) {
 			continue
 		}
-		j, err := json.MarshalIndent(pods, "", "    ")
+		j, err := json.MarshalIndent(pod, "", "    ")
 		if err != nil {
 			fmt.Println("Failed to marshal pods", err)
 			return


### PR DESCRIPTION
Due to a bug, now all the pods are dumped many times, one for each pod available. We need to dump the list only once.

