### PR TITLE
ztp: reduce sno monitoring footprint

### DIFF
--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
@@ -76,3 +76,5 @@ spec:
           source: registry.redhat.io
     - fileName: OperatorHub.yaml
       policyName: "oper-hub-policy"
+    - fileName: ReduceMonitoringFootprint.yaml
+      policyName: "mon-offload-policy"

--- a/ztp/source-crs/ReduceMonitoringFootprint.yaml
+++ b/ztp/source-crs/ReduceMonitoringFootprint.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    grafana:
+      enabled: false
+    alertmanagerMain:
+      enabled: false

--- a/ztp/ztp-policy-generator/testPolicyGenTemplate/common-ranGen.yaml
+++ b/ztp/ztp-policy-generator/testPolicyGenTemplate/common-ranGen.yaml
@@ -37,3 +37,5 @@ spec:
       policyName: "log-sub-policy"
     - fileName: StorageSubscription.yaml
       policyName: "storage-sub-policy"
+    - fileName: ReduceMonitoringFootprint.yaml
+      policyName: "mon-offload-policy"


### PR DESCRIPTION
Adds day-0 extra manifests disabling Grafana and alert manager. Required for SNO CPU footprint.
/assign @imiller0 
/cc @serngawy
/hold until tested