### PR TITLE
ztp: Bug 2006035: Backport rv field jsonpath

### DIFF
--- a/ztp/resource-generator/src/get-pre-sync-rv.sh
+++ b/ztp/resource-generator/src/get-pre-sync-rv.sh
@@ -2,7 +2,7 @@
 
 CM=$(oc get configmap/rv &> /dev/null)
 if (( $? == 0 )); then
-  RV=$( oc get configmap/rv -ojson | jq -rM '.metadata.resourceVersion' )
+  RV=$( oc get configmap/rv -ojson | jq -rM '.data.sitesResourceVersion' )
   echo "ztp-hooks.postsync $(date -R) INFO [post-sync-entrypoint] Retrieved RAN sites resourceVersion $RV" >> /proc/1/fd/2
   echo $RV
 else


### PR DESCRIPTION
This is a backport of the following fix:
    ztp: Bug 2000726: fix rv data name and path
    
    The post-sync resource hook was failing due to an expired resource version.
    The reason: mistakenly initialized the resource RV from the config map RV
    instead of its data.
Original commit: 8f962c4