### PR TITLE
[release 4.8] Support secure boot in sriov and dpdk tests

### DIFF
--- a/cnf-tests/testsuites/e2esuite/sctp/sctp_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/sctp/sctp_sriov.go
@@ -39,6 +39,11 @@ var _ = Describe("[sriov] SCTP integration", func() {
 		err := namespaces.Create(TestNamespace, client.Client)
 		Expect(err).ToNot(HaveOccurred())
 
+		// This namespace is required for the DiscoverSriov function as it start a pod
+		// to check if secure boot is enable on that node
+		err = namespaces.Create(sriovnamespaces.Test, client.Client)
+		Expect(err).ToNot(HaveOccurred())
+
 		Eventually(func() error {
 			_, err := client.Client.ServiceAccounts(TestNamespace).Get(context.Background(), "default", metav1.GetOptions{})
 			return err

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ replace (
 
 // Test deps
 replace (
-	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20210519004800-ac2a59cfedfe // release-4.8
+	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20210720180325-cc2001abf67c // release-4.8
 	github.com/openshift-kni/performance-addon-operators => github.com/openshift-kni/performance-addon-operators v0.0.0-20210623211448-e47ab94cabf0 // release-4.8
 	github.com/openshift/ptp-operator => github.com/openshift/ptp-operator v0.0.0-20210514002532-732f677c5207 // release-4.8
 )

--- a/go.sum
+++ b/go.sum
@@ -1060,8 +1060,8 @@ github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mo
 github.com/openshift/ptp-operator v0.0.0-20210514002532-732f677c5207 h1:Ze8Dhn+foyIRLCQcmYEfjrcm+Ixt/ajHlxZVNMLxAso=
 github.com/openshift/ptp-operator v0.0.0-20210514002532-732f677c5207/go.mod h1:CqkuRFq/QBsKmWCyw3cD3VxNzD3HIhEg57/2DiQP9dU=
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912/go.mod h1:0OXNy7VoqFexkxKqyQbHJLPwn1MFp1/CxRJAgKHM+/o=
-github.com/openshift/sriov-network-operator v0.0.0-20210519004800-ac2a59cfedfe h1:hDcQ3JJ4BC8HfbfHpAtGRZwX8iDtS3nVQaj6wY/AsOI=
-github.com/openshift/sriov-network-operator v0.0.0-20210519004800-ac2a59cfedfe/go.mod h1:lo+4iE8a/9jK863cxaXo3kfwnLX0Sn7BApztX2nCNLE=
+github.com/openshift/sriov-network-operator v0.0.0-20210720180325-cc2001abf67c h1:Dxb0cARua1nxU2woJQN9SPu7jSNLpi/CEBA2qhCCuZE=
+github.com/openshift/sriov-network-operator v0.0.0-20210720180325-cc2001abf67c/go.mod h1:lo+4iE8a/9jK863cxaXo3kfwnLX0Sn7BApztX2nCNLE=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go
@@ -90,7 +90,7 @@ var _ = Describe("[sriov] operator", func() {
 		Expect(err).ToNot(HaveOccurred())
 		err = namespaces.Clean(operatorNamespace, namespaces.Test, clients, discovery.Enabled())
 		Expect(err).ToNot(HaveOccurred())
-		waitForSRIOVStable()
+		WaitForSRIOVStable()
 		sriovInfos, err = cluster.DiscoverSriov(clients, operatorNamespace)
 		Expect(err).ToNot(HaveOccurred())
 		initPassed = true
@@ -194,7 +194,7 @@ var _ = Describe("[sriov] operator", func() {
 			} else {
 				node = sriovInfos.Nodes[0]
 				createVanillaNetworkPolicy(node, sriovInfos, numVfs, resourceName)
-				waitForSRIOVStable()
+				WaitForSRIOVStable()
 				sriovDevice, err = sriovInfos.FindOneSriovDevice(node)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -916,7 +916,7 @@ var _ = Describe("[sriov] operator", func() {
 		BeforeEach(func() {
 			err := namespaces.Clean(operatorNamespace, namespaces.Test, clients, discovery.Enabled())
 			Expect(err).ToNot(HaveOccurred())
-			waitForSRIOVStable()
+			WaitForSRIOVStable()
 		})
 
 		Describe("Configuration", func() {
@@ -950,7 +950,7 @@ var _ = Describe("[sriov] operator", func() {
 						})))
 
 					By("waiting the sriov to be stable on the node")
-					waitForSRIOVStable()
+					WaitForSRIOVStable()
 
 					By("waiting for the resources to be available")
 					Eventually(func() int64 {
@@ -997,7 +997,7 @@ var _ = Describe("[sriov] operator", func() {
 									})),
 						})))
 
-					waitForSRIOVStable()
+					WaitForSRIOVStable()
 
 					Eventually(func() int64 {
 						testedNode, err := clients.Nodes().Get(context.Background(), vfioNode, metav1.GetOptions{})
@@ -1285,7 +1285,7 @@ var _ = Describe("[sriov] operator", func() {
 						err = clients.Create(context.Background(), mtuPolicy)
 						Expect(err).ToNot(HaveOccurred())
 
-						waitForSRIOVStable()
+						WaitForSRIOVStable()
 						By("waiting for the resources to be available")
 						Eventually(func() int64 {
 							testedNode, err := clients.Nodes().Get(context.Background(), node, metav1.GetOptions{})
@@ -1435,7 +1435,7 @@ var _ = Describe("[sriov] operator", func() {
 					})))
 
 				By("waiting the sriov to be stable on the node")
-				waitForSRIOVStable()
+				WaitForSRIOVStable()
 
 				By("waiting for the resources to be available")
 				Eventually(func() int64 {
@@ -1829,7 +1829,7 @@ func daemonsScheduledOnNodes(selector string) bool {
 func createSriovPolicy(sriovDevice string, testNode string, numVfs int, resourceName string) {
 	_, err := network.CreateSriovPolicy(clients, "test-policy-", operatorNamespace, sriovDevice, testNode, numVfs, resourceName, "netdevice")
 	Expect(err).ToNot(HaveOccurred())
-	waitForSRIOVStable()
+	WaitForSRIOVStable()
 
 	Eventually(func() int64 {
 		testedNode, err := clients.Nodes().Get(context.Background(), testNode, metav1.GetOptions{})
@@ -1922,7 +1922,7 @@ func pingPod(ip string, nodeSelector string, sriovNetworkAttachment string) {
 	}, 3*time.Minute, 1*time.Second).Should(Equal(k8sv1.PodSucceeded))
 }
 
-func waitForSRIOVStable() {
+func WaitForSRIOVStable() {
 	// This used to be to check for sriov not to be stable first,
 	// then stable. The issue is that if no configuration is applied, then
 	// the status won't never go to not stable and the test will fail.

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client/clients.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client/clients.go
@@ -10,6 +10,7 @@ import (
 	clientsriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/typed/sriovnetwork/v1"
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	clientmachineconfigv1 "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	discovery "k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -68,6 +69,7 @@ func New(kubeconfig string) *ClientSet {
 	clientgoscheme.AddToScheme(crScheme)
 	netattdefv1.SchemeBuilder.AddToScheme(crScheme)
 	sriovv1.AddToScheme(crScheme)
+	apiext.AddToScheme(crScheme)
 
 	clientSet.Client, err = runtimeclient.New(config, client.Options{
 		Scheme: crScheme,

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster/cluster.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster/cluster.go
@@ -5,35 +5,45 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	testclient "github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/namespaces"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/nodes"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/pod"
 )
 
 // EnabledNodes provides info on sriov enabled nodes of the cluster.
 type EnabledNodes struct {
-	Nodes  []string
-	States map[string]sriovv1.SriovNetworkNodeState
+	Nodes               []string
+	States              map[string]sriovv1.SriovNetworkNodeState
+	IsSecureBootEnabled map[string]bool
 }
 
 var (
 	supportedPFDrivers = []string{"mlx5_core", "i40e", "ixgbe"}
 	supportedVFDrivers = []string{"iavf", "vfio-pci", "mlx5_core"}
+	mlxVendorID        = "15b3"
+	intelVendorID      = "8086"
 )
 
 // DiscoverSriov retrieves Sriov related information of a given cluster.
 func DiscoverSriov(clients *testclient.ClientSet, operatorNamespace string) (*EnabledNodes, error) {
 	nodeStates, err := clients.SriovNetworkNodeStates(operatorNamespace).List(context.Background(), metav1.ListOptions{})
-	res := &EnabledNodes{}
-	res.States = make(map[string]sriovv1.SriovNetworkNodeState)
-	res.Nodes = make([]string, 0)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to retrieve note states %v", err)
 	}
+
+	res := &EnabledNodes{}
+	res.States = make(map[string]sriovv1.SriovNetworkNodeState)
+	res.Nodes = make([]string, 0)
+	res.IsSecureBootEnabled = make(map[string]bool)
 
 	ss, err := nodes.MatchingOptionalSelectorState(clients, nodeStates.Items)
 	if err != nil {
@@ -59,6 +69,15 @@ func DiscoverSriov(clients *testclient.ClientSet, operatorNamespace string) (*En
 		}
 	}
 
+	for _, node := range res.Nodes {
+		isSecureBootEnabled, err := GetNodeSecureBootState(clients, node)
+		if err != nil {
+			return nil, err
+		}
+
+		res.IsSecureBootEnabled[node] = isSecureBootEnabled
+	}
+
 	if len(res.Nodes) == 0 {
 		return nil, fmt.Errorf("No sriov enabled node found")
 	}
@@ -73,6 +92,13 @@ func (n *EnabledNodes) FindOneSriovDevice(node string) (*sriovv1.InterfaceExt, e
 	}
 	for _, itf := range s.Status.Interfaces {
 		if IsPFDriverSupported(itf.Driver) && sriovv1.IsSupportedDevice(itf.DeviceID) {
+
+			// Skip mlx interfaces if secure boot is enabled
+			// TODO: remove this when mlx support secure boot/lockdown mode
+			if itf.Vendor == mlxVendorID && n.IsSecureBootEnabled[node] {
+				continue
+			}
+
 			return &itf, nil
 		}
 	}
@@ -89,6 +115,12 @@ func (n *EnabledNodes) FindSriovDevices(node string) ([]*sriovv1.InterfaceExt, e
 
 	for i, itf := range s.Status.Interfaces {
 		if IsPFDriverSupported(itf.Driver) && sriovv1.IsSupportedDevice(itf.DeviceID) {
+			// Skip mlx interfaces if secure boot is enabled
+			// TODO: remove this when mlx support secure boot/lockdown mode
+			if itf.Vendor == mlxVendorID && n.IsSecureBootEnabled[node] {
+				continue
+			}
+
 			devices = append(devices, &s.Status.Interfaces[i])
 		}
 	}
@@ -99,7 +131,7 @@ func (n *EnabledNodes) FindSriovDevices(node string) ([]*sriovv1.InterfaceExt, e
 func (n *EnabledNodes) FindOneVfioSriovDevice() (string, sriovv1.InterfaceExt) {
 	for _, node := range n.Nodes {
 		for _, nic := range n.States[node].Status.Interfaces {
-			if nic.Vendor == "8086" {
+			if nic.Vendor == intelVendorID {
 				return node, nic
 			}
 		}
@@ -113,8 +145,15 @@ func (n *EnabledNodes) FindOneMellanoxSriovDevice(node string) (*sriovv1.Interfa
 	if !ok {
 		return nil, fmt.Errorf("Node %s not found", node)
 	}
+
+	// return error here as mlx interfaces are not supported when secure boot is enabled
+	// TODO: remove this when mlx support secure boot/lockdown mode
+	if n.IsSecureBootEnabled[node] {
+		return nil, fmt.Errorf("Secure boot is enabled on the node mellanox cards are not supported")
+	}
+
 	for _, itf := range s.Status.Interfaces {
-		if itf.Driver == "mlx5_core" {
+		if itf.Vendor == mlxVendorID {
 			return &itf, nil
 		}
 	}
@@ -222,4 +261,46 @@ func SetDisableNodeDrainState(clients *testclient.ClientSet, operatorNamespace s
 		return err
 	}
 	return nil
+}
+
+func GetNodeSecureBootState(clients *testclient.ClientSet, nodeName string) (bool, error) {
+	podDefinition := pod.GetDefinition()
+	podDefinition = pod.RedefineWithNodeSelector(podDefinition, nodeName)
+	podDefinition = pod.RedefineAsPrivileged(podDefinition)
+
+	volume := corev1.Volume{Name: "host", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}}
+	mount := corev1.VolumeMount{Name: "host", MountPath: "/host"}
+	podDefinition = pod.RedefineWithMount(podDefinition, volume, mount)
+	created, err := clients.Pods(namespaces.Test).Create(context.Background(), podDefinition, metav1.CreateOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	var runningPod *corev1.Pod
+	err = wait.PollImmediate(time.Second, 3*time.Minute, func() (bool, error) {
+		runningPod, err = clients.Pods(namespaces.Test).Get(context.Background(), created.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if runningPod.Status.Phase != corev1.PodRunning {
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	stdout, stderr, err := pod.ExecCommand(clients, runningPod, "cat", "/host/sys/kernel/security/lockdown")
+	if err != nil {
+		return false, err
+	}
+
+	if stderr != "" {
+		return false, fmt.Errorf("command return non 0 code: %s", stderr)
+	}
+
+	return strings.Contains(stdout, "[integrity]") || strings.Contains(stdout, "[confidentiality]"), nil
 }

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/pod/pod.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/pod/pod.go
@@ -21,7 +21,7 @@ import (
 
 const hostnameLabel = "kubernetes.io/hostname"
 
-func getDefinition() *corev1.Pod {
+func GetDefinition() *corev1.Pod {
 	podObject := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "testpod-",
@@ -36,14 +36,14 @@ func getDefinition() *corev1.Pod {
 }
 
 func DefineWithNetworks(networks []string) *corev1.Pod {
-	podObject := getDefinition()
+	podObject := GetDefinition()
 	podObject.Annotations = map[string]string{"k8s.v1.cni.cncf.io/networks": strings.Join(networks, ",")}
 
 	return podObject
 }
 
 func DefineWithHostNetwork(nodeName string) *corev1.Pod {
-	podObject := getDefinition()
+	podObject := GetDefinition()
 	podObject.Spec.HostNetwork = true
 	podObject.Spec.NodeSelector = map[string]string{
 		"kubernetes.io/hostname": nodeName,
@@ -52,7 +52,7 @@ func DefineWithHostNetwork(nodeName string) *corev1.Pod {
 	return podObject
 }
 
-// RedefineAsPrivileged uppdates the pod to be privileged
+// RedefineAsPrivileged updates the pod to be privileged
 func RedefineAsPrivileged(pod *corev1.Pod) *corev1.Pod {
 	pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{}
 	b := true
@@ -60,17 +60,25 @@ func RedefineAsPrivileged(pod *corev1.Pod) *corev1.Pod {
 	return pod
 }
 
-// RedefineWithHostNetwork uppdates the pod definition Spec.HostNetwork to true
+// RedefineWithHostNetwork updates the pod definition Spec.HostNetwork to true
 func RedefineWithHostNetwork(pod *corev1.Pod) *corev1.Pod {
 	pod.Spec.HostNetwork = true
 	return pod
 }
 
-// RedefineWithNodeSelector uppdates the pod definition with a node selector
+// RedefineWithNodeSelector updates the pod definition with a node selector
 func RedefineWithNodeSelector(pod *corev1.Pod, node string) *corev1.Pod {
 	pod.Spec.NodeSelector = map[string]string{
 		hostnameLabel: node,
 	}
+	return pod
+}
+
+// RedefineWithMount updates the pod definition with a volume and volume mount
+func RedefineWithMount(pod *corev1.Pod, volume corev1.Volume, mount corev1.VolumeMount) *corev1.Pod {
+	pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{mount}
+	pod.Spec.Volumes = []corev1.Volume{volume}
+
 	return pod
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -147,7 +147,7 @@ github.com/json-iterator/go
 ## explicit
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1
-# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20210519004800-ac2a59cfedfe
+# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20210720180325-cc2001abf67c
 ## explicit
 github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
 github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/scheme
@@ -850,6 +850,6 @@ sigs.k8s.io/yaml
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20200421122923-c1de486c7d47
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20201202182407-c470febe19e3
 # sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.6.0
-# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20210519004800-ac2a59cfedfe
+# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20210720180325-cc2001abf67c
 # github.com/openshift-kni/performance-addon-operators => github.com/openshift-kni/performance-addon-operators v0.0.0-20210623211448-e47ab94cabf0
 # github.com/openshift/ptp-operator => github.com/openshift/ptp-operator v0.0.0-20210514002532-732f677c5207


### PR DESCRIPTION
This is a backport to allow cnf-test to run on secure-boot enabled environments