### PR TITLE
Bug 2000726: ztp: fix rv data name and path

### DIFF
--- a/ztp/resource-generator/src/get-pre-sync-rv.sh
+++ b/ztp/resource-generator/src/get-pre-sync-rv.sh
@@ -2,7 +2,7 @@
 
 CM=$(oc get configmap/rv &> /dev/null)
 if (( $? == 0 )); then
-  RV=$( oc get configmap/rv -ojson | jq -rM '.metadata.resourceVersion' )
+  RV=$( oc get configmap/rv -ojson | jq -rM '.data.sitesResourceVersion' )
   echo "ztp-hooks.postsync $(date -R) INFO [post-sync-entrypoint] Retrieved RAN sites resourceVersion $RV" >> /proc/1/fd/2
   echo $RV
 else


### PR DESCRIPTION
Fixes an issue discovered in scalability tests, where the
post-sync resource hook was failing due to the resource version being
expired.
The reason - the resource version number post-sync was comparing to
was initialized from config map resource version instead of its data.
/assign @imiller0 
/cc @serngawy 