### PR TITLE
ztp: Create a fixed ACM inform policy

### DIFF
--- a/ztp/policygenerator/resources/acm-policy-du-platform-check-template.yaml
+++ b/ztp/policygenerator/resources/acm-policy-du-platform-check-template.yaml
@@ -1,0 +1,185 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: du-platform-check
+  labels:
+    name: du-platform-check
+---
+# This inform policy verifies the following conditions:
+#     MCP has required MCs applied
+#     Sriov network operator is available and ready
+#     SriovNetworkNodeState is synced
+#     Ptp operator is available and ready
+#     Pao operator is available and ready
+#     kube-apiserver pod is running
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: du-platform-check-policy
+  namespace: du-platform-check
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: du-platform-check-policy-check
+        spec:
+          remediationAction: inform
+          severity: low
+          namespaceselector:
+            exclude:
+                - kube-*
+            include:
+                - '*'
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: machineconfiguration.openshift.io/v1
+                kind: MachineConfigPool
+                metadata:
+                  labels:
+                    pools.operator.machineconfiguration.openshift.io/master: ""
+                  name: master
+                spec:
+                  machineConfigSelector:
+                    matchLabels:
+                      machineconfiguration.openshift.io/role: master
+                status:
+                  readyMachineCount: 1
+                  updatedMachineCount: 1
+                  unavailableMachineCount: 0
+                  conditions:
+                    - type: Updated
+                      status: "True"
+                    - type: Updating
+                      status: "False"
+                  configuration:
+                    source:
+                      - apiVersion: machineconfiguration.openshift.io/v1
+                        kind: MachineConfig
+                        name: container-mount-namespace-and-kubelet-conf
+                      - apiVersion: machineconfiguration.openshift.io/v1
+                        kind: MachineConfig
+                        name: load-sctp-module
+                      - apiVersion: machineconfiguration.openshift.io/v1
+                        kind: MachineConfig
+                        name: 02-master-workload-partitioning
+                      - apiVersion: machineconfiguration.openshift.io/v1
+                        kind: MachineConfig
+                        name: 04-accelerated-container-startup-master
+                      - apiVersion: machineconfiguration.openshift.io/v1
+                        kind: MachineConfig
+                        name: 05-chronyd-dynamic-master
+                      - apiVersion: machineconfiguration.openshift.io/v1
+                        kind: MachineConfig
+                        name: 50-performance-openshift-node-performance-profile
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: sriov-network-operator
+                  namespace: openshift-sriov-network-operator
+                status:
+                  conditions:
+                    - type: Available
+                      status: "True"
+                      reason: MinimumReplicasAvailable
+                  availableReplicas: 1
+                  readyReplicas: 1
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: sriovnetwork.openshift.io/v1
+                kind: SriovNetworkNodeState
+                metadata:
+                  namespace: openshift-sriov-network-operator
+                status:
+                  syncStatus: Succeeded
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: ptp-operator
+                  namespace: openshift-ptp
+                status:
+                  conditions:
+                    - type: Available
+                      status: "True"
+                      reason: MinimumReplicasAvailable
+                  availableReplicas: 1
+                  readyReplicas: 1
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: performance-operator
+                  namespace: openshift-performance-addon-operator
+                status:
+                  conditions:
+                    - type: Available
+                      status: "True"
+                      reason: MinimumReplicasAvailable
+                  availableReplicas: 1
+                  readyReplicas: 1
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: kube-apiserver-operator
+                  namespace: openshift-kube-apiserver-operator
+                status:
+                  conditions:
+                    - type: Available
+                      status: "True"
+                  availableReplicas: 1
+                  readyReplicas: 1
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  labels:
+                    apiserver: "true"
+                    app: openshift-kube-apiserver
+                  namespace: openshift-kube-apiserver
+                status:
+                  conditions:
+                    - type: Ready
+                      status: "True"
+                  phase: Running
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: du-platform-check-policy-placementbinding
+  namespace: du-platform-check
+placementRef:
+  name: du-platform-check-policy-placementrule
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+- name: du-platform-check-policy
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: du-platform-check-policy-placementrule
+  namespace: du-platform-check
+spec:
+  clusterSelector:
+    matchExpressions:
+      - key: common
+        operator: In
+        values: ["true"]


### PR DESCRIPTION
At the initial stage, this fixed inform policy is built to measure
some conditions that cannot be captured via the configuration policies
which are applied in the ztp pipeline. It should be used along with
configuration policies to determine if ztp of a cluster is completed
or not.

Jira: https://issues.redhat.com/browse/CNF-2959
