### PR TITLE
Fix remaining issues on installation

### DIFF
--- a/ztp/ztp-playbooks/install-ai-operator/roles/expose-endpoints/tasks/main.yml
+++ b/ztp/ztp-playbooks/install-ai-operator/roles/expose-endpoints/tasks/main.yml
@@ -3,7 +3,7 @@
   register: disconnecter_vm
 
 - name: Get IP of master vms
-  shell: "kcli info vm test-operator-master-0 -f ip -v ;  kcli info vm test-operator-master-1 -f ip -v;  kcli info vm test-operator-master-2 -f ip -v"
+  shell: "kcli info vm {{ provisioner_cluster_name }}-master-0 -f ip -v ;  kcli info vm {{ provisioner_cluster_name }}-master-1 -f ip -v;  kcli info vm {{ provisioner_cluster_name }}-master-2 -f ip -v"
   register: master_vms
 
 - name: Create tmp directory for haproxy

--- a/ztp/ztp-playbooks/install-ai-operator/roles/install-assisted-installer/templates/ai_secrets.yaml.j2
+++ b/ztp/ztp-playbooks/install-ai-operator/roles/install-assisted-installer/templates/ai_secrets.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: assisted-deployment-pull-secret
   namespace: assisted-installer
 stringData:
-  .dockerconfigjson: "{{ dockerconfigjson }}"
+  .dockerconfigjson: '{{ dockerconfigjson | regex_replace("'", '"') }}'
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
The dockerconfigjson secret needs to be embedded into
single quotes, not double. Also, fix a hardcoded
name when exposing the endpoints.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>