### PR TITLE
Add management workload annotations

### DIFF
--- a/feature-configs/deploy/performance/operator-namespace.yaml
+++ b/feature-configs/deploy/performance/operator-namespace.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-performance-addon-operator

--- a/feature-configs/deploy/ptp/01_namespace.yaml
+++ b/feature-configs/deploy/ptp/01_namespace.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: "management"
   name: openshift-ptp
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/feature-configs/deploy/sriov/01-sriov-namespace.yaml
+++ b/feature-configs/deploy/sriov/01-sriov-namespace.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: "management"
   name: openshift-sriov-network-operator
   labels:
     openshift.io/run-level: "1"

--- a/ztp/source-policy-crs/ClusterLogSubscription.yaml
+++ b/ztp/source-policy-crs/ClusterLogSubscription.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: "management"
   name: openshift-logging
 ---
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so. This commit sets the namespace
annotation for DU profile day-2 operators.

Signed-off-by: Ian Miller <imiller@redhat.com>