### PR TITLE
Enforce 'go vet' in both go projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ golint:
 
 govet:
 	@echo "Running go vet"
-	# Disabling GO111MODULE just for go vet execution
-	GO111MODULE=off go vet github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites...
+	cnf-tests/hack/govet.sh
+	ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/hack/govet.sh
 
 verify-commits:
 	hack/verify-commits.sh

--- a/cnf-tests/hack/common.sh
+++ b/cnf-tests/hack/common.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-pushd .
-cd "$(dirname "$0")/.."
+pushd "$(dirname "$0")/.."
 
 function finish {
     popd

--- a/cnf-tests/hack/govet.sh
+++ b/cnf-tests/hack/govet.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. $(dirname "$0")/common.sh
+echo "INFO: Running govet on cnf-tests/testsuites/..."
+go vet ./testsuites/...

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/hack/common.sh
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/hack/common.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+pushd "$(dirname "$0")/.."
+
+function finish {
+    popd
+}
+trap finish EXIT
+
+GOPATH="${GOPATH:-~/go}"
+export GOFLAGS="${GOFLAGS:-"-mod=vendor"}"
+
+export PATH=$PATH:$GOPATH/bin
+
+mkdir -p _cache

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/hack/govet.sh
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/hack/govet.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. $(dirname $0)/common.sh
+echo "INFO: Running go vet on ztp policy-generator"
+go vet ./...

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils/utils.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils/utils.go
@@ -65,7 +65,7 @@ type AcmPolicy struct {
 
 type acmPolicySpec struct {
 	RemediationAction string                   `yaml:"remediationAction"`
-	Disabled          bool                     `yaml:"disabled`
+	Disabled          bool                     `yaml:"disabled"`
 	PolicyTemplates   []PolicyObjectDefinition `yaml:"policy-templates"`
 }
 


### PR DESCRIPTION
- ztp: fix all 'go vet' complaints
- ztp: add go vet hack enforcement script
- cnf-tests: add go vet hack enforcement script
- infra: enforce govet in cnf-tests and ztp-policy-generator
