### PR TITLE
Consume 4.8 versions of the operators

### DIFF
--- a/feature-configs/deploy/ptp/03_subscription.yaml
+++ b/feature-configs/deploy/ptp/03_subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ptp-operator-subscription
   namespace: openshift-ptp
 spec:
-  channel: "4.7"
+  channel: "4.8"
   name: ptp-operator
   source: "redhat-operators"
   sourceNamespace: openshift-marketplace

--- a/feature-configs/deploy/sriov/03-sriov-subscription.yaml
+++ b/feature-configs/deploy/sriov/03-sriov-subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sriov-network-operator-subscription
   namespace: openshift-sriov-network-operator
 spec:
-  channel: "4.7"
+  channel: "4.8"
   name: sriov-network-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Now that master is pinned to 4.9, we update the versions of the
operators

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>