### PR TITLE
ztp: Split CRs for policyGen

### DIFF
--- a/ztp/source-policy-crs/ClusterLogOperGroup.yaml
+++ b/ztp/source-policy-crs/ClusterLogOperGroup.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    workload.openshift.io/allowed: management
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  targetNamespaces:
+  - openshift-logging

--- a/ztp/source-policy-crs/ClusterLogSubscription.yaml
+++ b/ztp/source-policy-crs/ClusterLogSubscription.yaml
@@ -1,11 +1,3 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-logging
-  annotations:
-    workload.openshift.io/allowed: management
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -16,12 +8,3 @@ spec:
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: cluster-logging
-  namespace: openshift-logging
-spec:
-  targetNamespaces:
-  - openshift-logging

--- a/ztp/ztp-policy-generator/ranPolicyGenTempExamples/common-ranGen.yaml
+++ b/ztp/ztp-policy-generator/ranPolicyGenTempExamples/common-ranGen.yaml
@@ -35,6 +35,8 @@ sourceFiles:
     policyName: "pao-sub-oper-policy"
   - fileName: PaoSubscriptionCatalogSource
     policyName: "pao-sub-catalog-policy"
+  - fileName: ClusterLogOperGroup
+    policyName: "log-oper-group-policy"
   - fileName: ClusterLogSubscription
     policyName: "log-sub-policy"
   - fileName: StorageSubscription


### PR DESCRIPTION
PolicyGen needs one CR per file for updates.

Split ClusterLogging subscription from namespace/opergroup to allow update of channel.

Signed-off-by: Ian Miller <imiller@redhat.com>