### PR TITLE
ztp: Fix mc-accelerated-startup-policy-worker-du  policy name more than 63 chars

### DIFF
--- a/ztp/ztp-policy-generator/testPolicyGenTemplate/group-du-ranGen.yaml
+++ b/ztp/ztp-policy-generator/testPolicyGenTemplate/group-du-ranGen.yaml
@@ -12,7 +12,7 @@ spec:
     - fileName: MachineConfigPool.yaml
       policyName: "mcp-worker-du-policy"
     - fileName: MachineConfigAcceleratedStartup.yaml
-      policyName: "mc-accelerated-startup-policy-worker-du"
+      policyName: "mc-accelerated-policy-worker-du"
       metadata:
         name: 04-accelerated-container-startup-worker-du
         labels:

--- a/ztp/ztp-policy-generator/testPolicyGenTemplate/group-du-sno-ranGen.yaml
+++ b/ztp/ztp-policy-generator/testPolicyGenTemplate/group-du-sno-ranGen.yaml
@@ -64,7 +64,7 @@ spec:
       spec:
         disableDrain: true
     - fileName: MachineConfigAcceleratedStartup.yaml
-      policyName: "mc-accelerated-startup-policy"
+      policyName: "mc-accelerated-policy"
       metadata:
         name: 04-accelerated-container-startup-master
         labels:


### PR DESCRIPTION
-  Fix increase policy name more than 63 chars     
Signed-off-by: melserngawy <melserng@redhat.com>