### PR TITLE
[ztp] Include clusterVersion resource-cr to manage cluster's lifecycle via ZTP flow

### DIFF
--- a/ztp/source-crs/ClusterVersion.yaml
+++ b/ztp/source-crs/ClusterVersion.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: $name
+spec:
+  channel: $channel
+  clusterID: $clusterid
+  desiredUpdate:
+    force: false
+    version: $version


### PR DESCRIPTION
Hi,

This PR intends to find a way to manage spoke's cluster lifecycle following the ZTP flow. Basically, we are including a new source-crs that applies changes via RHACM policy to the clusterVersion version object.

A valid example is shown below. This policy must be linked to a cluster specific policy since the clusterID is a required and specific value.

```yaml
    - fileName: ClusterVersion.yaml
      policyName: "cluster-lifecycle"
      metadata:
        name: "version"
      spec:
       channel: stable-4.8
       clusterID: 2c0a1c32-dd31-4ee8-b983-2d84bbb557bd
       desiredUpdate:
         version: 4.8.12
```

An enhancement to this policy I can imagine is that this policy is automatically created from the siteconfig CR. So far we have a global value that sets the version of OCP for all the clusters in the same siteconfig. This policy can be created automatically by the policy-generator tool when user includes/overrides the global OCP version per cluster.

Signed-off-by: Alberto Losada <alosadag@redhat.com>