### PR TITLE
Changed name of dpdk validation suite

### DIFF
--- a/cnf-tests/TESTLIST.md
+++ b/cnf-tests/TESTLIST.md
@@ -13,7 +13,7 @@ The validation tests are preliminary tests intended to verify that the instrumen
 | validation container-mount-namespace should have a container-mount-namespace machine config for worker | Check the presence of a machine config that enables container-mount-namespace on workers. | 
 | validation container-mount-namespace should have the container-mount-namespace machine config as part of the master machine config pool | Check if the container-mount-namespace machine config is used by the master machine config pool | 
 | validation container-mount-namespace should have the container-mount-namespace machine config as part of the worker machine config pool | Check if the container-mount-namespace machine config is used by the worker machine config pool | 
-| validation dpdk should have a tag ready from the dpdk imagestream | Check that, if a dpdk imagestream exists, it also have a tag ready to be consumed | 
+| validation dpdk imagestream should have a tag ready from the dpdk imagestream | Check that, if a dpdk imagestream exists, it also have a tag ready to be consumed | 
 | validation fec should have a ready deployment for the OpenNESS Operator for Intel FPGA PAC N3000 (Management) operator | Checks Intel FPGA PAC N3000 (Management) deployment ready - sriov-fec-controller-manager | 
 | validation fec should have all the required OpenNESS Operator for Intel FPGA PAC N3000 (Management) operands | Checks the existence and quantity of each Intel FPGA PAC N3000 (Management) daemonset | 
 | validation fec should have the fec CRDs available in the cluster | Checks the existence of the Intel FPGA PAC N3000 (Management) CRDs used by the Intel FPGA PAC N3000 (Management) operator. | 

--- a/cnf-tests/docgen/validation.json
+++ b/cnf-tests/docgen/validation.json
@@ -3,7 +3,7 @@
     "validation container-mount-namespace should have a container-mount-namespace machine config for worker": "Check the presence of a machine config that enables container-mount-namespace on workers.",
     "validation container-mount-namespace should have the container-mount-namespace machine config as part of the master machine config pool": "Check if the container-mount-namespace machine config is used by the master machine config pool",
     "validation container-mount-namespace should have the container-mount-namespace machine config as part of the worker machine config pool": "Check if the container-mount-namespace machine config is used by the worker machine config pool",
-    "validation dpdk should have a tag ready from the dpdk imagestream": "Check that, if a dpdk imagestream exists, it also have a tag ready to be consumed",
+    "validation dpdk imagestream should have a tag ready from the dpdk imagestream": "Check that, if a dpdk imagestream exists, it also have a tag ready to be consumed",
     "validation fec should have a ready deployment for the OpenNESS Operator for Intel FPGA PAC N3000 (Management) operator": "Checks Intel FPGA PAC N3000 (Management) deployment ready - sriov-fec-controller-manager",
     "validation fec should have all the required OpenNESS Operator for Intel FPGA PAC N3000 (Management) operands": "Checks the existence and quantity of each Intel FPGA PAC N3000 (Management) daemonset",
     "validation fec should have the fec CRDs available in the cluster": "Checks the existence of the Intel FPGA PAC N3000 (Management) CRDs used by the Intel FPGA PAC N3000 (Management) operator.",

--- a/cnf-tests/testsuites/validationsuite/cluster/validation.go
+++ b/cnf-tests/testsuites/validationsuite/cluster/validation.go
@@ -256,7 +256,7 @@ var _ = Describe("validation", func() {
 		})
 	})
 
-	Context("dpdk", func() {
+	Context("dpdk imagestream", func() {
 		It("should have a tag ready from the dpdk imagestream", func() {
 			imagestream, err := testclient.Client.ImageStreams("dpdk").Get(context.TODO(), "s2i-dpdk-app", metav1.GetOptions{})
 			if errors.IsNotFound(err) {


### PR DESCRIPTION
Changed the dpdk validation package name from `dpdk` to `dpdk imagestream` so that this validation test can be skipped.