### PR TITLE
Add missing attributes to performance profile

### DIFF
--- a/ztp/source-policy-crs/PerformanceProfile.yaml
+++ b/ztp/source-policy-crs/PerformanceProfile.yaml
@@ -13,6 +13,10 @@ spec:
       - size: $size
         count: $count
         node: $node
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/$mcp: ""
+  net:
+    userLevelNetworking: true
   nodeSelector:
     node-role.kubernetes.io/$mcp: ''
   numa:


### PR DESCRIPTION
The PerformanceProfile needs to have the machineConfigPool and
userLevelNetworking set.

Signed-off-by: Ian Miller <imiller@redhat.com>