### PR TITLE
Fix policy name exceeded allowed length

### DIFF
--- a/ztp/ztp-ran-policy-generator/kustomize/plugin/ranPolicyGenerator/v1/ranpolicygenerator/utils/utils.go
+++ b/ztp/ztp-ran-policy-generator/kustomize/plugin/ranPolicyGenerator/v1/ranpolicygenerator/utils/utils.go
@@ -5,9 +5,9 @@ const FileExt = ".yaml"
 const Common = "common"
 const Groups = "groups"
 const Sites = "sites"
-const CommonNS = Common + "-ran-subscriptions"
-const GroupNS = Groups + "-ran-subscriptions"
-const SiteNS = Sites + "-ran-subscriptions"
+const CommonNS = Common + "-ran-sub"
+const GroupNS = Groups + "-ran-sub"
+const SiteNS = Sites + "-ran-sub"
 const ExistOper = "Exists"
 const InOper = "In"
 const CustomResource = "customResource"
@@ -42,6 +42,7 @@ type labels struct {
 
 type sourceFile struct {
 	FileName string `yaml:"fileName"`
+	PolicyName string  `yaml:"policyName"`
 	Name string  `yaml:"name"`
 	Spec map[string]interface{} `yaml:"spec"`
 	Data map[string]interface{} `yaml:"data"`
@@ -116,9 +117,11 @@ type PlacementRule struct {
 		Name string `yaml:"name"`
 		Namespace string `yaml:"namespace"`
 	}
-	Spec struct{
-		ClusterSelector struct{
-			MatchExpressions map[string]interface{} `yaml:"matchExpressions"`
-		}
+	Spec struct {
+		ClusterSelector ClusterSelector `yaml:"clusterSelector"`
 	}
+}
+
+type ClusterSelector struct {
+	MatchExpressions []map[string]interface{} `yaml:"matchExpressions"`
 }

--- a/ztp/ztp-ran-policy-generator/ranGenTemplateExamples/common-ranGen.yaml
+++ b/ztp/ztp-ran-policy-generator/ranGenTemplateExamples/common-ranGen.yaml
@@ -13,18 +13,31 @@ metadata:
 sourceFiles:
   # Create operators policies that will be installed in all clusters
   - fileName: SriovSubscription
+    policyName: "sriov-sub-policy"
   - fileName: SriovSubscriptionNS
+    policyName: "sriov-sub-ns-policy"
   - fileName: SriovSubscriptionOperGroup
+    policyName: "sriov-sub-oper-policy"
   - fileName: PtpSubscription
+    policyName: "ptp-sub-policy"
   - fileName: PtpSubscriptionNS
+    policyName: "ptp-sub-ns-policy"
   - fileName: PtpSubscriptionOperGroup
+    policyName: "ptp-sub-oper-policy"
   - fileName: PaoSubscription
+    policyName: "pao-sub-policy"
     spec:
     # Changing the channel value will upgrade/downgrade the operator installed version.
       channel: "4.8"
   - fileName: PaoSubscriptionNS
+    policyName: "pao-sub-ns-policy"
   - fileName: PaoSubscriptionOperGroup
+    policyName: "pao-sub-oper-policy"
   - fileName: PaoSubscriptionCatalogSource
+    policyName: "pao-sub-catalog-policy"
   - fileName: ClusterLogSubscriptionNS
+    policyName: "log-sub-ns-policy"
   - fileName: ClusterLogSubscription
+    policyName: "log-sub-policy"
   - fileName: ClusterLogSubscriptionOperGroup
+    policyName: "log-sub-oper-policy"

--- a/ztp/ztp-ran-policy-generator/ranGenTemplateExamples/group-du-ranGen.yaml
+++ b/ztp/ztp-ran-policy-generator/ranGenTemplateExamples/group-du-ranGen.yaml
@@ -13,19 +13,25 @@ metadata:
 # sourceFiles.fileName values should be same as file name in the sourcePolicies dir without .yaml extension
 sourceFiles:
   - fileName: MachineConfigPool
+    policyName: "mcp-du-policy"
     # For MCP policy name is used to deifne the role name and node label.
     # The name will be used as the NodeSelector value in other policies that is should be applied only for this MachineConfigPool
     name: "worker-du"
   - fileName: SriovOperatorConfig
+    policyName: "sriov-operconfig-policy"
     name: "N/A"
   - fileName: MachineConfigSctp
+    policyName: "mc-sctp-policy"
     name: "N/A"
   - fileName: MachineConfigContainerMountNS
+    policyName: "mc-mount-ns-policy"
     name: "N/A"
   - fileName: MachineConfigDisableChronyd
+    policyName: "mc-chronyd-policy"
     name: "N/A"
   - fileName: PtpConfigSlave
-    name: "group-du-ptp-slave"
+    policyName: "ptp-config-policy"
+    name: "du-ptp-slave"
     spec:
       profile:
       - name: "slave"

--- a/ztp/ztp-ran-policy-generator/ranGenTemplateExamples/group-du-sno-ranGen.yaml
+++ b/ztp/ztp-ran-policy-generator/ranGenTemplateExamples/group-du-sno-ranGen.yaml
@@ -13,9 +13,11 @@ metadata:
     mcp: "master"
 sourceFiles:
   - fileName: ConsoleOperatorDisable
+    policyName: "console-policy"
     name: "N/A"
   # Set ClusterLogForwarder & ClusterLogging as example might be better to create another RanTemp-Group
   - fileName: ClusterLogForwarder
+    policyName: "log-forwarder-policy"
     name: "N/A"
     spec:
       outputs:
@@ -34,6 +36,7 @@ sourceFiles:
           outputRefs:
            - kafka-open
   - fileName: ClusterLogging
+    policyName: "log-policy"
     name: "N/A"
     spec:
       curation:

--- a/ztp/ztp-ran-policy-generator/ranGenTemplateExamples/site-du-sno-1-ranGen.yaml
+++ b/ztp/ztp-ran-policy-generator/ranGenTemplateExamples/site-du-sno-1-ranGen.yaml
@@ -12,11 +12,13 @@ metadata:
     mcp: worker-du
 sourceFiles:
   - fileName: SriovNetwork
+    policyName: "sriov-nw-fh-policy"
     name: "sriov-nw-du-fh"
     spec:
       resourceName: du_fh
       vlan: 140
   - fileName: SriovNetworkNodePolicy
+    policyName: "sriov-nn-fh-policy"
     name: "sriov-nnp-du-fh"
     spec:
       deviceType: netdevice
@@ -27,11 +29,13 @@ sourceFiles:
       priority: 10
       resourceName: du_fh
   - fileName: SriovNetwork
+    policyName: "sriov-nw-mh-policy"
     name: "sriov-nw-du-mh"
     spec:
       resourceName: du_mh
       vlan: 150
   - fileName: SriovNetworkNodePolicy
+    policyName: "sriov-nnp-mh-policy"
     name: "sriov-nnp-du-mh"
     spec:
       deviceType: vfio-pci
@@ -42,7 +46,7 @@ sourceFiles:
       priority: 10
       resourceName: du_mh
   - fileName: PerformanceProfile
-    name: "du-sno-1-PerfProfile"
+    name: "perfprofile-policy"
     spec:
       # ex: overriding the additionalKernelArgs values exist in the source policy file PerformanceProfile
       additionalKernelArgs:

--- a/ztp/ztp-ran-policy-generator/ranGenTemplates/RanGenTemplate.yaml
+++ b/ztp/ztp-ran-policy-generator/ranGenTemplates/RanGenTemplate.yaml
@@ -14,13 +14,43 @@ metadata:
     # Set siteName value (ex:prod-cluster) if the generated policies will be applied for a specific cluster.
     mcp: "N/A"
 sourceFiles:
-    # fileName values must be same as file name in the sourcePolicies dir without .yaml extension ex: SriovNetwork
+    # (mandatory) The fileName values must be same as file name in the sourcePolicies dir without .yaml extension ex: SriovNetwork
   - fileName: "N/A"
-    # the name will be used to set the generated resource definition metadata.name
-    # if name is defined as N/A the name value exist in the sourcePolicies/{fileName} will be used.
+
+    # (mandatory) The policyName will be used with common|{metadata.labels.groupName}|{metadata.labels.siteName}
+    # to set the generated policy name. ex: group1-ptp-policy or common-sriov-sub-policy
+    # When a policy is propagated to a managed cluster, the replicated policy is named namespaceName.policyName.
+    # When you create a policy, make sure that the length of the namespaceName.policyName must not exceed 63 characters
+    # due to the Kubernetes limit for object names.
+    # The namespace.names that ran policy generator use are: common-ran-sub, groups-ran-sub and sites-ran-sub
+    policyName: "N/A"
+
+    # (optional) The name will be used to set the generated custom resource metadata.name
+    # if name is defined as N/A, "" or not set the name value exist in the sourcePolicies/{fileName} will be used.
     name: "N/A"
-    # spec must contain the values that is needed to be set in the source policy ex:
-    #spec:
+
+    # (optional) spec must contain the values that is needed to be set in the source policy following the exact same path ex:
+    # sriovnetwork.spec as follow
+    # spec:
     #  resourceName: du_fh
     #  vlan: 140
+    #
+    # If the spec is not defined, the defined spec in the sourcePolicies/{fileName} will be carried out to
+    # the generated custom resource.
+    # If Any of the spec items defined in the source file as variable start with $, it will be deleted
+    # from the generated spec items if it is not setted.
     spec: "N/A"
+
+    # (optional) data must contain the values that is needed to be set in the source policy following the exact same path ex:
+    # configMap.data as follow
+    # data:
+    #   rules1.properties: |
+    #   name: cnf*
+    #   labels:
+    #    - node-role.kubernetes.io/worker-du
+    #
+    # If the data is not defined, the defined data in the sourcePolicies/{fileName} will be carried out to
+    # the generated custom resource.
+    # If Any of the data items defined in the source file as variable start with $, it will be deleted
+    # from the generated data items if it is not setted.
+    data: "N/A"


### PR DESCRIPTION
Based on the ACM document at [0] the policy name must not exceed 63 chars.
- Adding policyName field to fix acm naming limitation
- Fix matchExpression struct

[0] https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.2/html/security/governance-and-risk