### PR TITLE
improve du performance profile

### DIFF
--- a/feature-configs/5g-ref-nw/profile-base/du-dual/performance/kustomization.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-dual/performance/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
+  - ../../du-general/performance
+
+patchesStrategicMerge:
   - performance-profile.yaml
+
+nameSuffix:
+  -dual

--- a/feature-configs/5g-ref-nw/profile-base/du-dual/performance/performance-profile.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-dual/performance/performance-profile.yaml
@@ -1,13 +1,8 @@
 apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
-  name: perf-du-dual
+  name: perf-du
 spec:
-  net:
-  # Set to "true" if all the workload will be DPDK based
-    userLevelNetworking: true
-  numa:
-    topologyPolicy: "restricted"
   cpu:
     isolated: "2-51"
     reserved: "0-1"
@@ -16,14 +11,4 @@ spec:
     pages:
     - count: 32
       size: 1G
-  realTimeKernel:
-    enabled: true
-  additionalKernelArgs:
-  - "nosmt"
-  - "nmi_watchdog=0"
-  - "audit=0"
-  - "mce=off"
-  - "processor.max_cstate=1"
-  - "idle=poll"
-  - "intel_idle.max_cstate=0"
 # Note: node selector is applied by the customizations using this profile

--- a/feature-configs/5g-ref-nw/profile-base/du-general/performance/kustomization.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-general/performance/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - performance-profile.yaml

--- a/feature-configs/5g-ref-nw/profile-base/du-general/performance/performance-profile.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-general/performance/performance-profile.yaml
@@ -1,0 +1,21 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: perf-du
+spec:
+  net:
+  # Set to "true" if all the workload will be DPDK based
+    userLevelNetworking: true
+  numa:
+    topologyPolicy: "restricted"
+  realTimeKernel:
+    enabled: true
+  additionalKernelArgs:
+  - "nosmt"
+  - "nmi_watchdog=0"
+  - "audit=0"
+  - "mce=off"
+  - "processor.max_cstate=1"
+  - "idle=poll"
+  - "intel_idle.max_cstate=0"
+# Note: node selector is applied by the customizations using this profile

--- a/feature-configs/5g-ref-nw/profile-base/du-single/performance/kustomization.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-single/performance/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
+  - ../../du-general/performance
+
+patchesStrategicMerge:
   - performance-profile.yaml
+
+nameSuffix:
+  -single

--- a/feature-configs/5g-ref-nw/profile-base/du-single/performance/performance-profile.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-single/performance/performance-profile.yaml
@@ -1,13 +1,8 @@
 apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
-  name: perf-du-single
+  name: perf-du
 spec:
-  net:
-  # Set to "true" if all the workload will be DPDK based
-    userLevelNetworking: true
-  numa:
-    topologyPolicy: "restricted"
   cpu:
     isolated: "2-25"
     reserved: "0-1"
@@ -16,14 +11,4 @@ spec:
     pages:
     - count: 16
       size: 1G
-  realTimeKernel:
-    enabled: true
-  additionalKernelArgs:
-  - "nosmt"
-  - "nmi_watchdog=0"
-  - "audit=0"
-  - "mce=off"
-  - "processor.max_cstate=1"
-  - "idle=poll"
-  - "intel_idle.max_cstate=0"
 # Note: node selector is applied by the customizations using this profile


### PR DESCRIPTION
- add general performance profile to 5g reference
- add pci=realloc to ran-overlays

pci=realloc is needed on some BMs where BIOS fail to properly set BARs
