### PR TITLE
Update performance tests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/openshift-kni/performance-addon-operators v0.0.0-20200928164137-ec36742f4ded
+	github.com/openshift-kni/performance-addon-operators v0.0.0-20201008142722-e143c79c1f33
 	github.com/openshift/api v3.9.1-0.20191213091414-3fbf6bcf78e8+incompatible
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
 	github.com/openshift/cluster-node-tuning-operator v0.0.0-00010101000000-000000000000
@@ -80,7 +80,7 @@ replace (
 
 // Test deps
 replace (
-	github.com/openshift-kni/performance-addon-operators => github.com/openshift-kni/performance-addon-operators v0.0.0-20200928164137-ec36742f4ded // release-4.6
+	github.com/openshift-kni/performance-addon-operators => github.com/openshift-kni/performance-addon-operators v0.0.0-20201008142722-e143c79c1f33 // release-4.7
 	github.com/openshift/ptp-operator => github.com/openshift/ptp-operator v0.0.0-20201002155552-d601b99bf51e // release-4.6
 	github.com/openshift/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20201002123007-ad2447de6f7f // release-4.6
 )

--- a/go.sum
+++ b/go.sum
@@ -989,8 +989,8 @@ github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openshift-kni/performance-addon-operators v0.0.0-20200928164137-ec36742f4ded h1:1aoPqTnL0FzOPWbRiXd7Rh8CqVM/RPtiSX7DiUmp3y0=
-github.com/openshift-kni/performance-addon-operators v0.0.0-20200928164137-ec36742f4ded/go.mod h1:jr8Chbww9nGFfRBc5q+31w68O4lcUfWArUG3LRQij1E=
+github.com/openshift-kni/performance-addon-operators v0.0.0-20201008142722-e143c79c1f33 h1:H/sM+k1h7XS/fAYLQeHpeFJDxrRwTnbYYKUkASTKI3g=
+github.com/openshift-kni/performance-addon-operators v0.0.0-20201008142722-e143c79c1f33/go.mod h1:jr8Chbww9nGFfRBc5q+31w68O4lcUfWArUG3LRQij1E=
 github.com/openshift/api v0.0.0-20200526144822-34f54f12813a h1:riE/kCXnb051RWT/z+DytxKEZ3+JromVDl79rXAKyFY=
 github.com/openshift/api v0.0.0-20200526144822-34f54f12813a/go.mod h1:l6TGeqJ92DrZBuWMNKcot1iZUHfbYSJyBWHGgg6Dn6s=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=

--- a/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/profiles/profiles.go
+++ b/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/profiles/profiles.go
@@ -25,12 +25,12 @@ func GetByNodeLabels(nodeLabels map[string]string) (*performancev1.PerformancePr
 	}
 
 	var result *performancev1.PerformanceProfile
-	for _, profile := range profiles.Items {
-		if reflect.DeepEqual(profile.Spec.NodeSelector, nodeLabels) {
+	for i := 0; i < len(profiles.Items); i++ {
+		if reflect.DeepEqual(profiles.Items[i].Spec.NodeSelector, nodeLabels) {
 			if result != nil {
 				return nil, fmt.Errorf("found more than one performance profile with specified node selector %v", nodeLabels)
 			}
-			result = &profile
+			result = &profiles.Items[i]
 		}
 	}
 

--- a/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/utils.go
+++ b/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/utils.go
@@ -19,7 +19,10 @@ func BeforeAll(fn func()) {
 }
 
 func ExecAndLogCommand(name string, arg ...string) ([]byte, error) {
-	out, err := exec.Command(name, arg...).CombinedOutput()
-	klog.Infof("run command '%s %v':\n  out=%s\n  err=%v", name, arg, out, err)
+	out, err := exec.Command(name, arg...).Output()
+	klog.Infof("run command '%s %v' (err=%v):\n  stdout=%s\n", name, arg, err, out)
+	if exitError, ok := err.(*exec.ExitError); ok {
+		klog.Infof("run command '%s %v' (err=%v):\n  stderr=%s", name, arg, err, exitError.Stderr)
+	}
 	return out, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -134,7 +134,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift-kni/performance-addon-operators v0.0.0-20200928164137-ec36742f4ded => github.com/openshift-kni/performance-addon-operators v0.0.0-20200928164137-ec36742f4ded
+# github.com/openshift-kni/performance-addon-operators v0.0.0-20201008142722-e143c79c1f33 => github.com/openshift-kni/performance-addon-operators v0.0.0-20201008142722-e143c79c1f33
 github.com/openshift-kni/performance-addon-operators/functests/0_config
 github.com/openshift-kni/performance-addon-operators/functests/1_performance
 github.com/openshift-kni/performance-addon-operators/functests/utils


### PR DESCRIPTION
This version of tests ignore the output of oc on stderr unless the command returns an error, making
them compatible with the 4.5 version. The new CI based on multistep relies on the e2e workflow which
ships the 4.5 version of oc.
