### PR TITLE
ztp: Fix typo in source-crs-builder README

### DIFF
--- a/ztp/source-crs-builder/README.md
+++ b/ztp/source-crs-builder/README.md
@@ -12,7 +12,7 @@ subdirectory follows the following conventions:
   rendered yaml identically every time it is called, provided that the
   input files remain the same (it must not include any date stamps or
   git commit hashes).  This is used both to generate the rendered
-  `../source-crs/*.yaml` and to do an inegrity check as part of the ci-job
+  `../source-crs/*.yaml` and to do an integrity check as part of the ci-job
   target which ensures the rendered yaml stays in-sync with the source
   content.
 - The directory may contain a `test.sh` which can additionally perform


### PR DESCRIPTION
Signed-off-by: Ian Miller <imiller@redhat.com>