### PR TITLE
Add custom RPMs utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ feature-wait:
 	@echo "Waiting for features"
 	SKIP_TESTS="$(SKIP_TESTS)" FEATURES="$(FEATURES)" hack/feature-wait.sh
 
+custom-rpms:
+	@echo "Installing rpms"
+	RPMS_SRC="$(RPMS_SRC)" hack/custom_rpms.sh
+
 test-bin:
 	@echo "Making test binary"
 	cnf-tests/hack/build-test-bin.sh

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ The full test suite can be found at [https://github.com/openshift/openshift-test
 
 - optionally run `ORIGIN_TESTS_REPOSITORY=test.repository.com:5000/origin-tests make origin-tests-disconnected-environment` to mirror all the required test images to a container image repository and source required test images from your repository when running origin-tests in a disconnected environment.
 
+### Custom RPMs
+The custom RPMs utility allows to install RPMs from an external source on an OCP node.
+RPMS_SRC (RPMs download source URL) must be provided.
+REMOVE_PACKAGES should be set when installing RT kernel RPMs to override the installed kernel packages.
+RPMS_NODE_ROLE is optional and defaults to `node-role.kubernetes.io/worker`.
+
+- run `RPMS_SRC="http://test.download.com/example1.rpm http://test.download.com/example2.rpm" make custom-rpms`.  
+  This will install all the RPMs listed in RPMS_SRC on the selected nodes.
+
+- optionally run `RPMS_SRC="http://test.download.com/rt-kernel-package1.rpm http://test.download.com/rt-kernel-package1.rpm http://test.download.com/rt-kernel-package3.rpm" REMOVE_PACKAGES="kernel kernel-core kernel-modules kernel-modules-extra" make custom-rpms` to install RT kernel RPMs listed in RPMS_SRC on the selected nodes and override the installed kernel packages listed in REMOVE_PACKAGES.
+
 ### Dockerized version
 
 A dockerized version of CNF tests is available at [quay.io/openshift-kni/cnf-tests](https://quay.io/openshift-kni/cnf-tests).

--- a/hack/custom_rpms.sh
+++ b/hack/custom_rpms.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -e
+
+. $(dirname "$0")/common.sh
+
+RPMS_SRC="${RPMS_SRC:-}"
+REMOVE_PACKAGES="${REMOVE_PACKAGES:-}"
+RPMS_NODE_ROLE="${RPMS_NODE_ROLE:-node-role.kubernetes.io/worker}"
+
+if [ "$RPMS_SRC" == "" ]; then
+	echo "[ERROR]: No RPMS_SRC provided"
+	exit 1
+fi
+
+cat <<EOF | oc apply -f -
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rpms-entrypoint
+data:
+  entrypoint.sh: |
+    #!/bin/sh
+
+    set -euo pipefail
+        
+    LOG_FILE="/opt/log/installed_rpms.txt"
+    LOG_DIR=\$(dirname \${LOG_FILE})
+    TEMP_DIR=\$(mktemp -d)
+
+    function finish {
+      rm -Rf \${TEMP_DIR}
+    }
+    trap finish EXIT
+
+    if [ -f "\${LOG_FILE}" ]; then
+      if grep -Fxq "\${RPMS_CM_ID}" \${LOG_FILE}; then
+        echo "rpms are already installed!"
+        exit 0
+      fi
+    fi
+
+    rpm-ostree reset
+
+    # Fetch required packages
+    install_rpms=""
+    for rpm in ${RPMS_SRC}; do
+      rpm_name=\$(echo \${rpm} | rev | cut -d '/' -f 1 | rev)
+      install_rpms="\${install_rpms} \${rpm_name}"
+      curl -s \${rpm} -o \${TEMP_DIR}/\${rpm_name}
+    done
+    
+    if [ "${REMOVE_PACKAGES}" != "" ]; then
+      rpm_install_cmd="rpm-ostree override remove ${REMOVE_PACKAGES}"
+      for rpm in \${install_rpms}; do
+        rpm_install_cmd="\${rpm_install_cmd} --install=\${TEMP_DIR}/\${rpm}"
+      done   
+      \${rpm_install_cmd}
+    else
+      for rpm in \${install_rpms}; do
+        rpm-ostree install \${TEMP_DIR}/\${rpm}
+      done
+    fi
+
+    mkdir -p \${LOG_DIR}
+    rm -rf \${LOG_FILE}
+    echo \${RPMS_CM_ID} > \${LOG_FILE}
+
+    rm -Rf \${TEMP_DIR}
+
+    # Reboot to apply changes
+    systemctl reboot
+EOF
+
+cm_id=$(${OC_TOOL} get configmap rpms-entrypoint -o json | jq '.metadata.resourceVersion' | tr -d '"')
+
+cat <<EOF | oc apply -f -
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: rpms-ds
+  labels:
+    app: rpms-ds
+spec:
+  selector:
+    matchLabels:
+      app: rpms-ds
+  template:
+    metadata:
+      labels:
+        app: rpms-ds
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        ${RPMS_NODE_ROLE}: ""
+      containers:
+      - name: rpms-loader
+        image: ubi8/ubi-minimal
+        command: ['sh', '-c', 'cp /script/entrypoint.sh /host/tmp && chmod +x /host/tmp/entrypoint.sh && echo "Installing rpms" && chroot /host /tmp/entrypoint.sh && sleep infinity']
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        env:
+          - name: RPMS_CM_ID
+            value: "${cm_id}"
+        volumeMounts:
+        - mountPath: /script
+          name: rpms-script
+        - mountPath: /host
+          name: host
+      hostNetwork: true
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          name: rpms-entrypoint
+        name: rpms-script
+      - hostPath:
+          path: /
+          type: Directory
+        name: host
+EOF


### PR DESCRIPTION
The custom RPMs script allows to install RPMs from an external source on a node.
One main use of this script is to install RT kernel on a node.