### PR TITLE
cnf-tests: rename the gatekeeper deployment

### DIFF
--- a/cnf-tests/testsuites/pkg/utils/consts.go
+++ b/cnf-tests/testsuites/pkg/utils/consts.go
@@ -128,7 +128,7 @@ const (
 	// GatekeeperControllerDeploymentName contains the name of the gatekeeper-controller-manager deployment
 	GatekeeperControllerDeploymentName = "gatekeeper-controller-manager"
 	// GatekeeperOperatorDeploymentName contains the name of the gatekeeper-operator-controller-manager deployment
-	GatekeeperOperatorDeploymentName = "gatekeeper-operator-controller-manager"
+	GatekeeperOperatorDeploymentName = "gatekeeper-operator-controller"
 	// GatekeeperTestingNamespace is the namespace for resources in this test
 	GatekeeperTestingNamespace = "gatekeeper-testing"
 	// GatekeeperMutationIncludedNamespace is a test namespace that includes mutation


### PR DESCRIPTION
Deployment name needs to be change. The actual name in the
gk operator is: gatekeeper-operator-controller
https://github.com/gatekeeper/gatekeeper-operator/blob/master/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml#L287

