### PR TITLE
Removed sleep 900 from Downward API

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -461,7 +461,6 @@ var _ = Describe("dpdk", func() {
 			podMacAdd := getPodMac(dpdkWorkloadPod)
 			containerPci, err := checkDownwardApi(dpdkWorkloadPod, "annotations", "PCI")
 			podPci := getPodPci(dpdkWorkloadPod)
-			time.Sleep(900 * time.Second)
 			Expect(containerIP).To(ContainSubstring(podIP))
 			Expect(containerMac).To(ContainSubstring(podMacAdd))
 			Expect(containerPci).To(ContainSubstring(podPci))


### PR DESCRIPTION
Ori found a sleep command which was used for testing.  Command was removed. 