### PR TITLE
features: Add a ref field to the dpdk build config

### DIFF
--- a/feature-configs/deploy/dpdk/build-config.yaml
+++ b/feature-configs/deploy/dpdk/build-config.yaml
@@ -29,6 +29,7 @@ spec:
     contextDir: tools/s2i-dpdk/test/test-app
     git:
       uri: https://github.com/openshift-kni/cnf-features-deploy.git
+      ref: master
     type: Git
   strategy:
     sourceStrategy:


### PR DESCRIPTION
This is needed as there was a change in dpdk and test-pmd

Signed-off-by: Sebastian Sch <sebassch@gmail.com>