### PR TITLE
RHACM manifests to use deploy folder to install CNF components in managed clusters

### DIFF
--- a/feature-configs/rhacm-manifests/operator-install/dpdk/channel-cnf-features-deploy.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/dpdk/channel-cnf-features-deploy.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: cnf-features-deploy 
+  namespace: dpdk
+spec:
+  type: Git
+  pathname: https://github.com/openshift-kni/cnf-features-deploy

--- a/feature-configs/rhacm-manifests/operator-install/dpdk/dpdk-build-install.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/dpdk/dpdk-build-install.yaml
@@ -1,0 +1,34 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: dpdk-build-install
+  namespace: dpdk
+spec:
+  componentKinds:
+  - group: apps.open-cluster-management.io
+    kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - dpdk-build-install
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: dpdk-subscription-4.6
+  namespace: dpdk
+  labels:
+    app: dpdk-build-install
+  annotations:
+    apps.open-cluster-management.io/git-path: feature-configs/deploy/dpdk
+    apps.open-cluster-management.io/git-branch: release-4.6
+spec:
+  name: dpdk-subscription-4.6
+  channel: dpdk/cnf-features-deploy
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: placement-cluster-cnf21

--- a/feature-configs/rhacm-manifests/operator-install/dpdk/kustomization.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/dpdk/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dpdk-build-install.yaml 
+  - channel-cnf-features-deploy.yaml
+  - placement-cluster-cnf21.yaml

--- a/feature-configs/rhacm-manifests/operator-install/dpdk/placement-cluster-cnf21.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/dpdk/placement-cluster-cnf21.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-cluster-cnf21
+  namespace: dpdk
+spec:
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+        - cnf21
+      - key: ocpversion
+        operator: In
+        values:
+        - 4.6.6

--- a/feature-configs/rhacm-manifests/operator-install/performance-operator/app-subs-stage.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/performance-operator/app-subs-stage.yaml
@@ -1,0 +1,34 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: pao-operator-install
+  namespace: openshift-performance-addon-operator
+spec:
+  componentKinds:
+  - group: apps.open-cluster-management.io
+    kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - pao-operator-install
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: pao-subscription-4.6
+  namespace: openshift-performance-addon-operator
+  labels:
+    app: pao-operator-install
+  annotations:
+    apps.open-cluster-management.io/git-path: feature-configs/deploy/performance
+    apps.open-cluster-management.io/git-branch: release-4.6
+spec:
+  name: pao-subscription-stage
+  channel: openshift-performance-addon-operator/cnf-features-deploy
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: placement-cluster-cnf21

--- a/feature-configs/rhacm-manifests/operator-install/performance-operator/channel-cnf-features-deploy.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/performance-operator/channel-cnf-features-deploy.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: cnf-features-deploy 
+  namespace: openshift-performance-addon-operator
+spec:
+  type: Git
+  pathname: https://github.com/openshift-kni/cnf-features-deploy

--- a/feature-configs/rhacm-manifests/operator-install/performance-operator/kustomization.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/performance-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app-subs-stage.yaml  
+  - channel-cnf-features-deploy.yaml
+  - placement-cluster-cnf21.yaml

--- a/feature-configs/rhacm-manifests/operator-install/performance-operator/placement-cluster-cnf21.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/performance-operator/placement-cluster-cnf21.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-cluster-cnf21
+  namespace: openshift-performance-addon-operator
+spec:
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+        - cnf21
+      - key: ocpversion
+        operator: In
+        values:
+        - 4.6.6

--- a/feature-configs/rhacm-manifests/operator-install/ptp/channel-cnf-features-deploy.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/ptp/channel-cnf-features-deploy.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: cnf-features-deploy 
+  namespace: openshift-ptp
+spec:
+  type: Git
+  pathname: https://github.com/openshift-kni/cnf-features-deploy

--- a/feature-configs/rhacm-manifests/operator-install/ptp/kustomization.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/ptp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ptp-operator-install.yaml 
+  - channel-cnf-features-deploy.yaml
+  - placement-cluster-cnf21.yaml

--- a/feature-configs/rhacm-manifests/operator-install/ptp/placement-cluster-cnf21.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/ptp/placement-cluster-cnf21.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-cluster-cnf21
+  namespace: openshift-ptp
+spec:
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+        - cnf21
+      - key: ocpversion
+        operator: In
+        values:
+        - 4.6.6

--- a/feature-configs/rhacm-manifests/operator-install/ptp/ptp-operator-install.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/ptp/ptp-operator-install.yaml
@@ -1,0 +1,34 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: ptp-operator-install
+  namespace: openshift-ptp
+spec:
+  componentKinds:
+  - group: apps.open-cluster-management.io
+    kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - ptp-operator-install
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: ptp-subscription-4.6
+  namespace: openshift-ptp
+  labels:
+    app: ptp-operator-install
+  annotations:
+    apps.open-cluster-management.io/git-path: feature-configs/deploy/ptp
+    apps.open-cluster-management.io/git-branch: release-4.6
+spec:
+  name: ptp-subscription-4.6
+  channel: openshift-ptp/cnf-features-deploy
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: placement-cluster-cnf21

--- a/feature-configs/rhacm-manifests/operator-install/sctp/channel-cnf-features-deploy.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/sctp/channel-cnf-features-deploy.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: cnf-features-deploy 
+  namespace: sctp-module
+spec:
+  type: Git
+  pathname: https://github.com/openshift-kni/cnf-features-deploy

--- a/feature-configs/rhacm-manifests/operator-install/sctp/kustomization.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/sctp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - sctp-module-install.yaml 
+  - channel-cnf-features-deploy.yaml
+  - placement-cluster-cnf21.yaml

--- a/feature-configs/rhacm-manifests/operator-install/sctp/placement-cluster-cnf21.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/sctp/placement-cluster-cnf21.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-cluster-cnf21
+  namespace: sctp-module
+spec:
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+        - cnf21
+      - key: ocpversion
+        operator: In
+        values:
+        - 4.6.6

--- a/feature-configs/rhacm-manifests/operator-install/sctp/sctp-module-install.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/sctp/sctp-module-install.yaml
@@ -1,0 +1,34 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: sctp-module-install
+  namespace: sctp-module
+spec:
+  componentKinds:
+  - group: apps.open-cluster-management.io
+    kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - sctp-module-install
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: sctp-subscription-4.6
+  namespace: sctp-module
+  labels:
+    app: sctp-module-install
+  annotations:
+    apps.open-cluster-management.io/git-path: feature-configs/deploy/sctp
+    apps.open-cluster-management.io/git-branch: release-4.6 
+spec:
+  name: sctp-subscription-4.6
+  channel: sctp-module/cnf-features-deploy
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: placement-cluster-cnf21

--- a/feature-configs/rhacm-manifests/operator-install/sriov-operator/channel-cnf-features-deploy.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/sriov-operator/channel-cnf-features-deploy.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: cnf-features-deploy 
+  namespace: openshift-sriov-network-operator
+spec:
+  type: Git
+  pathname: https://github.com/openshift-kni/cnf-features-deploy

--- a/feature-configs/rhacm-manifests/operator-install/sriov-operator/kustomization.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/sriov-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - sriov-operator-install.yaml 
+  - channel-cnf-features-deploy.yaml
+  - placement-cluster-cnf21.yaml

--- a/feature-configs/rhacm-manifests/operator-install/sriov-operator/placement-cluster-cnf21.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/sriov-operator/placement-cluster-cnf21.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-cluster-cnf21
+  namespace: openshift-sriov-network-operator
+spec:
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+        - cnf21
+      - key: ocpversion
+        operator: In
+        values:
+        - 4.6.6

--- a/feature-configs/rhacm-manifests/operator-install/sriov-operator/sriov-operator-install.yaml
+++ b/feature-configs/rhacm-manifests/operator-install/sriov-operator/sriov-operator-install.yaml
@@ -1,0 +1,34 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: sriov-operator-install
+  namespace: openshift-sriov-network-operator
+spec:
+  componentKinds:
+  - group: apps.open-cluster-management.io
+    kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - sriov-operator-install
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: sriov-subscription-4.6
+  namespace: openshift-sriov-network-operator
+  labels:
+    app: sriov-operator-install
+  annotations:
+    apps.open-cluster-management.io/git-path: feature-configs/deploy/sriov
+    apps.open-cluster-management.io/git-branch: release-4.6
+spec:
+  name: sriov-subscription-4.6
+  channel: openshift-sriov-network-operator/cnf-features-deploy
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: placement-cluster-cnf21


### PR DESCRIPTION
These are the manifests required by ACM to install CNF components stored in [deploy folder|https://github.com/openshift-kni/cnf-features-deploy/tree/release-4.6/feature-configs/deploy/]

Applying these manifests into an ACM hub cluster will install all CNF components (dpdk, sctp, ptp, sriov and pao) in any targeted cluster (spoke) applying the "kustomization" file stored in the operator's deploy folder.

The point here is to have something similar to a single point of truth for installing CNF components. Based on the definitions folder already created and maintained, you choose whether you want to deploy using kubectl/oc (customize) or RHACM, but the base is the same.

Note that, since I just tested on clusters (hub and spoke) running on OCP 4.6 and installing CNF components 4.6, the merge request targets release-4.6 branch. If required, I can take a look at 4.7 version of OCP & CNF components and then merged it into the current master/main.

The proposed folder is feature-configs/ but I am not sure if makes more sense in the cn-ran overlay effort (cc/ @yuvalk @vitus133)

Signed-off-by: Alberto Losada <alosadag@redhat.com>