### PR TITLE
Disable chronyd when using ptp

### DIFF
--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/disable-chronyd.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/disable-chronyd.yaml
@@ -1,0 +1,35 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    # Pay attention to the node label, create MCP accordingly
+    machineconfiguration.openshift.io/role: worker-cnf
+  name: disable-chronyd
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=NTP client/server
+            Documentation=man:chronyd(8) man:chrony.conf(5)
+            After=ntpdate.service sntp.service ntpd.service
+            Conflicts=ntpd.service systemd-timesyncd.service
+            ConditionCapability=CAP_SYS_TIME
+
+            [Service]
+            Type=forking
+            PIDFile=/run/chrony/chronyd.pid
+            EnvironmentFile=-/etc/sysconfig/chronyd
+            ExecStart=/usr/sbin/chronyd $OPTIONS
+            ExecStartPost=/usr/libexec/chrony-helper update-daemon
+            PrivateTmp=yes
+            ProtectHome=yes
+            ProtectSystem=full
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: false
+          name: "chronyd.service"

--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/kustomization.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ptpconfig-slave.yaml
   - ptpconfig-grandmaster.yaml
+  - disable-chronyd.yaml

--- a/feature-configs/demo/ptp/disable-chronyd.yaml
+++ b/feature-configs/demo/ptp/disable-chronyd.yaml
@@ -1,0 +1,34 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+  name: disable-chronyd
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=NTP client/server
+            Documentation=man:chronyd(8) man:chrony.conf(5)
+            After=ntpdate.service sntp.service ntpd.service
+            Conflicts=ntpd.service systemd-timesyncd.service
+            ConditionCapability=CAP_SYS_TIME
+
+            [Service]
+            Type=forking
+            PIDFile=/run/chrony/chronyd.pid
+            EnvironmentFile=-/etc/sysconfig/chronyd
+            ExecStart=/usr/sbin/chronyd $OPTIONS
+            ExecStartPost=/usr/libexec/chrony-helper update-daemon
+            PrivateTmp=yes
+            ProtectHome=yes
+            ProtectSystem=full
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: false
+          name: "chronyd.service"

--- a/feature-configs/demo/ptp/kustomization.yaml
+++ b/feature-configs/demo/ptp/kustomization.yaml
@@ -6,5 +6,6 @@ bases:
 resources:
   - ptpconfig-grandmaster.yaml
   - ptpconfig-slave.yaml
+  - disable-chronyd.yaml
 patchesStrategicMerge:
   - subscription.yaml


### PR DESCRIPTION
This commit add a machine config to disable chronyd under the ptp kustomize

Signed-off-by: Sebastian Sch <sebassch@gmail.com>