### PR TITLE
Add ztp local gitignore

### DIFF
--- a/ztp/.gitignore
+++ b/ztp/.gitignore
@@ -1,0 +1,2 @@
+ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/PolicyGenerator
+ztp-policy-generator/out


### PR DESCRIPTION
Add .gitignore file local to ztp directory.
It will allow us to ignore ztp build products and other
artifacts unwanted in the SCM without affecting any of the
parent directory objects