### PR TITLE
Fix docgen shuffling order of markdown everytime

### DIFF
--- a/cnf-tests/docgen/cmd/generate.go
+++ b/cnf-tests/docgen/cmd/generate.go
@@ -124,10 +124,11 @@ func descriptionsToList(descriptions map[string]string, matcher func(string) boo
 		if !matcher(n) {
 			continue
 		}
-		i := sort.Search(len(res), func(i int) bool { return res[i].Name >= n })
+		sanitizedName := sanitizeName(n)
+		i := sort.Search(len(res), func(i int) bool { return res[i].Name >= sanitizedName })
 		res = append(res, TestDescription{})
 		copy(res[i+1:], res[i:])
-		res[i] = TestDescription{sanitizeName(n), d}
+		res[i] = TestDescription{sanitizedName, d}
 	}
 	return res
 }


### PR DESCRIPTION
problem was caused because the sort happened before cleaning the string

https://github.com/openshift-kni/cnf-features-deploy/issues/373