### PR TITLE
DPDK performance profile changes in doc / code.

### DIFF
--- a/cnf-tests/README.md
+++ b/cnf-tests/README.md
@@ -338,13 +338,13 @@ metadata:
   name: performance
 spec:
   cpu:
-    isolated: "0-15"
-    reserved: "0-7"
+    isolated: "4-15"
+    reserved: "0-3"
   hugepages:
     defaultHugepagesSize: "1G"
     pages:
     - size: "1G"
-      count: 16
+      count: 4
       node: 0
   realTimeKernel:
     enabled: true

--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -537,7 +537,7 @@ func CreatePerformanceProfile() error {
 				DefaultHugePagesSize: &hugepageSize,
 				Pages: []perfv1.HugePage{
 					{
-						Count: 16,
+						Count: 4,
 						Size:  hugepageSize,
 						Node:  pointer.Int32Ptr(0),
 					},


### PR DESCRIPTION
- In doc, make isolated and reserved not to overlap
- In doc & code: reduce the amount of hugepages. 4 is fine if a profile is found, so it's enough
to make dpdk work.