### PR TITLE
Change the sriov-fec catalogSource to the custom one

### DIFF
--- a/feature-configs/deploy/sriov-fec/subscription.yaml
+++ b/feature-configs/deploy/sriov-fec/subscription.yaml
@@ -6,5 +6,7 @@ metadata:
 spec:
   channel: stable
   name: sriov-fec
-  source: certified-operators
+  # TODO: replace this after intel publish the operator for 4.7 and 4.8
+  #  source: certified-operators
+  source: custom-catalog
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This commit continue the work on https://github.com/openshift-kni/cnf-features-deploy/pull/471

We need to allow the sriov-fec to also use the same custom-catalog

Signed-off-by: Sebastian Sch <sebassch@gmail.com>