### PR TITLE
ztp: Plumb through per-node 'installerArgs' and 'ignitionConfigOverride'

### DIFF
--- a/ztp/ran-site-plan-crd/site-config-crd.yaml
+++ b/ztp/ran-site-plan-crd/site-config-crd.yaml
@@ -252,6 +252,14 @@ spec:
                                 should only be necessary to set this when inspection cannot
                                 automatically determine the profile.
                               type: string
+                            installerArgs:
+                              description: Additional command-line arguments to pass through to the OpenShift Installer for this node.
+                              type: array
+                              items:
+                                type: string
+                            ignitionConfigOverride:
+                              description: Json formatted string containing user overrides for the initial ignition config for this node.
+                              type: string
                             nodeNetwork:
                               description: Defination of the applied network to the node.
                               type: object

--- a/ztp/source-cluster-crs/cluster-crs.yaml
+++ b/ztp/source-cluster-crs/cluster-crs.yaml
@@ -119,6 +119,8 @@ metadata:
   annotations:
     inspect.metal3.io: disabled
     bmac.agent-install.openshift.io/hostname: siteconfig.Spec.Clusters.Nodes.HostName
+    bmac.agent-install.openshift.io/installer-args: siteconfig.Spec.Clusters.Nodes.InstallerArgs
+    bmac.agent-install.openshift.io/ignition-config-overrides: siteconfig.Spec.Clusters.Nodes.IgnitionConfigOverride
   labels:
     infraenvs.agent-install.openshift.io: siteconfig.Spec.Clusters.ClusterName
 spec:

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfig.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfig.go
@@ -107,15 +107,17 @@ type Clusters struct {
 
 // Nodes
 type Nodes struct {
-	BmcAddress         string                 `yaml:"bmcAddress"`
-	BootMACAddress     string                 `yaml:"bootMACAddress"`
-	RootDeviceHints    map[string]interface{} `yaml:"rootDeviceHints"`
-	Cpuset             string                 `yaml:"cpuset"`
-	NodeNetwork        NodeNetwork            `yaml:"nodeNetwork"`
-	HostName           string                 `yaml:"hostName"`
-	BmcCredentialsName BmcCredentialsName     `yaml:"bmcCredentialsName"`
-	BootMode           string                 `yaml:"bootMode"`
-	UserData           map[string]interface{} `yaml:"userData"`
+	BmcAddress             string                 `yaml:"bmcAddress"`
+	BootMACAddress         string                 `yaml:"bootMACAddress"`
+	RootDeviceHints        map[string]interface{} `yaml:"rootDeviceHints"`
+	Cpuset                 string                 `yaml:"cpuset"`
+	NodeNetwork            NodeNetwork            `yaml:"nodeNetwork"`
+	HostName               string                 `yaml:"hostName"`
+	BmcCredentialsName     BmcCredentialsName     `yaml:"bmcCredentialsName"`
+	BootMode               string                 `yaml:"bootMode"`
+	UserData               map[string]interface{} `yaml:"userData"`
+	InstallerArgs          string                 `yaml:"installerArgs"`
+	IgnitionConfigOverride string                 `yaml:"ignitionConfigOverride"`
 }
 
 // MachineNetwork


### PR DESCRIPTION
These allow per-node customization of the ignition and installer defined
in the SiteConfig CR, through the BareMetalHost annotations to the
AssistedService Agent.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
