### PR TITLE
Assign more hugepages for dpdk test

### DIFF
--- a/feature-configs/typical-baremetal/performance/performance_profile.patch.yaml
+++ b/feature-configs/typical-baremetal/performance/performance_profile.patch.yaml
@@ -18,5 +18,5 @@ spec:
   hugepages:
     pages:
     - size: "1G"
-      count: 4
+      count: 5
       node: 0


### PR DESCRIPTION
dpdk test requires at least 5 hugepages to work