### PR TITLE
Bug 2006675:cnf-tests: cyclictest and hwlat recieve start delay arg as an integer

### DIFF
--- a/cnf-tests/pod-utils/cyclictest-runner/main.go
+++ b/cnf-tests/pod-utils/cyclictest-runner/main.go
@@ -19,7 +19,7 @@ func main() {
 	duration := flag.String("duration", "15s", "specify a length for the test run. Append 'm', 'h', or 'd' to specify minutes, hours or days.")
 	histogram := flag.String("histogram", "30", "dump a latency histogram to stdout after the run US is the max latency time to be be tracked in microseconds")
 	interval := flag.Int("interval", 1000, "base interval of thread in us default=1000")
-	cyclictestStartDelay := flag.Duration("cyclictest-start-delay", 0, "delay in second before running the cyclictest binary")
+	cyclictestStartDelay := flag.Int("cyclictest-start-delay", 0, "delay in second before running the cyclictest binary")
 
 	flag.Parse()
 
@@ -33,7 +33,9 @@ func main() {
 		klog.Fatalf("failed to print node information: %v", err)
 	}
 
-	time.Sleep(*cyclictestStartDelay)
+	if *cyclictestStartDelay > 0 {
+		time.Sleep(time.Duration(*cyclictestStartDelay) * time.Second)
+	}
 
 	cyclictestArgs := []string{
 		"-D", *duration,

--- a/cnf-tests/pod-utils/hwlatdetect-runner/main.go
+++ b/cnf-tests/pod-utils/hwlatdetect-runner/main.go
@@ -22,7 +22,7 @@ func main() {
 	duration := flag.String("duration", "15s", "total time to test for hardware latency: <n>{smdw}")
 	window := flag.Duration("window", time.Microsecond*10000000, "time between samples: <n>{usmss}")
 	width := flag.Duration("width", time.Microsecond*950000, "time to actually measure: <n>{usmss}")
-	hwlatdetectStartDelay := flag.Duration("hwlatdetect-start-delay", 0, "delay in second before running the hwlatdetect binary")
+	hwlatdetectStartDelay := flag.Int("hwlatdetect-start-delay", 0, "delay in second before running the hwlatdetect binary")
 
 	flag.Parse()
 
@@ -31,7 +31,9 @@ func main() {
 		klog.Fatalf("failed to print node information: %v", err)
 	}
 
-	time.Sleep(*hwlatdetectStartDelay)
+	if *hwlatdetectStartDelay > 0 {
+		time.Sleep(time.Duration(*hwlatdetectStartDelay) * time.Second)
+	}
 
 	hwlatdetectArgs := []string{
 		hwlatdetectBinary,


### PR DESCRIPTION
All runners need to get the start delay argument as an integer value.
It makes more sense to get that arg as a Duration, but since oslat is already getting the start delay argument as an integer value, we prefer to keep on backward compatibility.