### PR TITLE
Allow deploying fec feature without deploying n3000 feature first

### DIFF
--- a/feature-configs/deploy/fec/kustomization.yaml
+++ b/feature-configs/deploy/fec/kustomization.yaml
@@ -2,8 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-# issue: https://github.com/openshift-kni/cnf-features-deploy/pull/464#issuecomment-801775347
-# issue: https://github.com/kubernetes-sigs/kustomize/issues/2747
-#  - namespace.yaml
-#  - operatorgroup.yaml
+  - namespace.yaml
+  - operatorgroup.yaml
   - subscription.yaml

--- a/feature-configs/deploy/n3000/kustomization.yaml
+++ b/feature-configs/deploy/n3000/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  # issue: https://github.com/openshift-kni/cnf-features-deploy/pull/464#issuecomment-801775347
+  # issue: https://github.com/kubernetes-sigs/kustomize/issues/2747
   # TODO: remove this after intel publish the operator for 4.7 and 4.8
   - catalogSource.yaml
-  - namespace.yaml
-  - operatorgroup.yaml
+#  - namespace.yaml
+#  - operatorgroup.yaml
   - subscription.yaml


### PR DESCRIPTION
So far fec feature deployment was depending on n3000 deployment. The operatorgroup
and namespace are created for both features when deploying n3000 due to an issue
in the ran-profile deployment.

As n3000 is not supported since OCP 4.7 we should be able to deploy fec feature separatly.

issue: https://github.com/openshift-kni/cnf-features-deploy/pull/464#issuecomment-801775347
issue: https://github.com/kubernetes-sigs/kustomize/issues/2747