### PR TITLE
Add linuxptp package to have pmc command inside cnf-test container

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -59,7 +59,7 @@ RUN yum install -y numactl-devel make gcc && \
 
 FROM centos:7
 
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs
+RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs linuxptp
 
 RUN mkdir -p /usr/local/etc/cnf
 

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -73,7 +73,7 @@ RUN yum install -y numactl-devel make gcc && \
 
 FROM openshift/origin-base
 
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod
+RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp
 
 RUN mkdir -p /usr/local/etc/cnf
 


### PR DESCRIPTION
This commit add the pmc binary into the container so we can use it later for ptp testing

Signed-off-by: Sebastian Sch <sebassch@gmail.com>