### PR TITLE
ztp: add local volume provisioning

### DIFF
--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/group-du-sno-ranGen.yaml
@@ -75,3 +75,5 @@ spec:
         name: 04-accelerated-container-startup-master
         labels:
           machineconfiguration.openshift.io/role: master
+    - fileName: StorageLV.yaml
+      policyName: "local-disks-policy"

--- a/ztp/source-crs/StorageLV.yaml
+++ b/ztp/source-crs/StorageLV.yaml
@@ -1,0 +1,55 @@
+apiVersion: "local.storage.openshift.io/v1"
+kind: "LocalVolume"
+metadata:
+  name: "local-disks"
+  namespace: "openshift-local-storage" 
+spec:
+  logLevel: Normal
+  managementState: Managed
+  storageClassDevices:
+    - storageClassName: "fs-sc" 
+      volumeMode: Filesystem
+      fsType: xfs 
+      # The below must be adjusted to the hardware
+      devicePaths: 
+        - /dev/sdb
+---
+## How to verify
+## 1. Create a PVC
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: local-pvc-name 
+# spec:
+#   accessModes:
+#   - ReadWriteOnce
+#   volumeMode: Filesystem 
+#   resources:
+#     requests:
+#       storage: 100Gi 
+#   storageClassName: fs-sc 
+#---
+## 2. Create a pod that mounts it
+# apiVersion: v1
+# kind: Pod
+# metadata:
+#   labels:
+#     run: busybox
+#   name: busybox
+# spec:
+#   containers:
+#   - image: quay.io/quay/busybox:latest
+#     name: busybox
+#     resources: {}
+#     command: ["/bin/sh", "-c", "sleep infinity"]
+#     volumeMounts:
+#     - name: local-pvc 
+#       mountPath: /data
+#   volumes:
+#   - name: local-pvc
+#     persistentVolumeClaim:
+#       claimName: local-pvc-name
+#   dnsPolicy: ClusterFirst
+#   restartPolicy: Always
+## 3. Run the pod on the cluster and verify the size and access of the `/data` mount
+

--- a/ztp/source-crs/StorageSubscription.yaml
+++ b/ztp/source-crs/StorageSubscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: local-storage-operator
   namespace: openshift-local-storage
 spec:
-  channel: "4.7"
+  channel: "4.9"
   installPlanApproval: Automatic
   name: local-storage-operator
   source: redhat-operators


### PR DESCRIPTION
Add LocalVolume provisioning manifest to source-crs.
Add an example of configuring a PersistentVolumeClaim
and using it from within a pod.
Bump operator to 4.9
/assign @imiller0 
/cc @serngawy @lack @browsell 