### PR TITLE
ztp: support networkType parametrization

### DIFF
--- a/ztp/ran-crd/site-config-crd.yaml
+++ b/ztp/ran-crd/site-config-crd.yaml
@@ -102,6 +102,13 @@ spec:
                           - du
                           - cu
                           - cu-du
+                      networkType:
+                        description: NetworkType is the SDN plugin that will be deployed on the Cluster.
+                        type: string
+                        default: OVNKubernetes
+                        enum:
+                          - OVNKubernetes
+                          - OpenShiftSDN
                       clusterLabels:
                         description: |
                           clusterLabels specify the the day2 configuration policies that will get applied on the cluster. The following labels example should be included in order to match the policy generatroe policies rules.

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/resources/cluster-crs.yaml
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/resources/cluster-crs.yaml
@@ -10,6 +10,8 @@ kind: AgentClusterInstall
 metadata:
   name: siteconfig.Spec.Clusters.ClusterName
   namespace: siteconfig.Spec.Clusters.ClusterName
+  annotations:
+    agent-install.openshift.io/install-config-overrides: siteconfig.Spec.Clusters.NetworkType
 spec:
   clusterDeploymentRef:
     name: siteconfig.Spec.Clusters.ClusterName

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfig.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfig.go
@@ -99,6 +99,7 @@ type Clusters struct {
 	NumMasters             uint8             `yaml:"numMasters"`
 	ClusterProfile         string            `yaml:"clusterProfile"`
 	ClusterLabels          map[string]string `yaml:"clusterLabels"`
+	NetworkType            string            `yaml:"networkType"`
 	ClusterNetwork         []ClusterNetwork  `yaml:"clusterNetwork"`
 	IgnitionConfigOverride string            `yaml:"ignitionConfigOverride"`
 	DiskEncryption         DiskEncryption    `yaml:"diskEncryption"`

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfigBuilder.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfigBuilder.go
@@ -53,6 +53,14 @@ func (scbuilder *SiteConfigBuilder) Build(siteConfigTemp SiteConfig) (map[string
 		if cluster.ClusterName == "" {
 			return clustersCRs, errors.New("Error: Missing cluster name at site " + siteConfigTemp.Metadata.Name)
 		}
+		if cluster.NetworkType == "" {
+			cluster.NetworkType = "OVNKubernetes"
+			siteConfigTemp.Spec.Clusters[id].NetworkType = "OVNKubernetes"
+		}
+		if cluster.NetworkType != "OpenShiftSDN" && cluster.NetworkType != "OVNKubernetes" {
+			return clustersCRs, errors.New("Error: networkType must be either OpenShiftSDN or OVNKubernetes " + siteConfigTemp.Metadata.Name)
+		}
+		siteConfigTemp.Spec.Clusters[id].NetworkType = "{\"networking\":{\"networkType\":\"" + cluster.NetworkType + "\"}}"
 		clusterValue, err := scbuilder.getClusterCRs(id, siteConfigTemp)
 		if err != nil {
 			return clustersCRs, err


### PR DESCRIPTION
Users cannot choose which SDN plugin gets deployed via the SiteConfigs, they will always get OpenShiftSDN for IPv4 clusters and OVNKubernetes for IPv6 clusters.

This PR adds a new parameter inside the Cluster definitions named `networkType` that can be set to either "OVNKubernetes" or "OpenShiftSDN". If it's not set, by default OVNKubernetes will be used.

Example:

~~~yaml
<omitted>
  clusters:
  - clusterName: "mycluster1"
    clusterType: "sno"
    clusterProfile: "du"
    clusterLabels:
      group-du-sno: ""
      common: true
      sites : "westford-lab"
    networkType: "OVNKubernetes"
<omitted>
~~~

I couldn't do something like this in the ACI yaml, it seems not possible to add a spec value and a string in the same line, that's why this modifies the CR inside the `getClusterCRs` function.

~~~
apiVersion: extensions.hive.openshift.io/v1beta1
kind: AgentClusterInstall
metadata:
  name: siteconfig.Spec.Clusters.ClusterName
  namespace: siteconfig.Spec.Clusters.ClusterName
  annotations: 
    agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType":"siteconfig.Spec.Clusters.NetworkType"}}'
spec:
<omitted>
~~~