### PR TITLE
ztp: Perform test policy generation for 'make ci-job'

### DIFF
--- a/ztp/Makefile
+++ b/ztp/Makefile
@@ -2,8 +2,8 @@ POLICYGEN_DIR := ./ztp-policy-generator/kustomize/plugin/policyGenerator/v1/poli
 
 export GOFLAGS := $(if $(GOFLAGS),$(GOFLAGS),-mod=vendor)
 
-.PHONY: ci-job govet gotest
-ci-job: govet gotest
+.PHONY: ci-job govet gotest testPolicygen
+ci-job: govet gotest testPolicygen
 
 govet:
 	@echo "ZTP: Running 'go vet'"
@@ -12,3 +12,6 @@ govet:
 gotest:
 	@echo "ZTP: Running 'go test'"
 	go test $(POLICYGEN_DIR)/...
+
+testPolicygen:
+	$(MAKE) -C ./ztp-policy-generator generate-all

--- a/ztp/ztp-policy-generator/Makefile
+++ b/ztp/ztp-policy-generator/Makefile
@@ -1,0 +1,11 @@
+.PHONY: build generate-policy generate-crs
+build:
+	./hack/build.sh
+
+generate-policy:
+	./hack/generate-policy.sh
+
+generate-crs:
+	./hack/generate-crs.sh
+
+generate-all: generate-policy generate-crs

--- a/ztp/ztp-policy-generator/hack/build.sh
+++ b/ztp/ztp-policy-generator/hack/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. $(dirname $0)/common.sh
+
+cd "${PLUGINPATH}"
+go build -o $PLUGINBIN

--- a/ztp/ztp-policy-generator/hack/common.sh
+++ b/ztp/ztp-policy-generator/hack/common.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+pushd "$(dirname "$0")/.." >&2
+
+function finish {
+    popd >&2
+}
+trap finish EXIT
+
+GOPATH="${GOPATH:-~/go}"
+export GOFLAGS="${GOFLAGS:-"-mod=vendor"}"
+
+export PATH=$PATH:$GOPATH/bin
+
+PLUGINPATH=kustomize/plugin/policyGenerator/v1/policygenerator/
+PLUGINBIN=PolicyGenerator
+
+getKustomize() {
+    local kustomize_version=$1
+    local kustomize_dir=/tmp/policygenKustomize
+    kustomize=$kustomize_dir/kustomize
+    if [[ -x $kustomize ]]; then
+        echo "Found cached kustomize at $kustomize" >&2
+    else
+        echo "Installing kustomize $kustomize_version into $kustomize_dir" >&2
+        [[ -d $kustomize_dir ]] || mkdir -p $kustomize_dir >&2
+        pushd $kustomize_dir >&2
+        set +e
+        curl -m 600 -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
+          | bash -s $kustomize_version >&2
+        set -e
+        popd >&2
+    fi
+    # Log the version of kustomize we found
+    $kustomize version >&2
+    echo $kustomize
+}

--- a/ztp/ztp-policy-generator/hack/generate-crs.sh
+++ b/ztp/ztp-policy-generator/hack/generate-crs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+. $(dirname $0)/common.sh
+
+PGTDIR=testPolicyGenTemplate
+cp -a $PGTDIR $PGTDIR.backup
+
+restorePgt() {
+    rm -rf $PGTDIR
+    mv $PGTDIR.backup $PGTDIR
+}
+trap restorePgt EXIT
+
+sed -i -e 's/policyName: ".*"/policyName: ""/' testPolicyGenTemplate/*
+./hack/generate-policy.sh

--- a/ztp/ztp-policy-generator/hack/generate-policy.sh
+++ b/ztp/ztp-policy-generator/hack/generate-policy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. $(dirname $0)/common.sh
+./hack/build.sh
+
+XDG_CONFIG_HOME=./ $(getKustomize) build --enable-alpha-plugins


### PR DESCRIPTION
This ensures that the example policy xan generate both policy-wrapped
CRs and non-wrapped CRs.

Does not do any chexk for correctness; just success/fail

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
