### PR TITLE
[release-4.6] Use index image instead of registry one to deploy PAO

### DIFF
--- a/feature-configs/deploy/performance/operator_catalogsource.yaml
+++ b/feature-configs/deploy/performance/operator_catalogsource.yaml
@@ -8,6 +8,6 @@ spec:
   icon:
     base64data: ""
     mediatype: ""
-  image: quay.io/openshift-kni/performance-addon-operator-registry:4.6-snapshot
+  image: quay.io/openshift-kni/performance-addon-operator-index:4.6-snapshot
   publisher: Red Hat
   sourceType: grpc


### PR DESCRIPTION
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>