### PR TITLE
ztp: fixes issue when adding more clusters to a siteconfig

### DIFF
--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/resources/cluster-crs.yaml
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/resources/cluster-crs.yaml
@@ -42,7 +42,6 @@ spec:
     name: siteconfig.Spec.Clusters.ClusterName
     version: v1beta1
   clusterName: siteconfig.Spec.Clusters.ClusterName
-  installed: false
   platform:
     agentBareMetal:
       agentSelector:


### PR DESCRIPTION
This fixes an issue when you already have a SiteConfig with some clusters deployed and you want to add a new cluster to that same SiteConfig. Without this change in the ClusterDeployment when the policygen tool renders the yaml files it will render the ClusterDeployments with `installed: false` that will cause a validation webhook from Hive to fail:

~~~sh
The ClusterDeployment "cnfdb1" is invalid: spec.installed: Invalid value: false: cannot make uninstalled once installed

Traceback (most recent call last):
  File "watcher.py", line 100, in __init__
    check=True)
  File "/usr/lib64/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['oc', 'apply', '-f', '/tmp/tmpyjcaw7de/update/customResource/telco-5g-lab/cnfdb1.yaml']' returned non-zero exit status 1.
ztp-hooks.watcher 2021-09-22 12:32:50 UTC [ERROR]             [watcher:160]: Exception by ApiResponseParser: Failed to apply target manifests
Traceback (most recent call last):
  File "watcher.py", line 100, in __init__
    check=True)
  File "/usr/lib64/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['oc', 'apply', '-f', '/tmp/tmpyjcaw7de/update/customResource/telco-5g-lab/cnfdb1.yaml']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "watcher.py", line 148, in __init__
    OcWrapper('apply', out_upd_path)
  File "watcher.py", line 109, in __init__
    raise Exception(f"Failed to {action} target manifests")
Exception: Failed to apply target manifests
~~~

Since the `installed` parameter is optional we can unset it and the apply operation will not fail.