### PR TITLE
Skip setup if in discovery mode.

### DIFF
--- a/cnf-tests/test-run.sh
+++ b/cnf-tests/test-run.sh
@@ -11,6 +11,10 @@ if [ "$IMAGE_REGISTRY" != "" ] && [[ "$IMAGE_REGISTRY" != */ ]]; then
 fi
 
 for suite in "${suites[@]}"; do
+    if [ "$DISCOVERY_MODE" == "true" ] &&  [ "$suite" == "configsuite" ]; then
+        echo "Discovery mode enabled, skipping setup"
+        continue
+    fi
     echo running "$SUITES_PATH/$suite" "$@"
     "$SUITES_PATH/$suite" "$@"
 done


### PR DESCRIPTION
If discovery mode is enabled, it does not make sense to run any kind of configuration.
