### PR TITLE
ztp: Run gofmt on all policyGenerator code

### DIFF
--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/policyGen/policyHelper.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/policyGen/policyHelper.go
@@ -1,9 +1,9 @@
 package policyGen
 
 import (
+	"errors"
 	utils "github.com/openshift-kni/cnf-features-deploy/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils"
 	"strings"
-	"errors"
 )
 
 func CreateAcmPolicy(name string, namespace string, policyObjDefArr []utils.PolicyObjectDefinition) utils.AcmPolicy {
@@ -102,7 +102,7 @@ func CreatePlacementRule(name string, namespace string, matchKey string, matchOp
 
 func CheckNameLength(namespace string, name string) error {
 	// the policy (namespace.name + name) must not exceed 63 chars based on ACM documentation.
-	if len(namespace + "." + name) > 63 {
+	if len(namespace+"."+name) > 63 {
 		err := errors.New("Namespace.Name + ResourceName is exceeding the 63 chars limit: " + namespace + "." + name)
 		return err
 	}

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/policyGenerator.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/policyGenerator.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"gopkg.in/yaml.v3"
 	"bytes"
-	utils "github.com/openshift-kni/cnf-features-deploy/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils"
+	"fmt"
 	policyGen "github.com/openshift-kni/cnf-features-deploy/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/policyGen"
 	siteConfigs "github.com/openshift-kni/cnf-features-deploy/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig"
+	utils "github.com/openshift-kni/cnf-features-deploy/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils"
+	"gopkg.in/yaml.v3"
+	"os"
 )
 
 var sourcePoliciesPath string
@@ -16,7 +16,6 @@ var outPath string
 var stdout bool
 var customResources bool
 var siteConfigFlag bool
-
 
 func main() {
 
@@ -41,7 +40,7 @@ func main() {
 				panic(err)
 			}
 
-			for clusterName, crs:= range scBuilder.Build(siteConfig) {
+			for clusterName, crs := range scBuilder.Build(siteConfig) {
 				for _, crIntf := range crs {
 					cr, err := yaml.Marshal(crIntf)
 					if err != nil {
@@ -54,13 +53,13 @@ func main() {
 				if stdout {
 					fmt.Println(buffer.String())
 				}
-				fHandler.WriteFile( clusterName + utils.FileExt, buffer.Bytes())
+				fHandler.WriteFile(clusterName+utils.FileExt, buffer.Bytes())
 				buffer.Reset()
 			}
 		}
 	} else {
 		for _, file := range fHandler.GetPolicyGenTemplates() {
-			policyGenTemp :=  utils.PolicyGenTemplate{}
+			policyGenTemp := utils.PolicyGenTemplate{}
 			yamlFile := fHandler.ReadPolicyGenTempFile(file.Name())
 			err := yaml.Unmarshal(yamlFile, &policyGenTemp)
 			if err != nil {
@@ -74,7 +73,7 @@ func main() {
 					fmt.Println("---")
 					fmt.Println(string(policy))
 				}
-				fHandler.WriteFile(k + utils.FileExt, policy)
+				fHandler.WriteFile(k+utils.FileExt, policy)
 			}
 		}
 	}

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfig.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfig.go
@@ -1,9 +1,9 @@
 package siteConfig
 
 import (
-	"strings"
-	"reflect"
 	"fmt"
+	"reflect"
+	"strings"
 )
 
 const clusterCRsFileName = "cluster-crs.yaml"
@@ -27,7 +27,7 @@ func (sc *SiteConfig) GetSiteConfigFieldValue(path string, clusterId int, nodeId
 	}
 	for _, key := range keys[1:] {
 		if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
-			intf :=  v.Interface()
+			intf := v.Interface()
 			arrClusters, ok := intf.([]Clusters)
 
 			if ok {
@@ -53,7 +53,6 @@ func (sc *SiteConfig) GetSiteConfigFieldValue(path string, clusterId int, nodeId
 	return v.Interface(), nil
 }
 
-
 // SiteConfig
 type SiteConfig struct {
 	ApiVersion string   `yaml:"apiVersion"`
@@ -64,9 +63,9 @@ type SiteConfig struct {
 
 // Metadata
 type Metadata struct {
-	Name      string `yaml:"name"`
-	Namespace string `yaml:"namespace"`
-	Labels map[string]string `yaml:"labels"`
+	Name      string            `yaml:"name"`
+	Namespace string            `yaml:"namespace"`
+	Labels    map[string]string `yaml:"labels"`
 }
 
 // Spec
@@ -137,8 +136,8 @@ type ManifestsConfig struct {
 
 // NodeNetwork
 type NodeNetwork struct {
-	Config map[string]interface{} `yaml:"config"`
-	Interfaces []Interfaces `yaml:"interfaces"`
+	Config     map[string]interface{} `yaml:"config"`
+	Interfaces []Interfaces           `yaml:"interfaces"`
 }
 
 // BmcCredentialsName

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfigBuilder.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfigBuilder.go
@@ -2,21 +2,22 @@ package siteConfig
 
 import (
 	"bytes"
+	"encoding/base64"
 	"io"
+	"reflect"
+	"strings"
+
 	utils "github.com/openshift-kni/cnf-features-deploy/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils"
 	yaml "gopkg.in/yaml.v3"
-	"strings"
-	"reflect"
-	base64 "encoding/base64"
 )
 
 type SiteConfigBuilder struct {
-	fHandler *utils.FilesHandler
+	fHandler         *utils.FilesHandler
 	SourceClusterCRs []interface{}
 }
 
 func NewSiteConfigBuilder(fileHandler *utils.FilesHandler) *SiteConfigBuilder {
-	scBuilder := SiteConfigBuilder{fHandler:fileHandler}
+	scBuilder := SiteConfigBuilder{fHandler: fileHandler}
 	clusterCRsFile := scBuilder.fHandler.ReadSourceFileCR(clusterCRsFileName)
 	clusterCRsYamls, err := scBuilder.splitYamls(clusterCRsFile)
 	scBuilder.SourceClusterCRs = make([]interface{}, 9)
@@ -36,14 +37,14 @@ func NewSiteConfigBuilder(fileHandler *utils.FilesHandler) *SiteConfigBuilder {
 	return &scBuilder
 }
 
-func (scbuilder *SiteConfigBuilder) Build(siteConfigTemp SiteConfig) (map[string][]interface{}) {
+func (scbuilder *SiteConfigBuilder) Build(siteConfigTemp SiteConfig) map[string][]interface{} {
 	clustersCRs := make(map[string][]interface{})
 
-	for id, cluster:= range siteConfigTemp.Spec.Clusters {
+	for id, cluster := range siteConfigTemp.Spec.Clusters {
 		if cluster.ClusterName == "" {
 			panic("Error: Missing cluster name at site " + siteConfigTemp.Metadata.Name)
 		}
-		clustersCRs[utils.CustomResource + "/" + siteConfigTemp.Metadata.Name + "/" + cluster.ClusterName] = scbuilder.getClusterCRs(id, siteConfigTemp)
+		clustersCRs[utils.CustomResource+"/"+siteConfigTemp.Metadata.Name+"/"+cluster.ClusterName] = scbuilder.getClusterCRs(id, siteConfigTemp)
 	}
 
 	return clustersCRs
@@ -91,7 +92,7 @@ func (scbuilder *SiteConfigBuilder) getClusterCR(clusterId int, siteConfigTemp S
 			}
 		}
 
-		operatorGroups, operatorGroupsValue := scbuilder.getOperGroupsManifest();
+		operatorGroups, operatorGroupsValue := scbuilder.getOperGroupsManifest()
 		dataMap[operatorGroups] = operatorGroupsValue
 		mountNS, mountNSValue := scbuilder.getMountNsManifest()
 		dataMap[mountNS] = mountNSValue

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils/filesHandler.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils/filesHandler.go
@@ -2,18 +2,18 @@ package utils
 
 import (
 	"io/ioutil"
-	"strings"
 	"os"
+	"strings"
 )
 
 type FilesHandler struct {
 	sourcePoliciesDir string
-	policyGenTempDir string
-	outDir string
+	policyGenTempDir  string
+	outDir            string
 }
 
 func NewFilesHandler(sourcePoliciesDir string, policyGenTempDir string, outDir string) *FilesHandler {
-	return &FilesHandler{sourcePoliciesDir:sourcePoliciesDir, policyGenTempDir:policyGenTempDir, outDir:outDir}
+	return &FilesHandler{sourcePoliciesDir: sourcePoliciesDir, policyGenTempDir: policyGenTempDir, outDir: outDir}
 }
 
 func (fHandler *FilesHandler) WriteFile(filePath string, content []byte) {
@@ -22,7 +22,7 @@ func (fHandler *FilesHandler) WriteFile(filePath string, content []byte) {
 		os.MkdirAll(path, 0775)
 	}
 
-	err := ioutil.WriteFile( fHandler.outDir + "/" + filePath, content, 0644)
+	err := ioutil.WriteFile(fHandler.outDir+"/"+filePath, content, 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils/utils.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils/utils.go
@@ -14,59 +14,59 @@ const CustomResource = "customResource"
 
 type PolicyGenConfig struct {
 	SourcePoliciesPath string
-	PolicyGenTempPath string
-	OutPath string
-	Stdout bool
+	PolicyGenTempPath  string
+	OutPath            string
+	Stdout             bool
 }
 
 type PolicyGenTemplate struct {
-	ApiVersion string  `yaml:"apiVersion"`
-	Kind string `yaml:"kind"`
-	Metadata metaData `yaml:"metadata"`
+	ApiVersion  string       `yaml:"apiVersion"`
+	Kind        string       `yaml:"kind"`
+	Metadata    metaData     `yaml:"metadata"`
 	SourceFiles []SourceFile `yaml:"sourceFiles"`
 }
 
 type metaData struct {
-	Name string `yaml:"name"`
-	Labels labels `yaml:"labels"`
+	Name      string `yaml:"name"`
+	Labels    labels `yaml:"labels"`
 	Namespace string `yaml:"namespace"`
 }
 
 type labels struct {
-	Common bool  `yaml:"common"`
-	GroupName string  `yaml:"groupName"`
-	SiteName string  `yaml:"siteName"`
-	Mcp string  `yaml:"mcp"`
+	Common    bool   `yaml:"common"`
+	GroupName string `yaml:"groupName"`
+	SiteName  string `yaml:"siteName"`
+	Mcp       string `yaml:"mcp"`
 }
 
 type SourceFile struct {
-	FileName string `yaml:"fileName"`
-	PolicyName string  `yaml:"policyName"`
-	Metadata struct {
-			 Annotations map[string]string `yaml:"annotations"`
-			 Labels map[string]string `yaml:"labels"`
-			 Name   string  `yaml:"name"`
-			 Namespace string `yaml:"namespace"`
-		 }
+	FileName   string `yaml:"fileName"`
+	PolicyName string `yaml:"policyName"`
+	Metadata   struct {
+		Annotations map[string]string `yaml:"annotations"`
+		Labels      map[string]string `yaml:"labels"`
+		Name        string            `yaml:"name"`
+		Namespace   string            `yaml:"namespace"`
+	}
 	Spec map[string]interface{} `yaml:"spec"`
 	Data map[string]interface{} `yaml:"data"`
 }
 
 type AcmPolicy struct {
-	ApiVersion string  `yaml:"apiVersion"`
-	Kind string `yaml:"kind"`
-	Metadata struct {
-			   Name string `yaml:"name"`
-			   Namespace string `yaml:"namespace"`
-			   Annotations map[string]string `yaml:"annotations"`
-		   }
+	ApiVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name        string            `yaml:"name"`
+		Namespace   string            `yaml:"namespace"`
+		Annotations map[string]string `yaml:"annotations"`
+	}
 	Spec acmPolicySpec `yaml:"spec"`
 }
 
 type acmPolicySpec struct {
-	RemediationAction string `yaml:"remediationAction"`
-	Disabled bool `yaml:"disabled`
-	PolicyTemplates []PolicyObjectDefinition `yaml:"policy-templates"`
+	RemediationAction string                   `yaml:"remediationAction"`
+	Disabled          bool                     `yaml:"disabled`
+	PolicyTemplates   []PolicyObjectDefinition `yaml:"policy-templates"`
 }
 
 type PolicyObjectDefinition struct {
@@ -74,56 +74,56 @@ type PolicyObjectDefinition struct {
 }
 
 type AcmConfigurationPolicy struct {
-	ApiVersion string  `yaml:"apiVersion"`
-	Kind string `yaml:"kind"`
-	Metadata struct {
-			   Name string `yaml:"name"`
-		   }
+	ApiVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	}
 	Spec acmConfigPolicySpec `yaml:"spec"`
 }
 
 type acmConfigPolicySpec struct {
 	RemediationAction string `yaml:"remediationAction"`
-	Severity string `yaml:"severity"`
+	Severity          string `yaml:"severity"`
 	NamespaceSelector struct {
-				  Exclude []string `yaml:"exclude"`
-				  Include []string `yaml:"include"`
-			  }
+		Exclude []string `yaml:"exclude"`
+		Include []string `yaml:"include"`
+	}
 	ObjectTemplates []ObjectTemplates `yaml:"object-templates"`
 }
 
 type ObjectTemplates struct {
-	ComplianceType string `yaml:"complianceType"`
+	ComplianceType   string                 `yaml:"complianceType"`
 	ObjectDefinition map[string]interface{} `yaml:"objectDefinition"`
 }
 
 type PlacementBinding struct {
-	ApiVersion string  `yaml:"apiVersion"`
-	Kind string `yaml:"kind"`
-	Metadata struct {
-			   Name string `yaml:"name"`
-			   Namespace string `yaml:"namespace"`
-		   }
-	PlacementRef Subject `yaml:"placementRef"`
-	Subjects []Subject `yaml:"subjects"`
+	ApiVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name      string `yaml:"name"`
+		Namespace string `yaml:"namespace"`
+	}
+	PlacementRef Subject   `yaml:"placementRef"`
+	Subjects     []Subject `yaml:"subjects"`
 }
 
 type Subject struct {
-	Name string `yaml:"name"`
-	Kind string `yaml:"kind"`
+	Name     string `yaml:"name"`
+	Kind     string `yaml:"kind"`
 	ApiGroup string `yaml:"apiGroup"`
 }
 
 type PlacementRule struct {
-	ApiVersion string  `yaml:"apiVersion"`
-	Kind string `yaml:"kind"`
-	Metadata struct {
-			   Name string `yaml:"name"`
-			   Namespace string `yaml:"namespace"`
-		   }
+	ApiVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name      string `yaml:"name"`
+		Namespace string `yaml:"namespace"`
+	}
 	Spec struct {
-			   ClusterSelector ClusterSelector `yaml:"clusterSelector"`
-		   }
+		ClusterSelector ClusterSelector `yaml:"clusterSelector"`
+	}
 }
 
 type ClusterSelector struct {


### PR DESCRIPTION
Keeping our sources in sync with gofmt help with code consistency and
minimizes future churn with multiple editors.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
