### PR TITLE
Wait longer for resources to be available in sctp-sriov integration test

### DIFF
--- a/functests/sctp/sctp_sriov.go
+++ b/functests/sctp/sctp_sriov.go
@@ -66,7 +66,7 @@ var _ = Describe("[sriov] SCTP integration", func() {
 				resNum, _ := testedNode.Status.Allocatable["openshift.io/sctptestres"]
 				capacity, _ := resNum.AsInt64()
 				return capacity
-			}, 3*time.Minute, time.Second).Should(Equal(int64(5)))
+			}, 10*time.Minute, time.Second).Should(Equal(int64(5)))
 
 		} else {
 			err := sriovnamespaces.CleanNetworks(sriovOperatorNamespace, sriovclient)


### PR DESCRIPTION
Now that we only look at the status, we must ensure the resources are there.

