### PR TITLE
ztp: Add sriov-fec operator installation manifests

### DIFF
--- a/ztp/source-crs/AcceleratorsNS.yaml
+++ b/ztp/source-crs/AcceleratorsNS.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vran-acceleration-operators

--- a/ztp/source-crs/AcceleratorsOperGroup.yaml
+++ b/ztp/source-crs/AcceleratorsOperGroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: vran-operators 
+  namespace: vran-acceleration-operators 
+spec:
+  targetNamespaces:
+  - vran-acceleration-operators

--- a/ztp/source-crs/AcceleratorsSubscription.yaml
+++ b/ztp/source-crs/AcceleratorsSubscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sriov-fec-subscription 
+  namespace: vran-acceleration-operators 
+spec:
+  channel: stable 
+  name: sriov-fec 
+  source: certified-operators 
+  sourceNamespace: openshift-marketplace
+
+


### PR DESCRIPTION
Adds installation manifests for OpenNESS SR-IOV
Operator for Wireless FEC Accelerators.
The deployment is disabled by default (not added to
the DU policy generation template).
/assign @imiller0 
/cc @serngawy @lack @browsell 