### PR TITLE
Add new parameter for number of masters

### DIFF
--- a/ztp/ran-crd/site-config-crd.yaml
+++ b/ztp/ran-crd/site-config-crd.yaml
@@ -84,6 +84,13 @@ spec:
                         enum:
                           - standard
                           - sno
+                      numMasters:
+                        description: Number of masters for the control plane.
+                        type: integer
+                        default: 1
+                        enum:
+                          - 1
+                          - 3
                       clusterProfile:
                         description: |
                           clusterProfile specify the day 0 configuration that will get applied on the cluster. Must be one

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/resources/cluster-crs.yaml
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/resources/cluster-crs.yaml
@@ -22,7 +22,7 @@ spec:
     machineNetwork: siteconfig.Spec.Clusters.MachineNetwork
     serviceNetwork: siteconfig.Spec.Clusters.ServiceNetwork
   provisionRequirements:
-    controlPlaneAgents: 1
+    controlPlaneAgents: siteconfig.Spec.Clusters.NumMasters
   sshPublicKey: siteconfig.Spec.SshPublicKey
   manifestsConfigMapRef:
     name: siteconfig.Spec.Clusters.ClusterName


### PR DESCRIPTION
While we implement the number of masters depending on
data type, add this additional parameter, to specify
the number of nodes manually.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>