### PR TITLE
Fixed link to detailed list of cnf-tests

### DIFF
--- a/cnf-tests/README.md
+++ b/cnf-tests/README.md
@@ -100,7 +100,7 @@ The set of available features to filter are:
 - sctp
 - dpdk
 
-A detailed list of the tests can be found [here](cnf-tests/TESTLIST.md).
+A detailed list of the tests can be found [here](./TESTLIST.md).
 
 ### Dry Run
 


### PR DESCRIPTION
Signed-off-by: Alberto Losada <alosadag@redhat.com>

Fixing a broken link in the documentation. 