### PR TITLE
Add iperf3 to the Dockerfiles

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -59,7 +59,7 @@ RUN yum install -y numactl-devel make gcc && \
 
 FROM centos:7
 
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs linuxptp
+RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs linuxptp iperf3
 
 RUN mkdir -p /usr/local/etc/cnf
 

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -73,7 +73,7 @@ RUN yum install -y numactl-devel make gcc && \
 
 FROM openshift/origin-base
 
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp
+RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3
 
 RUN mkdir -p /usr/local/etc/cnf
 


### PR DESCRIPTION
iperf3 is needed for the ovs_qos tests