### PR TITLE
Bug 1976243: Add partitioning annotation to  PAO CatalogSource.

### DIFF
--- a/feature-configs/deploy/performance/operator_catalogsource.yaml
+++ b/feature-configs/deploy/performance/operator_catalogsource.yaml
@@ -3,6 +3,8 @@ kind: CatalogSource
 metadata:
   name: performance-addon-operator
   namespace: openshift-marketplace
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   displayName: Openshift Performance Addon Operator
   icon:


### PR DESCRIPTION
This annotation is required for the index pod to be included in the
management partition.