### PR TITLE
ztp: remove provisioning from ClusterDeployment

### DIFF
--- a/ztp/source-cluster-crs/cluster-crs.yaml
+++ b/ztp/source-cluster-crs/cluster-crs.yaml
@@ -48,9 +48,6 @@ spec:
           cluster-name: siteconfig.Spec.Clusters.ClusterName
   pullSecretRef:
     name: siteconfig.Spec.PullSecretRef.Name
-  provisioning:
-    sshPrivateKeySecretRef:
-      name: siteconfig.Spec.SshPrivateKeySecretRef.Name
 ---
 apiVersion: agent-install.openshift.io/v1beta1
 kind: NMStateConfig


### PR DESCRIPTION
This is needed to eliminate conflicting definitions with AI operator:
spec.provisioning: Forbidden: provisioning and clusterInstallRef cannot be set at the same time