### PR TITLE
ztp: Update kernel args for performance

### DIFF
--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   additionalKernelArgs:
   - "idle=poll"
+  - "rcupdate.rcu_normal_after_boot=0"
   cpu:
     isolated: $isolated
     reserved: $reserved


### PR DESCRIPTION
Set kernel flags based on updated RT kernel. The
rcupdate.rcu_normal_after_boot=0 reduces contention on kernel locks
which improves reboot recovery time (reference BZ 1975356)

Signed-off-by: Ian Miller <imiller@redhat.com>