### PR TITLE
Adding monitor label to the namespace

### DIFF
--- a/feature-configs/deploy/n3000/namespace.yaml
+++ b/feature-configs/deploy/n3000/namespace.yaml
@@ -2,4 +2,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
   name: vran-acceleration-operators

--- a/feature-configs/deploy/sriov-fec/namespace.yaml
+++ b/feature-configs/deploy/sriov-fec/namespace.yaml
@@ -2,4 +2,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
   name: vran-acceleration-operators


### PR DESCRIPTION
This commit and the monitor annotation into the intel operators namespace so the monitor project(prometheus) will query the endpoints

Signed-off-by: Sebastian Sch <sebassch@gmail.com>