### PR TITLE
Bug 2019181: ztp: Update PAO subscription catalog source

### DIFF
--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
@@ -39,10 +39,6 @@ spec:
       complianceType: musthave
     - fileName: PaoSubscriptionOperGroup.yaml
       policyName: "pao-sub-policy"
-    - fileName: PaoSubscriptionCatalogSource.yaml
-      policyName: "pao-sub-policy"
-      spec:
-        image: quay.io/openshift-kni/performance-addon-operator-index:4.9-snapshot
     - fileName: ClusterLogOperGroup.yaml
       policyName: "log-sub-policy"
     - fileName: ClusterLogSubscription.yaml

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/common-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/common-ranGen.yaml
@@ -22,14 +22,9 @@ spec:
       policyName: "ptp-sub-policy"
     - fileName: PaoSubscription.yaml
       policyName: "pao-sub-policy"
-      spec:
-      # Changing the channel value will upgrade/downgrade the operator installed version.
-        channel: "4.8"
     - fileName: PaoSubscriptionNS.yaml
       policyName: "pao-sub-policy"
     - fileName: PaoSubscriptionOperGroup.yaml
-      policyName: "pao-sub-policy"
-    - fileName: PaoSubscriptionCatalogSource.yaml
       policyName: "pao-sub-policy"
     - fileName: ClusterLogOperGroup.yaml
       policyName: "log-sub-policy"

--- a/ztp/ran-crd/policy-gen-template-ex.yaml
+++ b/ztp/ran-crd/policy-gen-template-ex.yaml
@@ -44,8 +44,6 @@ spec:
       policyName: "pao-sub-policy"
     - fileName: PaoSubscriptionOperGroup.yaml
       policyName: "pao-sub-policy"
-    - fileName: PaoSubscriptionCatalogSource.yaml
-      policyName: "pao-sub-policy"
 ---
 # Example for using the PolicyGenTemplate to create the CR without wrapping it to ACM policy by giving empty policyName
 apiVersion: ran.openshift.io/v1

--- a/ztp/source-crs/PaoSubscription.yaml
+++ b/ztp/source-crs/PaoSubscription.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   channel: "4.9"
   name: performance-addon-operator
-  source: performance-addon-operator
+  source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/ztp/source-crs/PaoSubscriptionCatalogSource.yaml
+++ b/ztp/source-crs/PaoSubscriptionCatalogSource.yaml
@@ -1,3 +1,5 @@
+# This CatalogSource is no longer required. The PAO operator is now available in the
+# redhat-operators catalog.
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:

--- a/ztp/source-crs/PaoSubscriptionCatalogSource.yaml
+++ b/ztp/source-crs/PaoSubscriptionCatalogSource.yaml
@@ -1,5 +1,3 @@
-# This CatalogSource is no longer required. The PAO operator is now available in the
-# redhat-operators catalog.
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:


### PR DESCRIPTION
Updating source CR for PAO subscription to use redhat-operators
catalogsource where the operator is now located.

Leaving the PaoSubscriptionCatalogSource.yaml in place to avoid breaking
any deployments that are currently using it.

Signed-off-by: bartwensley <bwensley@redhat.com>