### PR TITLE
Fix Mellanox DPDK issue

### DIFF
--- a/feature-configs/demo/dpdk/deployment-config.yaml
+++ b/feature-configs/demo/dpdk/deployment-config.yaml
@@ -36,7 +36,7 @@ spec:
           securityContext:
             runAsUser: 0
             capabilities:
-              add: ["IPC_LOCK","SYS_RESOURCE"]
+              add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"]
           imagePullPolicy: Always
           env:
             - name: RUN_TYPE

--- a/functests/dpdk/dpdk.go
+++ b/functests/dpdk/dpdk.go
@@ -667,7 +667,10 @@ sleep INF
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser: pointer.Int64Ptr(0),
 			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"IPC_LOCK", "SYS_RESOURCE"},
+				// Enable NET_RAW is required by mellanox nics as they are using the netdevice driver
+				// NET_RAW was removed from the default capabilities
+				// https://access.redhat.com/security/cve/cve-2020-14386
+				Add: []corev1.Capability{"IPC_LOCK", "SYS_RESOURCE","NET_RAW"},
 			},
 		},
 		Env: []corev1.EnvVar{


### PR DESCRIPTION
This commit add the NET_RAW capability that was removed
from the default list of capabilities as part of
https://access.redhat.com/security/cve/cve-2020-14386

Signed-off-by: Sebastian Sch <sebassch@gmail.com>