### PR TITLE
deploy: always use the documented name

### DIFF
--- a/feature-configs/deploy/performance/operator_operatorgroup.yaml
+++ b/feature-configs/deploy/performance/operator_operatorgroup.yaml
@@ -1,5 +1,5 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: performance-addon-operator
+  name: openshift-performance-addon-operator
   namespace: openshift-performance-addon-operator


### PR DESCRIPTION
per https://docs.openshift.com/container-platform/4.6/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#installing-the-performance-addon-operator_cnf-master

the name we should use is 'openshift-performance-addon-operator'

Signed-off-by: Francesco Romani <fromani@redhat.com>