### PR TITLE
Bug 2009660:cnf-tests:add mlockall arg to cyclictest runner

### DIFF
--- a/cnf-tests/pod-utils/cyclictest-runner/main.go
+++ b/cnf-tests/pod-utils/cyclictest-runner/main.go
@@ -42,6 +42,7 @@ func main() {
 		"-a", selfCPUs.String(),
 		"-h", *histogram,
 		"-i", strconv.Itoa(*interval),
+		"--mlockall",
 		"--quiet",
 	}
 


### PR DESCRIPTION
It is recommended to run cyclictest with the --mlockall flag in order to lock current and future memory allocations to prevent being paged out.
Same done here:https://github.com/redhat-nfvpe/container-perf-tools/blob/f641d725ffa694b735561b837abc4219753c93d8/cyclictest/cmd.sh#L94

Signed-off-by: Talor Itzhak <titzhak@redhat.com>