### PR TITLE
Add tasks for exposing endpoints

### DIFF
--- a/ztp/ztp-playbooks/install-ai-operator/playbook.yml
+++ b/ztp/ztp-playbooks/install-ai-operator/playbook.yml
@@ -14,3 +14,7 @@
     - role: install-assisted-installer
       tags: install-assisted-installer
       become: yes
+    - role: expose-endpoints
+      tags: expose-endpoints
+      when: provisioner_cluster_name is defined and provisioner_cluster_name|length > 0
+      become: yes

--- a/ztp/ztp-playbooks/install-ai-operator/roles/expose-endpoints/tasks/main.yml
+++ b/ztp/ztp-playbooks/install-ai-operator/roles/expose-endpoints/tasks/main.yml
@@ -1,0 +1,25 @@
+- name: Get IP of the registry vm
+  shell: "kcli info vm {{ provisioner_cluster_name }}-disconnecter -f ip -v"
+  register: disconnecter_vm
+
+- name: Get IP of master vms
+  shell: "kcli info vm test-operator-master-0 -f ip -v ;  kcli info vm test-operator-master-1 -f ip -v;  kcli info vm test-operator-master-2 -f ip -v"
+  register: master_vms
+
+- name: Create tmp directory for haproxy
+  tempfile:
+    state: directory
+  register: tempdiroutput
+
+- name: Copy template to temporary directory
+  template:
+    src: "./templates/create_haproxy.sh.j2"
+    dest: "{{ tempdiroutput.path }}/create_haproxy.sh"
+    mode: 0755
+  vars:
+    provisioner_cluster_registry_var: "{% if provisioner_cluster_registry is defined and provisioner_cluster_registry|length > 0 %}{{ provisioner_cluster_registry }}{% else %}{{ provisioner_cluster_name }}-disconnecter.{{ provisioner_cluster_name }}.{{ provisioner_cluster_domain }}:5000{% endif %}"
+    master_ips: "{{ master_vms.stdout_lines }}"
+
+- name: Install haproxy
+  ansible.builtin.shell:
+    cmd: "ssh root@{{ disconnecter_vm.stdout }} 'bash -s' < {{ tempdiroutput.path }}/create_haproxy.sh"

--- a/ztp/ztp-playbooks/install-ai-operator/roles/expose-endpoints/templates/create_haproxy.sh.j2
+++ b/ztp/ztp-playbooks/install-ai-operator/roles/expose-endpoints/templates/create_haproxy.sh.j2
@@ -1,0 +1,103 @@
+#! /bin/bash
+
+# install haproxy if not done
+dnf -y install haproxy
+
+mkdir -p /etc/haproxy
+chmod 0755 /etc/haproxy
+
+rm /etc/haproxy/haproxy.cfg
+cat <<EOF >> /etc/haproxy/haproxy.cfg
+global
+    log         127.0.0.1 local2
+    maxconn     4000
+    daemon
+
+defaults
+    mode                    tcp
+    log                     global
+    retries                 3
+    timeout http-request    10s
+    timeout queue           1m
+    timeout connect         10s
+    timeout client          1m
+    timeout server          1m
+    timeout http-keep-alive 10s
+    timeout check           10s
+    maxconn                 3000
+
+listen stats-50000
+    bind *:50000
+    mode            http
+    log             global
+    maxconn 10
+    timeout client  100s
+    timeout server  100s
+    timeout connect 100s
+    stats enable
+    stats hide-version
+    stats refresh 30s
+    stats show-node
+    stats auth admin:password
+    stats uri  /haproxy?stats
+
+frontend api-devscripts2ipv6-6443
+    bind :::{{ haproxy_api_devscripts_port | default('6443') }} v4v6
+    mode tcp
+    default_backend api-devscripts2ipv6-be
+
+backend api-devscripts2ipv6-be
+    balance source
+    mode tcp
+
+    {% for master_ip in master_ips %}
+    server master{{ loop.index0 }} [{{ master_ip }}]:6443 check inter 1s
+    {% endfor %}
+
+frontend machineconfig-devscripts2ipv6-22623
+    bind :::{{ haproxy_machineconfig_port | default('6443') }} v4v6
+    mode tcp
+    default_backend mc-devscripts2ipv6-22623
+
+backend mc-devscripts2ipv6-22623
+    balance source
+    mode tcp
+
+    {% for master_ip in master_ips %}
+    server master{{ loop.index0 }} [{{ master_ip }}]:22623 check inter 1s
+    {% endfor %}
+
+frontend ingress-router-devscripts2ipv6-80
+    bind :::{{ haproxy_http_port | default('80') }} v4v6
+    mode tcp
+    default_backend ingress-devscripts2ipv6-80
+
+backend ingress-devscripts2ipv6-80
+    mode tcp
+    balance source
+
+    {% for master_ip in master_ips %}
+    server master{{ loop.index0 }} [{{ master_ip }}]:80 check inter 1s
+    {% endfor %}
+
+frontend ingress-router-devscripts2ipv6-443
+    bind :::{{ haproxy_https_port | default('443') }} v4v6
+    mode tcp
+    default_backend 443-devscripts2ipv6-be
+
+backend 443-devscripts2ipv6-be
+    mode tcp
+    balance source
+
+    {% for master_ip in master_ips %}
+    server master{{ loop.index0 }} [{{ master_ip }}]:443 check inter 1s
+    {% endfor %}
+
+EOF
+
+# set selinux rule
+setsebool -P haproxy_connect_any 1
+
+# restart haproxy
+systemctl restart haproxy
+systemctl enable haproxy


### PR DESCRIPTION
Run haproxy on the disconnecter vm, to expose
the cloud internal endpoints.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>