### PR TITLE
bug 1999862: ztp: Ensure the tuned performance-patch matches the PAO policy name

### DIFF
--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/test-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/test-sno.yaml
@@ -74,7 +74,7 @@ spec:
             data: |
               [main]
               summary=Configuration changes profile inherited from performance created tuned
-              include=openshift-node-performance-profile
+              include=openshift-node-performance-openshift-node-performance-profile
               [bootloader]
               cmdline_crash=nohz_full=2-19,22-39
               [sysctl]

--- a/ztp/source-crs/TunedPerformancePatch.yaml
+++ b/ztp/source-crs/TunedPerformancePatch.yaml
@@ -9,7 +9,7 @@ spec:
       data: |
         [main]
         summary=Configuration changes profile inherited from performance created tuned
-        include=${performance-profile-name}
+        include=openshift-node-performance-${performance-profile-name}
         [bootloader]
         cmdline_crash=nohz_full=${isolated_cores}
         [sysctl]

--- a/ztp/ztp-policy-generator/testPolicyGenTemplate/site-du-sno-1-ranGen.yaml
+++ b/ztp/ztp-policy-generator/testPolicyGenTemplate/site-du-sno-1-ranGen.yaml
@@ -68,7 +68,7 @@ spec:
             data: |
               [main]
               summary=Configuration changes profile inherited from performance created tuned
-              include=openshift-node-performance-profile
+              include=openshift-node-performance-openshift-node-performance-profile
               [bootloader]
               cmdline_crash=nohz_full=2-19,22-39
               [sysctl]


### PR DESCRIPTION
When PAO generates a tuned profile, it takes the associated PAO policy
object name and prepends `openshift-node-performance-`.  This means that
because our examples have a PAO policy named
`openshift-node-performance-profile` the tuned performance patch needs
to refer to a tuned policy named
`openshift-node-performance-openshift-node-performance-profile`

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
