### PR TITLE
VRF Test: reduce the permissions needed to use a VRF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #TODO add default features here
-export FEATURES?=sctp performance xt_u32
+export FEATURES?=sctp performance xt_u32 vrf
 export SKIP_TESTS?=
 IMAGE_BUILD_CMD ?= "docker"
 


### PR DESCRIPTION
We are running the tests with priviledged pod, here we do what a user
would do, assigning the least permissions which are NET_RAW
