### PR TITLE
Validate sriov nodes are targeted by the performance profile

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/nodes"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/pods"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/sriov"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/utils"
 )
 
 const (
@@ -369,6 +370,9 @@ var _ = Describe("dpdk", func() {
 			nodeNames, err = nodes.MatchingOptionalSelectorByName(sriovInfos.Nodes)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(nodeNames)).To(BeNumerically(">", 0))
+
+			nodeNames, err = nodes.MatchingCustomSelectorByName(nodeNames, fmt.Sprintf("%s/%s=", utils.LabelRole, machineConfigPoolName))
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		BeforeEach(func() {

--- a/cnf-tests/testsuites/pkg/nodes/nodes.go
+++ b/cnf-tests/testsuites/pkg/nodes/nodes.go
@@ -207,14 +207,22 @@ func MatchingOptionalSelectorByName(toFilter []string) ([]string, error) {
 	if NodesSelector == "" {
 		return toFilter, nil
 	}
+
+	return MatchingCustomSelectorByName(toFilter, NodesSelector)
+}
+
+// MatchingCustomSelectorByName filter the given slice with only the nodes matching the given custom selector.
+// The nodesSelector must be in the form of label=value.
+// For example: nodesSelector="sctp=true"
+func MatchingCustomSelectorByName(toFilter []string, nodesSelector string) ([]string, error) {
 	toMatch, err := client.Client.Nodes().List(context.Background(), metav1.ListOptions{
-		LabelSelector: NodesSelector,
+		LabelSelector: nodesSelector,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Error in getting nodes matching %s, %v", NodesSelector, err)
+		return nil, fmt.Errorf("Error in getting nodes matching %s, %v", nodesSelector, err)
 	}
 	if len(toMatch.Items) == 0 {
-		return nil, fmt.Errorf("Failed to get nodes matching %s, %v", NodesSelector, err)
+		return nil, fmt.Errorf("Failed to get nodes matching %s, %v", nodesSelector, err)
 	}
 
 	res := make([]string, 0)
@@ -226,7 +234,7 @@ func MatchingOptionalSelectorByName(toFilter []string) ([]string, error) {
 		}
 	}
 	if len(res) == 0 {
-		return nil, fmt.Errorf("Failed to find matching nodes with %s", NodesSelector)
+		return nil, fmt.Errorf("Failed to find matching nodes with %s", nodesSelector)
 	}
 	return res, nil
 }


### PR DESCRIPTION
Validates that the node picked is also configured by the performance profile.
Solves a problem where a node without hugepages is picked for the tests and pods
are stuck on pending