### PR TITLE
cnf-tests: update image version in images.json

### DIFF
--- a/cnf-tests/mirror/images.json
+++ b/cnf-tests/mirror/images.json
@@ -1,11 +1,11 @@
 [
     {
         "registry": "quay.io/openshift-kni/",
-        "image": "cnf-tests:4.8"
+        "image": "cnf-tests:4.9"
     },
     {
         "registry": "quay.io/openshift-kni/",
-        "image": "dpdk:4.8"
+        "image": "dpdk:4.9"
     }
 ]
 


### PR DESCRIPTION
images.json file is being used by the mirror.go program as a default value for mirroring the image version.
this PR updates the version written in the json from 4.8 to 4.9.
fix #761 