### PR TITLE
Configure RAN owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,6 +14,15 @@ aliases:
     - vladikr
     - mmirecki
     - yuvalk
+    - ijolliffe
+    - yrobla
+    - serngawy
+    - imiller0
+    - lack
+    - aneeshkp
+    - josephdrichard
+    - vitus133
+    - kenyis
   cnf-features-approvers:
     - davidvossel
     - fedepaol
@@ -22,3 +31,7 @@ aliases:
     - cynepco3hahue
     - fromanirh
     - yuvalk
+  RAN-approvers:
+    - ijolliffe
+    - lack
+    - vitus133

--- a/feature-configs/5g-ref-nw/OWNERS
+++ b/feature-configs/5g-ref-nw/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - RAN-approvers

--- a/feature-configs/cn-ran-overlays/OWNERS
+++ b/feature-configs/cn-ran-overlays/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - RAN-approvers


### PR DESCRIPTION
This adds the RAN team members to the default 'reviewers' group, and also defines a new 'RAN-approver' alias, which will have approver access to both feature-configs/cn-ran-overlays and the forthcoming feature-configs/5g-ref-nw DU profile areas.
