### PR TITLE
Bug 1979554: Update the oslat version to 2.0

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -48,7 +48,7 @@ RUN go build -mod=vendor -o /oslat-runner
 FROM centos:7 as builder-oslat
 
 ENV RT_TESTS_URL=https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git/snapshot
-ENV RT_TESTS_PKG=rt-tests-1.9
+ENV RT_TESTS_PKG=rt-tests-2.0
 
 RUN yum install -y numactl-devel make gcc && \
     curl -O $RT_TESTS_URL/$RT_TESTS_PKG.tar.gz && \

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -62,7 +62,7 @@ RUN go build -mod=vendor -o /oslat-runner
 FROM openshift/origin-release:golang-1.13 as builder-oslat
 
 ENV RT_TESTS_URL=https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git/snapshot
-ENV RT_TESTS_PKG=rt-tests-1.9
+ENV RT_TESTS_PKG=rt-tests-2.0
 
 RUN yum install -y numactl-devel make gcc && \
       curl -O $RT_TESTS_URL/$RT_TESTS_PKG.tar.gz && \

--- a/cnf-tests/pod-utils/oslat-runner/main.go
+++ b/cnf-tests/pod-utils/oslat-runner/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	oslatArgs := []string{
-		"--runtime", *runtime,
+		"--duration", *runtime,
 		"--rtprio", *rtPriority,
 		"--cpu-list", updatedSelfCPUs.String(),
 		"--cpu-main-thread", mainThreadCPUSet.String(),


### PR DESCRIPTION
We should align the version of the rt-test package between d/s and u/s.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>