### PR TITLE
ztp: disable SNO network diagnostics

### DIFF
--- a/ztp/source-crs/DisableSnoNetworkDiag.yaml
+++ b/ztp/source-crs/DisableSnoNetworkDiag.yaml
@@ -1,0 +1,6 @@
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  disableNetworkDiagnostics: true

--- a/ztp/ztp-policy-generator/testPolicyGenTemplate/group-du-sno-ranGen.yaml
+++ b/ztp/ztp-policy-generator/testPolicyGenTemplate/group-du-sno-ranGen.yaml
@@ -69,3 +69,8 @@ spec:
         name: 04-accelerated-container-startup-master
         labels:
           machineconfiguration.openshift.io/role: master
+    - fileName: DisableSnoNetworkDiag.yaml
+      policyname: "disable-network-diag"
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: master


### PR DESCRIPTION
This commit disables network diagnostic pods in SNO,
reducing the number of pods by two
/cc @serngawy 
/assign @imiller0 
/hold (until tested with ACM)