### PR TITLE
Fix bug in xt_u32 is ready script

### DIFF
--- a/feature-configs/deploy/xt_u32/is_ready.sh
+++ b/feature-configs/deploy/xt_u32/is_ready.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # no output means that the new machine config wasn't picked by MCO yet
-if [ -z "$(oc get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="load-xt_u32-module")].name}')" ]; then
+if [ -z "$(oc get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="load-xt-u32-module")].name}')" ]; then
     exit 1
 fi
 


### PR DESCRIPTION
The MachineConfig name was updated to load-xt-u32-module as it can't include '_' character