### PR TITLE
Fix dpdk test on SNO

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -895,7 +895,7 @@ func CreateSriovNetwork(sriovDevice *sriovv1.InterfaceExt, sriovNetworkName stri
 	Eventually(func() error {
 		netAttDef := &sriovk8sv1.NetworkAttachmentDefinition{}
 		return sriovclient.Get(context.Background(), goclient.ObjectKey{Name: sriovNetworkName, Namespace: namespaces.DpdkTest}, netAttDef)
-	}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	}, time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
 }
 
 func createDPDKWorkload(nodeSelector map[string]string, dpdkResourceName, testpmdCommand string, runningTime int, isServer bool) (*corev1.Pod, error) {


### PR DESCRIPTION
This commit extend the time we wait for the network attachment definition
to be created by the sriov operator from the sriov network CR

This is needed because after an SNO reboot it takes time for the net-attach-def webhook
to be available.

```
Internal error occurred: failed calling webhook \"multus-validating-config.k8s.io\": Post \"https://multus-admission-controller.openshift-multus.svc:443/validate?timeout=30s\": x509: certificate signed by unknown authority"
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>