### PR TITLE
Bug 1889275: When looking for the mc that enables sctp, skip if the raw config is empty

### DIFF
--- a/functests/sctp/sctp.go
+++ b/functests/sctp/sctp.go
@@ -562,6 +562,9 @@ func enablesSCTP(mc mcfgv1.MachineConfig) (bool, error) {
 	loadPathFound := false
 
 	ignitionConfig := igntypes.Config{}
+	if mc.Spec.Config.Raw == nil {
+		return false, nil
+	}
 
 	err := json.Unmarshal(mc.Spec.Config.Raw, &ignitionConfig)
 	if err != nil {

--- a/validationsuite/cluster/validation.go
+++ b/validationsuite/cluster/validation.go
@@ -171,9 +171,12 @@ var _ = Describe("validation", func() {
 	Context("sctp", func() {
 		findSCTPMachineConfig := func(mcl []clientmachineconfigv1.MachineConfig) (bool, *clientmachineconfigv1.MachineConfig) {
 			for _, mc := range mcl {
+				if mc.Spec.Config.Raw == nil {
+					continue
+				}
 				ignitionConfig := igntypes.Config{}
 				err := json.Unmarshal(mc.Spec.Config.Raw, &ignitionConfig)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "Failed to unmarshal raw config for ", mc.Name)
 
 				if ignitionConfig.Storage.Files != nil {
 					for _, file := range ignitionConfig.Storage.Files {


### PR DESCRIPTION
There are some configurations where we only apply kernel arguments to machine configs.
In this case, the config section is empty and this makes the checks performed by sctp to fail.
