### PR TITLE
ztp: Add amq interconnect operator for ptp operator fast event requirement

### DIFF
--- a/ztp/source-crs/AmqInstance.yaml
+++ b/ztp/source-crs/AmqInstance.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: interconnectedcloud.github.io/v1alpha1
+kind: Interconnect
+metadata:
+  name: amq-router
+  namespace: amq-router
+spec:
+  deploymentPlan:
+    placement: Any
+    role: interior
+    size: 1

--- a/ztp/source-crs/AmqSubscription.yaml
+++ b/ztp/source-crs/AmqSubscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: amq7-interconnect-subscription
+  namespace: amq-router
+spec:
+  channel: 1.10.x
+  name:  amq7-interconnect-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/ztp/source-crs/AmqSubscriptionNS.yaml
+++ b/ztp/source-crs/AmqSubscriptionNS.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: amq-router
+  annotations:
+    workload.openshift.io/allowed: management

--- a/ztp/source-crs/AmqSubscriptionOperGroup.yaml
+++ b/ztp/source-crs/AmqSubscriptionOperGroup.yaml
@@ -1,8 +1,8 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: ptp-operators
-  namespace: openshift-ptp
+  name: amq-router
+  namespace: amq-router
 spec:
   targetNamespaces:
-  - openshift-ptp
+  - amq-router


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
AMQ interconnect operator is a messaging router, required for PTP when the fast event publishing option is enabled in the ptp config.
This operator runs under its own namespace and allows event publisher's/consumer's to connect to transport hosts and produce/consume messages.