### PR TITLE
Add management workload annotations

### DIFF
--- a/feature-configs/deploy/performance/operator-namespace.yaml
+++ b/feature-configs/deploy/performance/operator-namespace.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: openshift-performance-addon-operator
+  annotations:
+    workload.openshift.io/allowed: management
   labels:
     openshift.io/cluster-monitoring: "true"
-  name: openshift-performance-addon-operator
 spec: {}

--- a/feature-configs/deploy/ptp/01_namespace.yaml
+++ b/feature-configs/deploy/ptp/01_namespace.yaml
@@ -3,5 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-ptp
+  annotations:
+    workload.openshift.io/allowed: management
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/feature-configs/deploy/sriov/01-sriov-namespace.yaml
+++ b/feature-configs/deploy/sriov/01-sriov-namespace.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-sriov-network-operator
+  annotations:
+    workload.openshift.io/allowed: management
   labels:
     openshift.io/run-level: "1"

--- a/ztp/source-policy-crs/ClusterLogSubscription.yaml
+++ b/ztp/source-policy-crs/ClusterLogSubscription.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-logging
+  annotations:
+    workload.openshift.io/allowed: management
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription


### PR DESCRIPTION
Operator namespaces must be annotated to facilitate their
classification as management workload. This is related to workload
partitioning feature in OCP 4.8.