### PR TITLE
infra: fix our invocation of 'go vet' to run everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,7 @@ golint:
 
 govet:
 	@echo "Running go vet"
-	# Disabling GO111MODULE just for go vet execution
-	GO111MODULE=off go vet github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites...
+	go vet -mod=vendor ./cnf-tests/testsuites/...
 
 verify-commits:
 	hack/verify-commits.sh


### PR DESCRIPTION
The previous mechanism of disabling go modules for calling 'go vet'
doesn't work with go 1.16.  This changed mechanism works on developer
machines an also in the Github CI.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
