### PR TITLE
Fix the source CR PaoSubscriptionNS

### DIFF
--- a/ztp/source-crs/PaoSubscriptionNS.yaml
+++ b/ztp/source-crs/PaoSubscriptionNS.yaml
@@ -6,4 +6,3 @@ metadata:
     workload.openshift.io/allowed: management
   labels:
     openshift.io/cluster-monitoring: "true"
-spec: {}


### PR DESCRIPTION
The source CR PaoSubscriptionNS is included in pao-sub-policy policy.
Fix the issue in the source CR that causes the policy complaint status
to flip between Compliant and NonCompliant.

Signed-off-by: Angie Wang <angwang@redhat.com>