### PR TITLE
Use Ethernet as the trasport layer for ptp tests

### DIFF
--- a/feature-configs/demo/ptp/ptpconfig-grandmaster.yaml
+++ b/feature-configs/demo/ptp/ptpconfig-grandmaster.yaml
@@ -7,7 +7,7 @@ spec:
   profile:
   - name: "grandmaster"
     interface: "eno1"
-    ptp4lOpts: ""
+    ptp4lOpts: "-2"
     phc2sysOpts: "-a -r -r"
   recommend:
   - profile: "grandmaster"

--- a/feature-configs/demo/ptp/ptpconfig-slave.yaml
+++ b/feature-configs/demo/ptp/ptpconfig-slave.yaml
@@ -7,7 +7,7 @@ spec:
   profile:
   - name: "slave"
     interface: "eno1"
-    ptp4lOpts: "-s"
+    ptp4lOpts: "-s -2"
     phc2sysOpts: "-a -r"
   recommend:
   - profile: "slave"

--- a/functests/ptp/ptp.go
+++ b/functests/ptp/ptp.go
@@ -54,7 +54,7 @@ var _ = Describe("ptp", func() {
 			By("Creating the policy for the grandmaster node")
 			err = createConfig(ptpGrandMasterPolicyName,
 				ptpGrandMasterNode.InterfaceList[0],
-				"",
+				"-2",
 				"-a -r -r",
 				ptpGrandmasterNodeLabel,
 				pointer.Int64Ptr(5))
@@ -63,7 +63,7 @@ var _ = Describe("ptp", func() {
 			By("Creating the policy for the slave node")
 			err = createConfig(ptpSlavePolicyName,
 				ptpSlaveNode.InterfaceList[0],
-				"-s",
+				"-s -2",
 				"-a -r",
 				ptpSlaveNodeLabel,
 				pointer.Int64Ptr(5))


### PR DESCRIPTION
This commit changes the transport for ptp tests and demo yamls
to L2 ethernet.

This is the telco prefer transport so we should use it and it will
allow the test also to run on interfaces that don't have an ip address
allocated.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>