### PR TITLE
ztp:Add Ptp operator config to enable fast event

### DIFF
--- a/ztp/source-crs/PtpOperatorConfigForEvent.yaml
+++ b/ztp/source-crs/PtpOperatorConfigForEvent.yaml
@@ -1,0 +1,10 @@
+apiVersion: ptp.openshift.io/v1
+kind: PtpOperatorConfig
+metadata:
+  name: default
+  namespace: openshift-ptp
+spec:
+  daemonNodeSelector: {}
+  ptpEventConfig:
+    enableEventPublisher: true
+    transportHost: "amqp://amq-router.amq-router.svc.cluster.local"


### PR DESCRIPTION
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>
Adding PTP Operator Config policy to enable or disable fast events.