### PR TITLE
Bug 1956788: VRF SR-IOV integration: use netdevice type for vfs

### DIFF
--- a/cnf-tests/testsuites/e2esuite/vrf/vrf_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/vrf/vrf_sriov.go
@@ -69,7 +69,7 @@ var _ = Describe("[sriov] VRF integration", func() {
 		Expect(len(nodesList)).To(BeNumerically(">", 0))
 		sriovDevice, err := sriovInfos.FindOneSriovDevice(nodesList[0])
 		Expect(err).ToNot(HaveOccurred())
-		_, err = sriovNetwork.CreateSriovPolicy(sriovclient, "test-policy-", namespaces.SRIOVOperator, sriovDevice.Name, nodesList[0], 5, resourceNameVRF, "vfio-pci")
+		_, err = sriovNetwork.CreateSriovPolicy(sriovclient, "test-policy-", namespaces.SRIOVOperator, sriovDevice.Name, nodesList[0], 5, resourceNameVRF, "netdevice")
 		Expect(err).ToNot(HaveOccurred())
 		sriov.WaitStable(sriovclient)
 


### PR DESCRIPTION
VRF is not compatible with vfio device, hence we must set the right type
or the CNI plugin won't find the device created in the pod's namespace.

