### PR TITLE
Remove dma-core package

### DIFF
--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -23,7 +23,6 @@ RUN yum install -y wget \
  make \
  libibverbs-devel \
  logrotate \
- rdma-core \
  ethtool \
  libpcap-devel \
  patch \


### PR DESCRIPTION
The installation complains about it being already present with a
different version, removing the specific installation.
