### PR TITLE
Update multi yaml file

### DIFF
--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
@@ -30,7 +30,7 @@ spec:
     - fileName: PaoSubscription.yaml
       policyName: "pao-sub-policy"
       spec:
-      # Changing the channel value will upgrade/downgrade the operator installed version.
+        # Changing the channel value will upgrade/downgrade the operator installed version.
         channel: "4.8"
     - fileName: PaoSubscriptionNS.yaml
       policyName: "pao-sub-policy"
@@ -73,9 +73,9 @@ spec:
       policyName: "disc-icsp-policy"
       spec:
         repositoryDigestMirrors:
-        - mirrors:
-          - registry.redhat.com:5000
-          source: registry.redhat.io
+          - mirrors:
+              - registry.redhat.com:5000
+            source: registry.redhat.io
     - fileName: OperatorHub.yaml
       policyName: "oper-hub-policy"
     - fileName: ReduceMonitoringFootprint.yaml

--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
@@ -40,6 +40,8 @@ spec:
       policyName: "pao-sub-policy"
       spec:
         image: quay.io/openshift-kni/performance-addon-operator-index:4.8-snapshot
+    - fileName: ClusterLogOperGroupNS.yaml
+      policyName: "log-sub-policy"
     - fileName: ClusterLogOperGroup.yaml
       policyName: "log-sub-policy"
     - fileName: ClusterLogSubscription.yaml

--- a/ztp/source-crs/ClusterLogOperGroup.yaml
+++ b/ztp/source-crs/ClusterLogOperGroup.yaml
@@ -1,11 +1,3 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-logging
-  annotations:
-    workload.openshift.io/allowed: management
----
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -13,4 +5,4 @@ metadata:
   namespace: openshift-logging
 spec:
   targetNamespaces:
-  - openshift-logging
+    - openshift-logging

--- a/ztp/source-crs/ClusterLogOperGroupNS.yaml
+++ b/ztp/source-crs/ClusterLogOperGroupNS.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    workload.openshift.io/allowed: management

--- a/ztp/ztp-policy-generator/testPolicyGenTemplate/common-ranGen.yaml
+++ b/ztp/ztp-policy-generator/testPolicyGenTemplate/common-ranGen.yaml
@@ -23,7 +23,7 @@ spec:
     - fileName: PaoSubscription.yaml
       policyName: "pao-sub-policy"
       spec:
-      # Changing the channel value will upgrade/downgrade the operator installed version.
+        # Changing the channel value will upgrade/downgrade the operator installed version.
         channel: "4.8"
     - fileName: PaoSubscriptionNS.yaml
       policyName: "pao-sub-policy"

--- a/ztp/ztp-policy-generator/testPolicyGenTemplate/common-ranGen.yaml
+++ b/ztp/ztp-policy-generator/testPolicyGenTemplate/common-ranGen.yaml
@@ -31,6 +31,8 @@ spec:
       policyName: "pao-sub-policy"
     - fileName: PaoSubscriptionCatalogSource.yaml
       policyName: "pao-sub-policy"
+    - fileName: ClusterLogOperGroupNS.yaml
+      policyName: "log-sub-policy"
     - fileName: ClusterLogOperGroup.yaml
       policyName: "log-sub-policy"
     - fileName: ClusterLogSubscription.yaml


### PR DESCRIPTION
Policy generator looks for single document `yaml` files when parsing `PolicyGenTemplate`, this pr splits the namespace creation in the `ClusterLogOperGroup.yaml` to it's own file `ClusterLogOperGroupNS.yaml` to fix errors that arise when policy gen renders the output