### PR TITLE
Fix image link in main 5G README

### DIFF
--- a/feature-configs/5g-ref-nw/README.md
+++ b/feature-configs/5g-ref-nw/README.md
@@ -76,7 +76,7 @@ This type of deployment is expected to run on the Far Edge in cases where single
 <img src="images/cu-up.png" width=800>
 
 ### <a name="du_nw"></a>DU networks
-<img src="images/du.png" width=800>
+<img src="images/du-ldc.png" width=800>
 
 # The manifest structure
 The manifests defined here assume Kustomize as the tool of choice for Kubernetes cluster configuration. The structure defined here attempts to satisfy following requirements and assumptions:


### PR DESCRIPTION
This commit is fixing a broken link in 5g-ref-nw main README.md
/assign @lack 