### PR TITLE
Add xt_u32 feature tests to the test suite.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #TODO add default features here
-export FEATURES?=sctp performance
+export FEATURES?=sctp performance xt_u32
 IMAGE_BUILD_CMD ?= "docker"
 
 # The environment represents the kustomize patches to apply when deploying the features

--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -57,9 +57,9 @@ RUN yum install -y numactl-devel make gcc && \
     make oslat && \
     cp oslat /oslat
 
-FROM centos:8
+FROM centos:7
 
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool numactl-libs iptables
+RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs
 
 RUN mkdir -p /usr/local/etc/cnf
 

--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -57,9 +57,9 @@ RUN yum install -y numactl-devel make gcc && \
     make oslat && \
     cp oslat /oslat
 
-FROM centos:7
+FROM centos:8
 
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs
+RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool numactl-libs iptables
 
 RUN mkdir -p /usr/local/etc/cnf
 

--- a/cnf-tests/README.md
+++ b/cnf-tests/README.md
@@ -23,6 +23,7 @@ Table of Contents
       * [DPDK tests](#dpdk-tests)
       * [PTP tests](#ptp-tests)
       * [SCTP tests](#sctp-tests)
+      * [XT_U32 tests](#xt_u32-tests)
       * [Performance operator tests](#performance-operator-tests)
     * [Limiting the nodes used during tests\.](#limiting-the-nodes-used-during-tests)
   * [Test Reports](#test-reports)
@@ -36,6 +37,7 @@ Table of Contents
   * [Troubleshooting](#troubleshooting)
   * [Impacts on the Cluster](#impacts-on-the-cluster)
     * [SCTP](#sctp)
+    * [XT_U32](#xt_u32)
     * [SR\-IOV](#sr-iov)
     * [PTP](#ptp)
     * [Performance](#performance)
@@ -51,6 +53,7 @@ This include:
 
 - Targeting a machine config pool to which the machines to be tested belong to
 - Enabling sctp via machine config
+- Enabling xt_u32 via machine config
 - Having the Performance Addon Operator installed
 - Having the SR-IOV operator installed
 - Having the PTP operator installed
@@ -166,6 +169,7 @@ The set of available features to filter are:
 - sriov
 - ptp
 - sctp
+- xt_u32
 - dpdk
 
 A detailed list of the tests can be found [here](./TESTLIST.md).
@@ -340,6 +344,10 @@ The DPDK related tests require:
 - SriovNetworkNodePolicy
 - a node matchin both the SriovNetworkNodePolicy and a MachineConfig which enables SCTP
 
+#### XT_U32 tests
+
+- a node with a MachineConfig which enables XT_U32
+
 #### Performance operator tests
 
 Various tests have different requirements. Some of them:
@@ -456,6 +464,10 @@ In general, only the `sctp` tests do not change the cluster configuration. All t
 ### SCTP
 
 SCTP tests just run different pods on different nodes to check connectivity. The impacts on the cluster are related to running simple pods on two nodes.
+
+### XT_U32
+
+XT_U32 tests just run pods on different nodes to check iptables rule that utilize xt_u32. The impacts on the cluster are related to running simple pods on two nodes.
 
 ### SR-IOV
 

--- a/cnf-tests/TESTLIST.md
+++ b/cnf-tests/TESTLIST.md
@@ -90,32 +90,32 @@ The cnf tests instrument each different feature required by CNF. Following, a de
 
 | Test Name | Description |
 | -- | ----------- |
-| [performance] Latency Test with the oslat image should succeed | Run the oslat with parameters specified via environment variables and validated that the maximum latency for isolated CPUs below the value specified under the OSLAT_MAXIMUM_LATENCY environment variable | 
-| [performance] Verify API Conversions  Verifies v1 <-> v1alpha1 conversions | Verifies that Performance Addon Operator can work with v1alpha1 Performance Profiles. | 
-| [performance]RT Kernel  a node without performance profile applied should not have RT kernel installed | Verifies that RT kernel is not enabled when not configured in the profile. | 
-| [performance]Topology Manager  should be enabled with the policy specified in profile | Verifies that when specifying a topology policy in the profile, that is used by the topology manager. | 
-| [performance] CPU Management Verification of configuration on the worker node  Verify rcu_nocbs kernel argument on the node | Checks that the node has rcu_nocbs kernel argument applied | 
-| [performance] Network latency parameters adjusted by the Node Tuning Operator  Should contain configuration injected through the openshift-node-performance profile | Checks that the node has injected tuned sysctl parameters | 
-| [performance] Pre boot tuning adjusted by tuned   initramfs should not have injected configuration | Checks that the iniramfs does not have injected configuration | 
-| [performance] Pre boot tuning adjusted by tuned  Should set CPU isolcpu's kernel argument managed_irq flag | Checks that the node has injected managed_irq argument under boot parameters | 
-| [performance] Tuned CRs generated from profile  Should have the expected name for tuned from the profile owner object | Checks that the PAO generates the tuned resources with the expected name | 
-| [performance] CPU Management Verification of configuration on the worker node  Verify CPU reservation on the node | When specifying reserved CPUs, verifies that they don't belong to the allocatable list. | 
-| [performance] Tuned kernel parameters  Should contain configuration injected through openshift-node-performance profile | Checks that the node has kernel arguments that should be injected via tuned | 
+| [performance] CPU Management  Verification of cpu manager functionality Verify CPU usage by stress PODs Non-guaranteed POD can work on any CPU | Checks that non guaranteed pod can use any CPU | 
+| [performance]Hugepages Huge pages support for container workloads  Huge pages support for container workloads | Verifies that huge pages are available in a container when requested. | 
 | [performance]Hugepages when NUMA node specified  should be allocated on the specifed NUMA node  | Verifies that when hugepages are specified on a given numa node in the profile are allocated to that node. | 
-| [performance]Hugepages with multiple sizes  should be supported and available for the container usage | Verifies that hugepages with different size can be configured and used by pods. | 
+| [performance]RT Kernel  should have RT kernel enabled | Verifies that RT kernel is enabled when configured in the profile. | 
+| [performance] Verify API Conversions  Verifies v1 <-> v1alpha1 conversions | Verifies that Performance Addon Operator can work with v1alpha1 Performance Profiles. | 
 | [performance] CPU Management Verification of configuration on the worker node  Verify CPU affinity mask, CPU reservation and CPU isolation on worker node | Verifies that CPU affinity, reservation and isolation are set correctly on the node as specified in the profile spec. | 
-| [performance] Additional kernel arguments added from perfomance profile  Should set additional kernel arguments on the machine | Verifies that when specifying additional kernel arguments to the profile, those are added on the node. | 
-| [performance] Verify API Conversions  Verifies v1 <-> v2 conversions | Verifies that Performance Addon Operator can work with v1 Performance Profiles. | 
-| [performance] Pre boot tuning adjusted by tuned   Should set workqueue CPU mask | Checks that the node has injected workqueue CPU mask | 
 | [performance] Pre boot tuning adjusted by tuned   Should set CPU affinity kernel argument | Checks that the node has injected systemd.cpu_affinity argument under boot parameters, that used to configure the CPU affinity | 
 | [performance] Create second performance profiles on a cluster  Verifies that cluster can have multiple profiles | Verifies that multiple performance profiles can be applied to the cluster. | 
-| [performance] CPU Management  Verification of cpu manager functionality Verify CPU usage by stress PODs Non-guaranteed POD can work on any CPU | Checks that non guaranteed pod can use any CPU | 
-| [performance] Pre boot tuning adjusted by tuned   stalld daemon is running on the host | Checks that the stalld daemon is running on the host | 
-| [performance]Hugepages Huge pages support for container workloads  Huge pages support for container workloads | Verifies that huge pages are available in a container when requested. | 
-| [performance]RT Kernel  should have RT kernel enabled | Verifies that RT kernel is enabled when configured in the profile. | 
-| [performance] CPU Management  Verification of cpu manager functionality Verify CPU usage by stress PODs Guaranteed POD should work on isolated cpu | Checks that the guaranteed pod will use the isolated CPU, the test relevant only for cases when reserved and isolated CPUs complementary and include all online CPUs | 
+| [performance] Tuned CRs generated from profile  Should have the expected name for tuned from the profile owner object | Checks that the PAO generates the tuned resources with the expected name | 
 | [performance] CPU Management when pod runs with the CPU load balancing runtime class  should disable CPU load balancing for CPU's used by the pod | Checks that the runtime will disable the CPU load balancing for the guaranteed pod with the specific runtime class and annotation | 
+| [performance] Latency Test with the oslat image should succeed | Run the oslat with parameters specified via environment variables and validated that the maximum latency for isolated CPUs below the value specified under the OSLAT_MAXIMUM_LATENCY environment variable | 
 | [performance] Performance Operator Should run on the control plane nodes | Checks that PAO runs on the master nodes | 
+| [performance] Pre boot tuning adjusted by tuned   Should set workqueue CPU mask | Checks that the node has injected workqueue CPU mask | 
+| [performance] Tuned kernel parameters  Should contain configuration injected through openshift-node-performance profile | Checks that the node has kernel arguments that should be injected via tuned | 
+| [performance] Verify API Conversions  Verifies v1 <-> v2 conversions | Verifies that Performance Addon Operator can work with v1 Performance Profiles. | 
+| [performance] Pre boot tuning adjusted by tuned  Should set CPU isolcpu's kernel argument managed_irq flag | Checks that the node has injected managed_irq argument under boot parameters | 
+| [performance] Additional kernel arguments added from perfomance profile  Should set additional kernel arguments on the machine | Verifies that when specifying additional kernel arguments to the profile, those are added on the node. | 
+| [performance] Network latency parameters adjusted by the Node Tuning Operator  Should contain configuration injected through the openshift-node-performance profile | Checks that the node has injected tuned sysctl parameters | 
+| [performance] Pre boot tuning adjusted by tuned   initramfs should not have injected configuration | Checks that the iniramfs does not have injected configuration | 
+| [performance] CPU Management Verification of configuration on the worker node  Verify CPU reservation on the node | When specifying reserved CPUs, verifies that they don't belong to the allocatable list. | 
+| [performance] CPU Management Verification of configuration on the worker node  Verify rcu_nocbs kernel argument on the node | Checks that the node has rcu_nocbs kernel argument applied | 
+| [performance]Hugepages with multiple sizes  should be supported and available for the container usage | Verifies that hugepages with different size can be configured and used by pods. | 
+| [performance]RT Kernel  a node without performance profile applied should not have RT kernel installed | Verifies that RT kernel is not enabled when not configured in the profile. | 
+| [performance]Topology Manager  should be enabled with the policy specified in profile | Verifies that when specifying a topology policy in the profile, that is used by the topology manager. | 
+| [performance] CPU Management  Verification of cpu manager functionality Verify CPU usage by stress PODs Guaranteed POD should work on isolated cpu | Checks that the guaranteed pod will use the isolated CPU, the test relevant only for cases when reserved and isolated CPUs complementary and include all online CPUs | 
+| [performance] Pre boot tuning adjusted by tuned   stalld daemon is running on the host | Checks that the stalld daemon is running on the host | 
 
 ## PTP
 
@@ -133,8 +133,14 @@ The cnf tests instrument each different feature required by CNF. Following, a de
 | ptp Test Offset PTP configuration verifications PTP time diff between Grandmaster and Slave should be in range -100ms and 100ms | Verifies that the time diff between master & slave is below 100 ms. | 
 | ptp prometheus Metrics reported by PTP pods Should all be reported by prometheus | Verifies that the PTP metrics are reported. | 
 
-## Others
+## XT_U32
 
 | Test Name | Description |
 | -- | ----------- |
+| xt_u32 Negative - xt_u32 disabled Should NOT create an iptable rule | Negative test: when the xt_u32 module is not enabled, appling an iptables rule that utilize the module should fail. | 
+| xt_u32 Validate the module is enabled and works Should create an iptables rule inside a pod that has the module enabled | Verifies that an iptables rule that utilize xt_u32 module can be applied successfully in a pod that has the module enabled. | 
 
+## Others 
+
+| Test Name | Description |
+| -- | ----------- |

--- a/cnf-tests/docgen/e2e.json
+++ b/cnf-tests/docgen/e2e.json
@@ -75,5 +75,7 @@
     "sctp Test Connectivity Connectivity between client and server connect a client pod to a server pod via Service ClusterIP Custom namespace": "Pod to pod connectivity via service ClusterIP, custom namespace",
     "sctp Test Connectivity Connectivity between client and server connect a client pod to a server pod via Service ClusterIP Default namespace": "Pod to pod connectivity via service ClusterIP, default namespace",
     "sctp Test Connectivity Connectivity between client and server connect a client pod to a server pod via Service Node Port Custom namespace": "Pod to pod connectivity via service nodeport, custom namespace",
-    "sctp Test Connectivity Connectivity between client and server connect a client pod to a server pod via Service Node Port Default namespace": "Pod to pod connectivity via service nodeport, default namespace"
+    "sctp Test Connectivity Connectivity between client and server connect a client pod to a server pod via Service Node Port Default namespace": "Pod to pod connectivity via service nodeport, default namespace",
+    "xt_u32 Negative - xt_u32 disabled Should NOT create an iptable rule": "Negative test: when the xt_u32 module is not enabled, appling an iptables rule that utilize the module should fail.",
+    "xt_u32 Validate the module is enabled and works Should create an iptables rule inside a pod that has the module enabled": "Verifies that an iptables rule that utilize xt_u32 module can be applied successfully in a pod that has the module enabled."
 }

--- a/cnf-tests/docgen/validation.json
+++ b/cnf-tests/docgen/validation.json
@@ -15,5 +15,7 @@
     "validation sriov should deploy the injector pod if requested": "Check the optional presence of the SR-IOV injector pod",
     "validation sriov should deploy the operator webhook if requested": "Check the optional presence of the SR-IOV webhook",
     "validation sriov should have the sriov namespace": "Checks the existence of the SR-IOV Operator's namespace.",
-    "validation sriov should have the sriov operator deployment in running state": "Check if the SR-IOV Operator is running."
+    "validation sriov should have the sriov operator deployment in running state": "Check if the SR-IOV Operator is running.",
+    "validation xt_u32 should have a xt_u32 enable machine config": "Check the presence of a machine config that enables xt_u32.",
+    "validation xt_u32 should have the xt_u32 enable machine config as part of the CNF machine config pool": "Check if the xt_u32 machine config is used by the declared machine config pool."
 }

--- a/feature-configs/deploy/xt_u32/is_ready.sh
+++ b/feature-configs/deploy/xt_u32/is_ready.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # no output means that the new machine config wasn't picked by MCO yet
-if [ -z "$(oc get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="load-xt_u32-module")].name}')" ]; then
+if [ -z "$(oc get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="load-xt-u32-module")].name}')" ]; then
     exit 1
 fi
 

--- a/functests/test_suite_test.go
+++ b/functests/test_suite_test.go
@@ -16,7 +16,8 @@ import (
 	_ "github.com/openshift-kni/cnf-features-deploy/functests/dpdk" // this is needed otherwise the dpdk test won't be executed
 	_ "github.com/openshift-kni/cnf-features-deploy/functests/ptp"  // this is needed otherwise the ptp test won't be executed
 	"github.com/openshift-kni/cnf-features-deploy/functests/sctp"
-	_ "github.com/openshift-kni/cnf-features-deploy/functests/sctp" // this is needed otherwise the sctp test won't be executed
+	_ "github.com/openshift-kni/cnf-features-deploy/functests/sctp"   // this is needed otherwise the sctp test won't be executed
+	_ "github.com/openshift-kni/cnf-features-deploy/functests/xt_u32" // this is needed otherwise the xt_u32 test won't be executed
 
 	_ "github.com/openshift-kni/performance-addon-operators/functests/1_performance" // this is needed otherwise the performance test won't be executed
 	_ "github.com/openshift-kni/performance-addon-operators/functests/4_latency" // this is needed otherwise the performance test won't be executed
@@ -124,6 +125,7 @@ var _ = AfterSuite(func() {
 		namespaces.DpdkTest,
 		sctp.TestNamespace,
 		sriovNamespaces.Test,
+		namespaces.XTU32Test,
 	}
 
 	for _, n := range nn {

--- a/functests/utils/namespaces/namespaces.go
+++ b/functests/utils/namespaces/namespaces.go
@@ -28,10 +28,18 @@ var SRIOVOperator = "openshift-sriov-network-operator"
 // PTPOperator is the namespace where the PTP Operator is installed
 var PTPOperator = "openshift-ptp"
 
+// XTU32Test is the namespace of xt_u32 test suite
+var XTU32Test string
+
 func init() {
 	DpdkTest = os.Getenv("DPDK_TEST_NAMESPACE")
 	if DpdkTest == "" {
 		DpdkTest = "dpdk-testing"
+	}
+
+	XTU32Test = os.Getenv("XT_U32_TEST_NAMESPACE")
+	if XTU32Test == "" {
+		XTU32Test = "xt-u32-testing"
 	}
 
 	if performanceOverride, ok := os.LookupEnv("PERFORMANCE_OPERATOR_NAMESPACE"); ok {

--- a/functests/utils/reporter.go
+++ b/functests/utils/reporter.go
@@ -37,6 +37,7 @@ func NewReporter(reportPath string) (*k8sreporter.KubernetesReporter, *os.File, 
 		namespaces.DpdkTest:            true,
 		sriovNamespaces.Test:           true,
 		ptpUtils.NamespaceTesting:      true,
+		namespaces.XTU32Test:           true,
 	}
 
 	crds := []k8sreporter.CRData{

--- a/functests/xt_u32/xt_u32.go
+++ b/functests/xt_u32/xt_u32.go
@@ -1,0 +1,210 @@
+package xt_u32
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/discovery"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/execute"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/images"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/namespaces"
+	utilNodes "github.com/openshift-kni/cnf-features-deploy/functests/utils/nodes"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/pods"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const hostnameLabel = "kubernetes.io/hostname"
+
+const xt_u32LoadPath = "/etc/modules-load.d/xt_u32-load.conf"
+
+var (
+	xt_u32NodeSelector string
+	hasNonCnfWorkers   bool
+)
+
+func init() {
+	roleWorkerCNF := os.Getenv("ROLE_WORKER_CNF")
+	if roleWorkerCNF != "" {
+		xt_u32NodeSelector = fmt.Sprintf("node-role.kubernetes.io/%s=", roleWorkerCNF)
+	}
+
+	hasNonCnfWorkers = true
+	if os.Getenv("XT_U32TEST_HAS_NON_CNF_WORKERS") == "false" {
+		hasNonCnfWorkers = false
+	}
+}
+
+var _ = Describe("xt_u32", func() {
+	execute.BeforeAll(func() {
+		err := namespaces.Create(namespaces.XTU32Test, client.Client)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = namespaces.Clean(namespaces.XTU32Test, "xt-u32", client.Client)
+		Expect(err).ToNot(HaveOccurred())
+
+		if xt_u32NodeSelector == "" {
+			xt_u32NodeSelector, err = findXT_U32NodeSelector()
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	Context("Validate the module is enabled and works", func() {
+		var testNode string
+		BeforeEach(func() {
+			namespaces.Clean(namespaces.XTU32Test, "xt-u32", client.Client)
+			By("Choosing the test node")
+			nodes, err := client.Client.Nodes().List(context.Background(), metav1.ListOptions{
+				LabelSelector: xt_u32NodeSelector,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			filtered, err := utilNodes.MatchingOptionalSelector(nodes.Items)
+			Expect(err).ToNot(HaveOccurred())
+
+			if discovery.Enabled() && len(filtered) == 0 {
+				Skip("Did not find a node without xt_u32 module enabled")
+			} else {
+				Expect(len(filtered)).To(BeNumerically(">", 0))
+			}
+			testNode = filtered[0].ObjectMeta.Labels[hostnameLabel]
+
+		})
+		It("Should create an iptables rule inside a pod that has the module enabled", func() {
+			By("Create a pod")
+			pod := xt_u32TestPod("xt-u32", testNode)
+			xt_u32Pod, err := client.Client.Pods(namespaces.XTU32Test).Create(context.Background(), pod, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Check if the pod is running")
+			Eventually(func() k8sv1.PodPhase {
+				res, err := client.Client.Pods(namespaces.XTU32Test).Get(context.Background(), xt_u32Pod.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return res.Status.Phase
+			}, 3*time.Minute, 1*time.Second).Should(Equal(k8sv1.PodRunning))
+
+			By("Check that xt_u32 module is loaded")
+			cmd := []string{"lsmod"}
+			out, err := pods.ExecCommand(client.Client, *xt_u32Pod, cmd)
+			Expect(err).ToNot(HaveOccurred(), out.String())
+			Expect(out.String()).Should(ContainSubstring("xt_u32"))
+
+			By("Create an iptables rule within the pod that drops icmp ping msgs from any source - ip protocol = 1 (ICMP) && not fragmented && icmp type = 8 (echo request)")
+			cmd = []string{"iptables", "-t", "filter", "-A", "INPUT", "-i", "eth0", "-m",
+				"u32", "--u32", "6 & 0xFF = 1 && 4 & 0x3FFF = 0 && 0 >> 22 & 0x3C @ 0 >> 24 = 8",
+				"-j", "DROP"}
+			out, err = pods.ExecCommand(client.Client, *xt_u32Pod, cmd)
+			Expect(err).ToNot(HaveOccurred(), out.String())
+		})
+	})
+})
+
+func findXT_U32NodeSelector() (string, error) {
+	mcList, err := client.Client.MachineConfigs().List(context.Background(), metav1.ListOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, mc := range mcList.Items {
+		enables, err := isXT_U32Enabled(mc)
+		if err != nil {
+			return "", err
+		}
+		if enables {
+			mcLabel, found := mc.ObjectMeta.Labels["machineconfiguration.openshift.io/role"]
+			if !found {
+				continue
+			}
+
+			xt_u32NodeSelector, err := findXT_U32NodeSelectorByMCLabel(mcLabel)
+			if err != nil {
+				continue
+			}
+
+			return xt_u32NodeSelector, nil
+		}
+	}
+
+	return "", errors.New("Cannot find a machine configuration that enables XT_U32")
+}
+
+func isXT_U32Enabled(mc mcfgv1.MachineConfig) (bool, error) {
+	loadPathFound := false
+
+	ignitionConfig := igntypes.Config{}
+	if mc.Spec.Config.Raw == nil {
+		return false, nil
+	}
+
+	err := json.Unmarshal(mc.Spec.Config.Raw, &ignitionConfig)
+	if err != nil {
+		return false, fmt.Errorf("Failed to unmarshal ignition config %v", err)
+	}
+
+	for _, file := range ignitionConfig.Storage.Files {
+		if !loadPathFound && file.Path == xt_u32LoadPath {
+			loadPathFound = true
+		}
+	}
+	return loadPathFound, nil
+}
+
+func findXT_U32NodeSelectorByMCLabel(mcLabel string) (string, error) {
+	mcpList, err := client.Client.MachineConfigPools().List(context.Background(), metav1.ListOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, mcp := range mcpList.Items {
+		for _, lsr := range mcp.Spec.MachineConfigSelector.MatchExpressions {
+			for _, value := range lsr.Values {
+				if value == mcLabel {
+					for key, label := range mcp.Spec.NodeSelector.MatchLabels {
+						newXT_U32NodeSelector := key + "=" + label
+						return newXT_U32NodeSelector, nil
+					}
+				}
+			}
+		}
+	}
+
+	return "", errors.New("Cannot find XT_U32NodeSelector")
+}
+
+func xt_u32TestPod(name, node string) *k8sv1.Pod {
+	res := k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"name": name,
+			},
+			Namespace: namespaces.XTU32Test,
+		},
+		Spec: k8sv1.PodSpec{
+			RestartPolicy: k8sv1.RestartPolicyNever,
+			Containers: []k8sv1.Container{
+				{
+					Name:    name,
+					Image:   images.For(images.TestUtils),
+					Command: []string{"/bin/sh", "-c"},
+					Args:    []string{"sleep inf"},
+					SecurityContext: &k8sv1.SecurityContext{
+						Capabilities: &k8sv1.Capabilities{
+							Add: []k8sv1.Capability{"NET_ADMIN"},
+						},
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				hostnameLabel: node,
+			},
+		},
+	}
+
+	return &res
+}


### PR DESCRIPTION
xt_u32 is an iptables filtering kernel module.

This test is crearing a pod that has the xt_u32 module enbaled in it,
then running an iptable rule inside it to test the module works.