### PR TITLE
Remove node-selector network-sriov.capable: "true" for ran profile

### DIFF
--- a/feature-configs/cn-ran-overlays/ran-profile/site.1.fqdn/networks/sriov-network-node-policy-dpdk-mh.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/site.1.fqdn/networks/sriov-network-node-policy-dpdk-mh.yaml
@@ -15,7 +15,6 @@ spec:
     pfNames: ["ens1f1"]
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
-    feature.node.kubernetes.io/network-sriov.capable: "true"
   numVfs: 4
   priority: 10
   resourceName: mh_u_site_1_fqdn_worker1


### PR DESCRIPTION
The node-selector node-role.kubernetes.io/worker-cnf is currently also used,
meaning that nodes need both labels, which is inconsistent with documentation,
which only specifies node-role.kubernetes.io/worker-cnf.