### PR TITLE
Add approvers to the forthcoming ZTP profile area

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -35,3 +35,9 @@ aliases:
     - ijolliffe
     - lack
     - vitus133
+  ZTP-approvers:
+    - ijolliffe
+    - yrobla
+    - serngawy
+    - imiller0
+    - vitus133

--- a/ztp/OWNERS
+++ b/ztp/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - ZTP-approvers


### PR DESCRIPTION
This defines a ZTP approver alias as well as granting approver access to
feature-configs/ZTP for that alias.