### PR TITLE
infra: update the vendor list in the githooks

### DIFF
--- a/.githooks/components.sh
+++ b/.githooks/components.sh
@@ -5,9 +5,9 @@ components=( \
 	["tools"]="tools" \
 	["s2i"]="tools/s2i-dpdk" \
 	["features"]="feature-configs" \
-	["ztp"]="ztp","go.mod","go.sum" \
+	["ztp"]="ztp" \
 	["infra"]="Makefile",".githooks/","hack/","openshift-ci/" \
-	["vendor"]="vendor","cnf-tests","ztp" \
-	["cnf-tests"]="cnf-tests","go.mod","go.sum"
+	["vendor"]="vendor","cnf-tests","ztp", "go.mod","go.sum" \
+	["cnf-tests"]="cnf-tests"
 )
 


### PR DESCRIPTION
the go.mod and sum is part of the vendor not cnf-test

Signed-off-by: Sebastian Sch <sebassch@gmail.com>