### PR TITLE
Assign more hugepages for dpdk test

### DIFF
--- a/feature-configs/typical-baremetal/performance/performance_profile.patch.yaml
+++ b/feature-configs/typical-baremetal/performance/performance_profile.patch.yaml
@@ -18,5 +18,4 @@ spec:
   hugepages:
     pages:
     - size: "1G"
-      count: 5
-      node: 0
+      count: 10


### PR DESCRIPTION
dpdk test requires now at least 10 hugepages to work.

Done in favor of d/s as the typical baremetal performance profile is not used u/s.