### PR TITLE
[release-4.8] Bug 2008246: ztp: update the default channel in StorageSubscription source CR

### DIFF
--- a/ztp/source-crs/StorageSubscription.yaml
+++ b/ztp/source-crs/StorageSubscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: local-storage-operator
   namespace: openshift-local-storage
 spec:
-  channel: "4.7"
+  channel: "4.8"
   installPlanApproval: Automatic
   name: local-storage-operator
   source: redhat-operators


### PR DESCRIPTION
The default subscribed channel of StorageSubscription CR for release-4.8
branch should be 4.8.

Signed-off-by: Angie Wang <angwang@redhat.com>