### PR TITLE
ztp: fix sample for standard cluster

### DIFF
--- a/ztp/ztp-policy-generator/testSiteConfig/site1-sno-du.yaml
+++ b/ztp/ztp-policy-generator/testSiteConfig/site1-sno-du.yaml
@@ -68,16 +68,22 @@ spec:
                   enabled: true
                   dhcp: false
                   address:
-                  - 10.16.231.3/24
-                  - 10.16.231.28/24
-                  - 10.16.231.31/24
+                  - ip: 10.16.231.3
+                    prefix-length: 24
+                  - ip: 10.16.231.28
+                    prefix-length: 24
+                  - ip: 10.16.231.31
+                    prefix-length: 24
                 ipv6:
                   enabled: true
                   dhcp: false
                   address:
-                  - "2620:52:0:10e7:e42:a1ff:fe8a:601/64"
-                  - "2620:52:0:10e7:e42:a1ff:fe8a:602/64"
-                  - "2620:52:0:10e7:e42:a1ff:fe8a:603/64"
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:601"
+                    prefix-length: 64
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:602"
+                    prefix-length: 64
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:603"
+                    prefix-length: 64
               - name: bond99
                 type: bond
                 state: up

--- a/ztp/ztp-policy-generator/testSiteConfig/site2-sno-du.yaml
+++ b/ztp/ztp-policy-generator/testSiteConfig/site2-sno-du.yaml
@@ -19,11 +19,11 @@ spec:
       group-du-sno: ""
       common: true
       sites : "site-sno-du-2"
+    apiVIP: "10.16.231.101"
+    ingressVIP: "10.16.231.102"       
     clusterNetwork:
       - cidr: 10.128.0.0/14
         hostPrefix: 23
-    machineNetwork:
-      - cidr: 10.16.231.0/24
     serviceNetwork:
       - 172.30.0.0/16
     manifestsConfig:
@@ -58,9 +58,12 @@ spec:
                   enabled: true
                   dhcp: false
                   address:
-                  - "2620:52:0:10e7:e42:a1ff:fe8a:601/64"
-                  - "2620:52:0:10e7:e42:a1ff:fe8a:602/64"
-                  - "2620:52:0:10e7:e42:a1ff:fe8a:603/64"
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:601"
+                    prefix-length: 64
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:602"
+                    prefix-length: 64
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:603"
+                    prefix-length: 64
             dns-resolver:
               config:
                 server:

--- a/ztp/ztp-policy-generator/testSiteConfig/site2-standard-du.yaml
+++ b/ztp/ztp-policy-generator/testSiteConfig/site2-standard-du.yaml
@@ -61,9 +61,12 @@ spec:
                   enabled: true
                   dhcp: false
                   address:
-                  - "2620:52:0:10e7:e42:a1ff:fe8a:601/64"
-                  - "2620:52:0:10e7:e42:a1ff:fe8a:602/64"
-                  - "2620:52:0:10e7:e42:a1ff:fe8a:603/64"
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:601"
+                    prefix-length: 64
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:602"
+                    prefix-length: 64
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:603"
+                    prefix-length: 64
             dns-resolver:
               config:
                 server:


### PR DESCRIPTION
To deploy an standard cluster, api vip and ingress vip
are needed. And machine network needs to be removed.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>