### PR TITLE
Remove provisioning from ClusterDeployment

### DIFF
--- a/ztp/source-cluster-crs/cluster-crs.yaml
+++ b/ztp/source-cluster-crs/cluster-crs.yaml
@@ -48,9 +48,9 @@ spec:
           cluster-name: siteconfig.Spec.Clusters.ClusterName
   pullSecretRef:
     name: siteconfig.Spec.PullSecretRef.Name
-  provisioning:
-    sshPrivateKeySecretRef:
-      name: siteconfig.Spec.SshPrivateKeySecretRef.Name
+#  provisioning:
+#    sshPrivateKeySecretRef:
+#      name: siteconfig.Spec.SshPrivateKeySecretRef.Name
 ---
 apiVersion: agent-install.openshift.io/v1beta1
 kind: NMStateConfig


### PR DESCRIPTION
The provisioning section is only used if the CR does not have a
clusterInstallRef (AgentClusterInstall)

Signed-off-by: Ian Miller <imiller@redhat.com>