### PR TITLE
features: Fix gatekeeper deployment

### DIFF
--- a/feature-configs/deploy/gatekeeper/config.yaml
+++ b/feature-configs/deploy/gatekeeper/config.yaml
@@ -3,13 +3,5 @@ kind: Gatekeeper
 metadata:
   name: gatekeeper
 spec:
-  audit:
-    logLevel: INFO
-    replicas: 1
-  image:
-    image: registry.redhat.io/rhacm2/gatekeeper-rhel8@sha256:63bd1bbb6f825fc45f2c7dc71f5f2bf118621a6b5dad8de4ad4e50eb5c720118
   mutatingWebhook: Enabled
   validatingWebhook: Enabled
-  webhook:
-    logLevel: INFO
-    replicas: 1


### PR DESCRIPTION
There is no need anymore to request a specific image.

Also the gatekeeper operator add a PDB and requesting 1 replica stuck the node from being drained because there is no other instance of the webhook deployment.


Signed-off-by: Sebastian Sch <sebassch@gmail.com>