### PR TITLE
infra: reduce feature-wait attempts

### DIFF
--- a/hack/feature-wait.sh
+++ b/hack/feature-wait.sh
@@ -13,7 +13,7 @@ if [ "$FEATURES" == "" ]; then
 fi
 
 ATTEMPTS=0
-MAX_ATTEMPTS=200
+MAX_ATTEMPTS=30
 all_ready=false
 export TEST_SUITES="validationsuite"
 export FAIL_FAST="-ginkgo.failFast"


### PR DESCRIPTION
currently validation suite takes about ~2minutes.
reducing to 30 rounds, to give ~1 hour of wait time
