### PR TITLE
revert ptp namespace to default run-level

### DIFF
--- a/feature-configs/deploy/ptp/01_namespace.yaml
+++ b/feature-configs/deploy/ptp/01_namespace.yaml
@@ -4,5 +4,4 @@ kind: Namespace
 metadata:
   name: openshift-ptp
   labels:
-    openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
run-level 1 is dangerous from security perspective
and seemingly ptp no longer require it
https://docs.openshift.com/container-platform/4.6/networking/multiple_networks/configuring-ptp.html#install-ptp-operator-cli_configuring-ptp