### PR TITLE
ztp: update cluster logging subscription to stable

### DIFF
--- a/ztp/source-crs/ClusterLogSubscription.yaml
+++ b/ztp/source-crs/ClusterLogSubscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "5.0"
+  channel: "stable"
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Update the default subscription channel for cluster logging to stable.

/cc @vitus133 
Signed-off-by: Angie Wang <angwang@redhat.com>