### PR TITLE
Downward API disable Discovery Mode

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -426,6 +426,9 @@ var _ = Describe("dpdk", func() {
 
 	Context("Downward API", func() {
 		execute.BeforeAll(func() {
+			if discovery.Enabled() {
+				Skip("Downward API test disabled for discovery mode")
+			}
 			CleanSriov()
 			createSriovPolicyAndNetworkShared()
 			var err error


### PR DESCRIPTION
The downward api test case has been disabled for discovery mode with the following code
			if discovery.Enabled() {
				Skip("Downward API test disabled for discovery mode")
			}