### PR TITLE
Bug 1896798: Make it possible to override the namespace used by the operators, plus switch the pao default one.

### DIFF
--- a/feature-configs/deploy/performance/operator-namespace.yaml
+++ b/feature-configs/deploy/performance/operator-namespace.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
-  name: openshift-performance-addon
+  name: openshift-performance-addon-operator
 spec: {}

--- a/feature-configs/deploy/performance/operator_operatorgroup.yaml
+++ b/feature-configs/deploy/performance/operator_operatorgroup.yaml
@@ -2,7 +2,4 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: performance-addon-operator
-  namespace: openshift-performance-addon
-spec:
-  targetNamespaces:
-    - openshift-performance-addon
+  namespace: openshift-performance-addon-operator

--- a/feature-configs/deploy/performance/operator_subscription.yaml
+++ b/feature-configs/deploy/performance/operator_subscription.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: performance-addon-operator
-  namespace: openshift-performance-addon
+  namespace: openshift-performance-addon-operator
 spec:
   channel: "4.6"
   name: performance-addon-operator

--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -48,8 +48,6 @@ const (
 )
 
 const (
-	// PerformanceOperatorNamespace contains the name of the performance operator namespace
-	PerformanceOperatorNamespace = "openshift-performance-addon"
 	// PerformanceOperatorDeploymentName contains the name of the performance operator deployment
 	PerformanceOperatorDeploymentName = "performance-operator"
 	// PerformanceCRDName contains the name of the performance profile CRD
@@ -57,8 +55,6 @@ const (
 )
 
 const (
-	// SriovNamespace contains the name of the sriov namespace
-	SriovNamespace = "openshift-sriov-network-operator"
 	// SriovOperatorDeploymentName contains the name of the sriov operator deployment
 	SriovOperatorDeploymentName = "sriov-network-operator"
 

--- a/functests/utils/namespaces/namespaces.go
+++ b/functests/utils/namespaces/namespaces.go
@@ -19,10 +19,34 @@ import (
 // DpdkTest is the namespace of dpdk test suite
 var DpdkTest string
 
+// PerformanceOperator is the namespace where PAO is installed
+var PerformanceOperator = "openshift-performance-addon-operator"
+
+// SRIOVOperator is the namespace where the SR-IOV Operator is installed
+var SRIOVOperator = "openshift-sriov-network-operator"
+
+// PTPOperator is the namespace where the PTP Operator is installed
+var PTPOperator = "openshift-ptp"
+
 func init() {
 	DpdkTest = os.Getenv("DPDK_TEST_NAMESPACE")
 	if DpdkTest == "" {
 		DpdkTest = "dpdk-testing"
+	}
+
+	if performanceOverride, ok := os.LookupEnv("PERFORMANCE_OPERATOR_NAMESPACE"); ok {
+		PerformanceOperator = performanceOverride
+	}
+	// Legacy value: in the SRIOV operator tests this variable is already
+	// used to override the namespace.
+	if sriovOverride, ok := os.LookupEnv("OPERATOR_NAMESPACE"); ok {
+		SRIOVOperator = sriovOverride
+	}
+	if sriovOverride, ok := os.LookupEnv("SRIOV_OPERATOR_NAMESPACE"); ok {
+		SRIOVOperator = sriovOverride
+	}
+	if ptpOverride, ok := os.LookupEnv("PTP_OPERATOR_NAMESPACE"); ok {
+		PTPOperator = ptpOverride
 	}
 }
 

--- a/functests/utils/reporter.go
+++ b/functests/utils/reporter.go
@@ -29,14 +29,14 @@ func NewReporter(reportPath string) (*k8sreporter.KubernetesReporter, *os.File, 
 	}
 
 	namespacesToDump := map[string]bool{
-		"openshift-performance-addon":      true,
-		"openshift-ptp":                    true,
-		"openshift-sriov-network-operator": true,
-		NamespaceTesting:                   true,
-		perfUtils.NamespaceTesting:         true,
-		namespaces.DpdkTest:                true,
-		sriovNamespaces.Test:               true,
-		ptpUtils.NamespaceTesting:          true,
+		namespaces.PerformanceOperator: true,
+		namespaces.PTPOperator:         true,
+		namespaces.SRIOVOperator:       true,
+		NamespaceTesting:               true,
+		perfUtils.NamespaceTesting:     true,
+		namespaces.DpdkTest:            true,
+		sriovNamespaces.Test:           true,
+		ptpUtils.NamespaceTesting:      true,
 	}
 
 	crds := []k8sreporter.CRData{

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/openshift-kni/performance-addon-operators v0.0.0-20201103202814-7e6e9a02bff2
+	github.com/openshift-kni/performance-addon-operators v0.0.0-20201119102728-ee2ea406ee2b
 	github.com/openshift/api v3.9.1-0.20191213091414-3fbf6bcf78e8+incompatible
 	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
 	github.com/openshift/cluster-node-tuning-operator v0.0.0-00010101000000-000000000000
@@ -82,7 +82,7 @@ replace (
 
 // Test deps
 replace (
-	github.com/openshift-kni/performance-addon-operators => github.com/openshift-kni/performance-addon-operators v0.0.0-20201103202814-7e6e9a02bff2 // release-4.6
+	github.com/openshift-kni/performance-addon-operators => github.com/openshift-kni/performance-addon-operators v0.0.0-20201119102728-ee2ea406ee2b // release-4.6
 	github.com/openshift/ptp-operator => github.com/openshift/ptp-operator v0.0.0-20201112012540-14e7b1287320 // release-4.6
 	github.com/openshift/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20201119062143-1a52c5be637f // release-4.6
 )

--- a/go.sum
+++ b/go.sum
@@ -988,8 +988,8 @@ github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openshift-kni/performance-addon-operators v0.0.0-20201103202814-7e6e9a02bff2 h1:U2hzsbIMjYCVDj44lthng4DdjzEKNTm51bRk4wgrtTo=
-github.com/openshift-kni/performance-addon-operators v0.0.0-20201103202814-7e6e9a02bff2/go.mod h1:jr8Chbww9nGFfRBc5q+31w68O4lcUfWArUG3LRQij1E=
+github.com/openshift-kni/performance-addon-operators v0.0.0-20201119102728-ee2ea406ee2b h1:kYA7WP47tnGBU4PopeboWj86vDeFdqmu+0ArLUCvKmE=
+github.com/openshift-kni/performance-addon-operators v0.0.0-20201119102728-ee2ea406ee2b/go.mod h1:jr8Chbww9nGFfRBc5q+31w68O4lcUfWArUG3LRQij1E=
 github.com/openshift/api v0.0.0-20200526144822-34f54f12813a h1:riE/kCXnb051RWT/z+DytxKEZ3+JromVDl79rXAKyFY=
 github.com/openshift/api v0.0.0-20200526144822-34f54f12813a/go.mod h1:l6TGeqJ92DrZBuWMNKcot1iZUHfbYSJyBWHGgg6Dn6s=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=

--- a/validationsuite/cluster/validation.go
+++ b/validationsuite/cluster/validation.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openshift-kni/cnf-features-deploy/functests/utils"
 	testclient "github.com/openshift-kni/cnf-features-deploy/functests/utils/client"
+	"github.com/openshift-kni/cnf-features-deploy/functests/utils/namespaces"
 )
 
 var (
@@ -77,16 +78,16 @@ var _ = Describe("validation", func() {
 
 	Context("performance", func() {
 		It("should have the performance operator namespace", func() {
-			_, err := testclient.Client.Namespaces().Get(context.Background(), utils.PerformanceOperatorNamespace, metav1.GetOptions{})
+			_, err := testclient.Client.Namespaces().Get(context.Background(), namespaces.PerformanceOperator, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should have the performance operator deployment in running state", func() {
-			deploy, err := testclient.Client.Deployments(utils.PerformanceOperatorNamespace).Get(context.Background(), utils.PerformanceOperatorDeploymentName, metav1.GetOptions{})
+			deploy, err := testclient.Client.Deployments(namespaces.PerformanceOperator).Get(context.Background(), utils.PerformanceOperatorDeploymentName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(deploy.Status.Replicas).To(Equal(deploy.Status.ReadyReplicas))
 
-			pods, err := testclient.Client.Pods(utils.PerformanceOperatorNamespace).List(context.Background(), metav1.ListOptions{
+			pods, err := testclient.Client.Pods(namespaces.PerformanceOperator).List(context.Background(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("name=%s", utils.PerformanceOperatorDeploymentName)})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -103,16 +104,16 @@ var _ = Describe("validation", func() {
 
 	Context("sriov", func() {
 		It("should have the sriov namespace", func() {
-			_, err := testclient.Client.Namespaces().Get(context.Background(), utils.SriovNamespace, metav1.GetOptions{})
+			_, err := testclient.Client.Namespaces().Get(context.Background(), namespaces.SRIOVOperator, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should have the sriov operator deployment in running state", func() {
-			deploy, err := testclient.Client.Deployments(utils.SriovNamespace).Get(context.Background(), utils.SriovOperatorDeploymentName, metav1.GetOptions{})
+			deploy, err := testclient.Client.Deployments(namespaces.SRIOVOperator).Get(context.Background(), utils.SriovOperatorDeploymentName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(deploy.Status.Replicas).To(Equal(deploy.Status.ReadyReplicas))
 
-			pods, err := testclient.Client.Pods(utils.SriovNamespace).List(context.Background(), metav1.ListOptions{
+			pods, err := testclient.Client.Pods(namespaces.SRIOVOperator).List(context.Background(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("name=%s", utils.SriovOperatorDeploymentName)})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -137,15 +138,15 @@ var _ = Describe("validation", func() {
 
 		It("should deploy the injector pod if requested", func() {
 			operatorConfig := &sriovv1.SriovOperatorConfig{}
-			err := testclient.Client.Get(context.TODO(), goclient.ObjectKey{Name: "default", Namespace: utils.SriovNamespace}, operatorConfig)
+			err := testclient.Client.Get(context.TODO(), goclient.ObjectKey{Name: "default", Namespace: namespaces.SRIOVOperator}, operatorConfig)
 			Expect(err).ToNot(HaveOccurred())
 
 			if *operatorConfig.Spec.EnableInjector {
-				daemonset, err := testclient.Client.DaemonSets(utils.SriovNamespace).Get(context.Background(), "network-resources-injector", metav1.GetOptions{})
+				daemonset, err := testclient.Client.DaemonSets(namespaces.SRIOVOperator).Get(context.Background(), "network-resources-injector", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(daemonset.Status.DesiredNumberScheduled).To(Equal(daemonset.Status.NumberReady))
 			} else {
-				_, err := testclient.Client.DaemonSets(utils.SriovNamespace).Get(context.Background(), "network-resources-injector", metav1.GetOptions{})
+				_, err := testclient.Client.DaemonSets(namespaces.SRIOVOperator).Get(context.Background(), "network-resources-injector", metav1.GetOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			}
@@ -153,15 +154,15 @@ var _ = Describe("validation", func() {
 
 		It("should deploy the operator webhook if requested", func() {
 			operatorConfig := &sriovv1.SriovOperatorConfig{}
-			err := testclient.Client.Get(context.TODO(), goclient.ObjectKey{Name: "default", Namespace: utils.SriovNamespace}, operatorConfig)
+			err := testclient.Client.Get(context.TODO(), goclient.ObjectKey{Name: "default", Namespace: namespaces.SRIOVOperator}, operatorConfig)
 			Expect(err).ToNot(HaveOccurred())
 
 			if *operatorConfig.Spec.EnableOperatorWebhook {
-				daemonset, err := testclient.Client.DaemonSets(utils.SriovNamespace).Get(context.Background(), "operator-webhook", metav1.GetOptions{})
+				daemonset, err := testclient.Client.DaemonSets(namespaces.SRIOVOperator).Get(context.Background(), "operator-webhook", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(daemonset.Status.DesiredNumberScheduled).To(Equal(daemonset.Status.NumberReady))
 			} else {
-				_, err := testclient.Client.DaemonSets(utils.SriovNamespace).Get(context.Background(), "operator-webhook", metav1.GetOptions{})
+				_, err := testclient.Client.DaemonSets(namespaces.SRIOVOperator).Get(context.Background(), "operator-webhook", metav1.GetOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			}

--- a/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/consts.go
+++ b/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/consts.go
@@ -79,8 +79,6 @@ const (
 )
 
 const (
-	// PerformanceOperatorNamespace contains the name of the performance operator namespace
-	PerformanceOperatorNamespace = "openshift-performance-addon"
 	// NamespaceMachineConfigOperator contains the namespace of the machine-config-opereator
 	NamespaceMachineConfigOperator = "openshift-machine-config-operator"
 	// NamespaceTesting contains the name of the testing namespace

--- a/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces/namespaces.go
+++ b/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces/namespaces.go
@@ -1,0 +1,49 @@
+package namespaces
+
+import (
+	"context"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+)
+
+// PerformanceOperator contains the name of the performance operator namespace
+// default as recommended in
+// https://docs.openshift.com/container-platform/4.6/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#install-operator-cli_cnf-master
+var PerformanceOperator string = "openshift-performance-addon-operator"
+
+func init() {
+	if operatorNS, ok := os.LookupEnv("PERFORMANCE_OPERATOR_NAMESPACE"); ok {
+		PerformanceOperator = operatorNS
+	}
+}
+
+// TestingNamespace is the namespace the tests will use for running test pods
+var TestingNamespace = &corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: testutils.NamespaceTesting,
+	},
+}
+
+// WaitForDeletion waits until the namespace will be removed from the cluster
+func WaitForDeletion(name string, timeout time.Duration) error {
+	key := types.NamespacedName{
+		Name:      name,
+		Namespace: metav1.NamespaceNone,
+	}
+	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		ns := &corev1.Namespace{}
+		if err := testclient.Client.Get(context.TODO(), key, ns); errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, nil
+	})
+}

--- a/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/pods/pods.go
+++ b/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/pods/pods.go
@@ -20,6 +20,7 @@ import (
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
 )
 
 // GetTestPod returns pod with the busybox image
@@ -155,7 +156,7 @@ func GetPerformanceOperatorPod() (*corev1.Pod, error) {
 
 	pods := &corev1.PodList{}
 
-	opts := &client.ListOptions{LabelSelector: selector, Namespace: testutils.PerformanceOperatorNamespace}
+	opts := &client.ListOptions{LabelSelector: selector, Namespace: namespaces.PerformanceOperator}
 	if err := testclient.Client.List(context.TODO(), pods, opts); err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -134,7 +134,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift-kni/performance-addon-operators v0.0.0-20201103202814-7e6e9a02bff2 => github.com/openshift-kni/performance-addon-operators v0.0.0-20201103202814-7e6e9a02bff2
+# github.com/openshift-kni/performance-addon-operators v0.0.0-20201119102728-ee2ea406ee2b => github.com/openshift-kni/performance-addon-operators v0.0.0-20201119102728-ee2ea406ee2b
 github.com/openshift-kni/performance-addon-operators/functests/0_config
 github.com/openshift-kni/performance-addon-operators/functests/1_performance
 github.com/openshift-kni/performance-addon-operators/functests/utils
@@ -143,6 +143,7 @@ github.com/openshift-kni/performance-addon-operators/functests/utils/client
 github.com/openshift-kni/performance-addon-operators/functests/utils/discovery
 github.com/openshift-kni/performance-addon-operators/functests/utils/images
 github.com/openshift-kni/performance-addon-operators/functests/utils/mcps
+github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces
 github.com/openshift-kni/performance-addon-operators/functests/utils/nodes
 github.com/openshift-kni/performance-addon-operators/functests/utils/pods
 github.com/openshift-kni/performance-addon-operators/functests/utils/profiles


### PR DESCRIPTION
When installing an operator, the user can choose the namespace where to install it. The common behaviour is to use the one described in the docs, which is different for the one being used here.
On top of that, we are making the namespaces related to the other two operators (ptp, sriov) configurable for what is related to the tests implemented here.
The deploy part is updated to create and use the new default namespace for PAO.
We update the pao test to contain the fix.