### PR TITLE
DPDK discovery fails on missing sriov testing namespace

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -127,7 +127,7 @@ var _ = Describe("dpdk", func() {
 
 			discovered, err := discovery.DiscoverPerformanceProfileAndPolicyWithAvailableNodes(client.Client, sriovclient, namespaces.SRIOVOperator, dpdkResourceName, performanceProfiles, nodeSelector)
 			if err != nil {
-				discoverySuccessful, discoveryFailedReason = false, "Can not run tests in discovery mode. Failed to discover required resources."
+				discoverySuccessful, discoveryFailedReason = false, fmt.Sprintf("Can not run tests in discovery mode. Failed to discover required resources. ERROR:\n%s", err)
 				return
 			}
 			profile, sriovDevice := discovered.Profile, discovered.Device

--- a/cnf-tests/testsuites/e2esuite/test_suite_test.go
+++ b/cnf-tests/testsuites/e2esuite/test_suite_test.go
@@ -117,6 +117,14 @@ var _ = BeforeSuite(func() {
 	}
 	_, err = testclient.Client.Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
+
+	ns = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sriovNamespaces.Test,
+		},
+	}
+	_, err = testclient.Client.Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
 })
 
 // We do the cleanup in AfterSuite because the failure reporter is triggered


### PR DESCRIPTION
https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/cb3b24b87a4de9e50f2b684b3a602dd6e657a8a1/test/util/cluster/cluster.go#L73
fails since the sriov-conformance-testing namespace isn't created by the suite