### PR TITLE
cnf-tests: bump image mirror to 4.10

### DIFF
--- a/cnf-tests/mirror/images.json
+++ b/cnf-tests/mirror/images.json
@@ -1,11 +1,11 @@
 [
     {
         "registry": "quay.io/openshift-kni/",
-        "image": "cnf-tests:4.9"
+        "image": "cnf-tests:4.10"
     },
     {
         "registry": "quay.io/openshift-kni/",
-        "image": "dpdk:4.9"
+        "image": "dpdk:4.10"
     }
 ]
 


### PR DESCRIPTION
Signed-off-by: Sebastian Sch <sebassch@gmail.com>