### PR TITLE
Bug 2017547: ztp: Support SiteConfig default values

### DIFF
--- a/ztp/policygenerator/siteConfig/siteConfig.go
+++ b/ztp/policygenerator/siteConfig/siteConfig.go
@@ -107,9 +107,38 @@ type Clusters struct {
 	ProxySettings          ProxySettings     `yaml:"proxy,omitempty"`
 }
 
+// Provide custom YAML unmarshal for Clusters which provides default values
+func (rv *Clusters) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type ClusterDefaulted Clusters
+	var defaults = ClusterDefaulted{
+		ClusterType:    "standard",
+		ClusterProfile: "none",
+		NetworkType:    "OVNKubernetes",
+		NumMasters:     1,
+	}
+
+	out := defaults
+	err := unmarshal(&out)
+	*rv = Clusters(out)
+	return err
+}
+
 type DiskEncryption struct {
 	Type string       `yaml:"type"`
 	Tang []TangConfig `yaml:"tang"`
+}
+
+// Provide custom YAML unmarshal for DiskEncryption which provides default values
+func (rv *DiskEncryption) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type ValueDefaulted DiskEncryption
+	var defaults = ValueDefaulted{
+		Type: "none",
+	}
+
+	out := defaults
+	err := unmarshal(&out)
+	*rv = DiskEncryption(out)
+	return err
 }
 
 type ProxySettings struct {
@@ -137,6 +166,20 @@ type Nodes struct {
 	InstallerArgs          string                 `yaml:"installerArgs"`
 	IgnitionConfigOverride string                 `yaml:"ignitionConfigOverride"`
 	Role                   string                 `yaml:"role"`
+}
+
+// Provide custom YAML unmarshal for Nodes which provides default values
+func (rv *Nodes) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type ValueDefaulted Nodes
+	var defaults = ValueDefaulted{
+		BootMode: "UEFI",
+		Role:     "master",
+	}
+
+	out := defaults
+	err := unmarshal(&out)
+	*rv = Nodes(out)
+	return err
 }
 
 // MachineNetwork

--- a/ztp/policygenerator/siteConfig/siteConfigBuilder.go
+++ b/ztp/policygenerator/siteConfig/siteConfigBuilder.go
@@ -53,10 +53,6 @@ func (scbuilder *SiteConfigBuilder) Build(siteConfigTemp SiteConfig) (map[string
 		if cluster.ClusterName == "" {
 			return clustersCRs, errors.New("Error: Missing cluster name at site " + siteConfigTemp.Metadata.Name)
 		}
-		if cluster.NetworkType == "" {
-			cluster.NetworkType = "OVNKubernetes"
-			siteConfigTemp.Spec.Clusters[id].NetworkType = "OVNKubernetes"
-		}
 		if cluster.NetworkType != "OpenShiftSDN" && cluster.NetworkType != "OVNKubernetes" {
 			return clustersCRs, errors.New("Error: networkType must be either OpenShiftSDN or OVNKubernetes " + siteConfigTemp.Metadata.Name)
 		}

--- a/ztp/policygenerator/siteConfig/siteConfig_test.go
+++ b/ztp/policygenerator/siteConfig/siteConfig_test.go
@@ -1,0 +1,112 @@
+package siteConfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+// Test cases for default values on fields in the SiteConfig.Clusters[] entries
+func TestClusterDefaults(t *testing.T) {
+	input := `
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+spec:
+  clusters:
+  - clusterName: "not-default-values"
+    clusterType: "sno"
+    clusterProfile: "du"
+    networkType: "OpenShiftSDN"
+    numMasters: 2
+  - clusterName: "expect-defaults"
+  - clusterName: "set-to-defaults"
+    clusterType: "standard"
+    clusterProfile: "none"
+    networkType: "OVNKubernetes"
+    numMasters: 1
+`
+	siteConfig := SiteConfig{}
+	_ = yaml.Unmarshal([]byte(input), &siteConfig)
+
+	// Validate ClusterType
+	assert.Equal(t, siteConfig.Spec.Clusters[0].ClusterType, "sno")
+	assert.Equal(t, siteConfig.Spec.Clusters[1].ClusterType, "standard")
+	assert.Equal(t, siteConfig.Spec.Clusters[2].ClusterType, "standard")
+
+	// Validate ClusterProfile
+	assert.Equal(t, siteConfig.Spec.Clusters[0].ClusterProfile, "du")
+	assert.Equal(t, siteConfig.Spec.Clusters[1].ClusterProfile, "none")
+	assert.Equal(t, siteConfig.Spec.Clusters[2].ClusterProfile, "none")
+
+	// Validate NetworkType
+	assert.Equal(t, siteConfig.Spec.Clusters[0].NetworkType, "OpenShiftSDN")
+	assert.Equal(t, siteConfig.Spec.Clusters[1].NetworkType, "OVNKubernetes")
+	assert.Equal(t, siteConfig.Spec.Clusters[2].NetworkType, "OVNKubernetes")
+
+	// Validate NumMasters
+	assert.Equal(t, siteConfig.Spec.Clusters[0].NumMasters, uint8(2))
+	assert.Equal(t, siteConfig.Spec.Clusters[1].NumMasters, uint8(1))
+	assert.Equal(t, siteConfig.Spec.Clusters[2].NumMasters, uint8(1))
+}
+
+// Test cases for default values on fields in the SiteConfig.Clusters[].Nodes[]
+// entries
+func TestNodeDefaults(t *testing.T) {
+	input := `
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+spec:
+  clusters:
+  - clusterName: "just-for-testing-node-defaults"
+    nodes:
+    - hostName: "node0-not-default"
+      bootMode: "legacy"
+      role: "worker"
+    - hostName: "node1-default"
+    - hostName: "node2-explicit"
+      bootMode: "UEFI"
+      role: "master"
+`
+	siteConfig := SiteConfig{}
+	_ = yaml.Unmarshal([]byte(input), &siteConfig)
+
+	// Validate BootMode
+	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[0].BootMode, "legacy")
+	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[1].BootMode, "UEFI")
+	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[2].BootMode, "UEFI")
+
+	// Validate Role
+	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[0].Role, "worker")
+	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[1].Role, "master")
+	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[2].Role, "master")
+}
+
+// Test cases for default values on fields in the
+// SiteConfig.Clusters[].DiskEncryption entries
+func TestNodeDiskEncryptionDefaults(t *testing.T) {
+	input := `
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+spec:
+  clusters:
+  - clusterName: "user"
+    diskEncryption:
+      type: nbde
+  - clusterName: "defaults"
+    # Without further content under diskEncryptionthe type does not get populated
+    diskEncryption:
+      type:
+  - clusterName: "explicit"
+    diskEncryption:
+      type: none
+`
+	siteConfig := SiteConfig{}
+	_ = yaml.Unmarshal([]byte(input), &siteConfig)
+
+	// Validate ClusterType
+	assert.Equal(t, siteConfig.Spec.Clusters[0].DiskEncryption.Type, "nbde")
+	assert.Equal(t, siteConfig.Spec.Clusters[1].DiskEncryption.Type, "none")
+	assert.Equal(t, siteConfig.Spec.Clusters[2].DiskEncryption.Type, "none")
+
+}


### PR DESCRIPTION
The SiteConfig CRD specifies default values for multiple fields. Ensure
that PolicyGen correctly handles these defaults when unmarshaling the
user CR.

Signed-off-by: Ian Miller <imiller@redhat.com>