### PR TITLE
Bug 2009233: ztp: Support complianceType override for CRs

### DIFF
--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
@@ -19,12 +19,14 @@ spec:
       policyName: "sriov-sub-policy"
     - fileName: SriovSubscriptionNS.yaml
       policyName: "sriov-sub-policy"
+      complianceType: musthave
     - fileName: SriovSubscriptionOperGroup.yaml
       policyName: "sriov-sub-policy"
     - fileName: PtpSubscription.yaml
       policyName: "ptp-sub-policy"
     - fileName: PtpSubscriptionNS.yaml
       policyName: "ptp-sub-policy"
+      complianceType: musthave
     - fileName: PtpSubscriptionOperGroup.yaml
       policyName: "ptp-sub-policy"
     - fileName: PaoSubscription.yaml
@@ -34,6 +36,7 @@ spec:
         channel: "4.9"
     - fileName: PaoSubscriptionNS.yaml
       policyName: "pao-sub-policy"
+      complianceType: musthave
     - fileName: PaoSubscriptionOperGroup.yaml
       policyName: "pao-sub-policy"
     - fileName: PaoSubscriptionCatalogSource.yaml
@@ -46,6 +49,7 @@ spec:
       policyName: "log-sub-policy"
     - fileName: StorageNS.yaml
       policyName: "storage-sub-policy"
+      complianceType: musthave
     - fileName: StorageOperGroup.yaml
       policyName: "storage-sub-policy"
     - fileName: StorageSubscription.yaml

--- a/ztp/policygenerator/policyGen/policyBuilder_test.go
+++ b/ztp/policygenerator/policyGen/policyBuilder_test.go
@@ -1,0 +1,202 @@
+package policyGen
+
+import (
+	utils "github.com/openshift-kni/cnf-features-deploy/ztp/policygenerator/utils"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func extractCRsFromPolicies(t *testing.T, policies map[string]interface{}) []utils.ObjectTemplates {
+	// The policies map contains entries such as:
+	// test1/test1-gen-sub-policy This is the one we want
+	// test1/test1-placementrules
+	// test1/test1-placementbinding
+	assert.Equal(t, len(policies), 3, "Expect a single policy with placement rule/binding for testing")
+	for key, value := range policies {
+		if strings.Contains(key, "placement") {
+			continue
+		}
+		// This is the configuration policy
+		policy := value.(utils.AcmPolicy)
+		// This is the policy-templates array
+		assert.Equal(t, len(policy.Spec.PolicyTemplates), 1)
+		// Extract the object-template from the object-definitions. The
+		// object-template contains the actual CR
+		objects := policy.Spec.PolicyTemplates[0].ObjDef.Spec.ObjectTemplates
+		// Return the first (and only) non-placement entry
+		return objects
+	}
+	return nil
+}
+
+// Test cases for override of complianceType for Namespace kinds. Namespace as the first object here.
+func TestComplianceTypeDefault(t *testing.T) {
+	input := `
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "test1"
+  namespace: "test1"
+spec:
+  bindingRules:
+    justfortest: "true"
+  sourceFiles:
+    # Create operators policies that will be installed in all clusters
+    - fileName: GenericNamespace.yaml
+      policyName: "gen-sub-policy"
+    - fileName: GenericSubscription.yaml
+      policyName: "gen-sub-policy"
+    - fileName: GenericOperatorGroup.yaml
+      policyName: "gen-sub-policy"
+`
+	// Read in the test PGT
+	pgt := utils.PolicyGenTemplate{}
+	_ = yaml.Unmarshal([]byte(input), &pgt)
+
+	// Set up the files handler to pick up local source-crs and skip any output
+	fHandler := utils.NewFilesHandler("./testData/GenericSourceFiles", "/dev/null", "/dev/null")
+	fHandler.SetResourceBaseDir("..")
+
+	// Run the PGT through the generator
+	pBuilder := NewPolicyBuilder(fHandler)
+	policies, err := pBuilder.Build(pgt)
+
+	// Validate the run
+	assert.Nil(t, err)
+	assert.NotNil(t, policies)
+
+	assert.Contains(t, policies, "test1/test1-gen-sub-policy")
+
+	objects := extractCRsFromPolicies(t, policies)
+	assert.Equal(t, len(objects), 3)
+
+	assert.Equal(t, objects[0].ComplianceType, "mustonlyhave")
+	assert.Equal(t, objects[0].ObjectDefinition["kind"], "Namespace")
+
+	assert.Equal(t, objects[1].ComplianceType, "mustonlyhave")
+	assert.Equal(t, objects[1].ObjectDefinition["kind"], "Subscription")
+
+	assert.Equal(t, objects[2].ComplianceType, "mustonlyhave")
+	assert.Equal(t, objects[2].ObjectDefinition["kind"], "OperatorGroup")
+}
+
+// Test cases for override of complianceType for Namespace kinds
+func TestNamespaceCompliance(t *testing.T) {
+	input := `
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "test1"
+  namespace: "test1"
+spec:
+  bindingRules:
+    justfortest: "true"
+  sourceFiles:
+    # Create operators policies that will be installed in all clusters
+    - fileName: GenericSubscription.yaml
+      policyName: "gen-sub-policy"
+    - fileName: GenericNamespace.yaml
+      policyName: "gen-sub-policy"
+      complianceType: "musthave"
+    - fileName: GenericOperatorGroup.yaml
+      policyName: "gen-sub-policy"
+    - fileName: GenericNamespace.yaml
+      policyName: "gen-sub-policy"
+`
+	// Read in the test PGT
+	pgt := utils.PolicyGenTemplate{}
+	_ = yaml.Unmarshal([]byte(input), &pgt)
+
+	// Set up the files handler to pick up local source-crs and skip any output
+	fHandler := utils.NewFilesHandler("./testData/GenericSourceFiles", "/dev/null", "/dev/null")
+	fHandler.SetResourceBaseDir("..")
+
+	// Run the PGT through the generator
+	pBuilder := NewPolicyBuilder(fHandler)
+	policies, err := pBuilder.Build(pgt)
+
+	// Validate the run
+	assert.Nil(t, err)
+	assert.NotNil(t, policies)
+
+	assert.Contains(t, policies, "test1/test1-gen-sub-policy")
+
+	objects := extractCRsFromPolicies(t, policies)
+	assert.Equal(t, len(objects), 4)
+
+	assert.Equal(t, objects[0].ComplianceType, "mustonlyhave")
+	assert.Equal(t, objects[0].ObjectDefinition["kind"], "Subscription")
+
+	assert.Equal(t, objects[1].ComplianceType, "musthave")
+	assert.Equal(t, objects[1].ObjectDefinition["kind"], "Namespace")
+
+	assert.Equal(t, objects[2].ComplianceType, "mustonlyhave")
+	assert.Equal(t, objects[2].ObjectDefinition["kind"], "OperatorGroup")
+
+	// We only override the first one
+	assert.Equal(t, objects[3].ComplianceType, "mustonlyhave")
+	assert.Equal(t, objects[3].ObjectDefinition["kind"], "Namespace")
+}
+
+// Test cases for override of complianceType for Namespace kinds
+func TestNamespaceComplianceMultiple(t *testing.T) {
+	input := `
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "test1"
+  namespace: "test1"
+spec:
+  bindingRules:
+    justfortest: "true"
+  sourceFiles:
+    # Create operators policies that will be installed in all clusters
+    - fileName: GenericNamespace.yaml
+      policyName: "gen-sub-policy"
+      complianceType: "musthave"
+    - fileName: GenericSubscription.yaml
+      policyName: "gen-sub-policy"
+      complianceType: "musthave"
+    - fileName: GenericOperatorGroup.yaml
+      policyName: "gen-sub-policy"
+      complianceType: "musthave"
+    - fileName: GenericNamespace.yaml
+      policyName: "gen-sub-policy"
+      complianceType: "mustonlyhave"
+`
+	// Read in the test PGT
+	pgt := utils.PolicyGenTemplate{}
+	_ = yaml.Unmarshal([]byte(input), &pgt)
+
+	// Set up the files handler to pick up local source-crs and skip any output
+	fHandler := utils.NewFilesHandler("./testData/GenericSourceFiles", "/dev/null", "/dev/null")
+	fHandler.SetResourceBaseDir("..")
+
+	// Run the PGT through the generator
+	pBuilder := NewPolicyBuilder(fHandler)
+	policies, err := pBuilder.Build(pgt)
+
+	// Validate the run
+	assert.Nil(t, err)
+	assert.NotNil(t, policies)
+
+	assert.Contains(t, policies, "test1/test1-gen-sub-policy")
+
+	objects := extractCRsFromPolicies(t, policies)
+	assert.Equal(t, len(objects), 4)
+
+	assert.Equal(t, objects[0].ComplianceType, "musthave")
+	assert.Equal(t, objects[0].ObjectDefinition["kind"], "Namespace")
+
+	assert.Equal(t, objects[1].ComplianceType, "musthave")
+	assert.Equal(t, objects[1].ObjectDefinition["kind"], "Subscription")
+
+	assert.Equal(t, objects[2].ComplianceType, "musthave")
+	assert.Equal(t, objects[2].ObjectDefinition["kind"], "OperatorGroup")
+
+	assert.Equal(t, objects[3].ComplianceType, "mustonlyhave")
+	assert.Equal(t, objects[3].ObjectDefinition["kind"], "Namespace")
+}

--- a/ztp/policygenerator/policyGen/policyHelper.go
+++ b/ztp/policygenerator/policyGen/policyHelper.go
@@ -58,3 +58,19 @@ func CheckNameLength(namespace string, name string) error {
 	}
 	return nil
 }
+
+// Create a new ObjectTemplate for the given resource with values
+// populated from the reference ACM template (pulled from
+// policyBuilder)
+func BuildObjectTemplate(resource generatedCR) utils.ObjectTemplates {
+	objTemplate := utils.ObjectTemplates{}
+
+	// BZ 2009233 Namespaces will be updated by OLM with labels and
+	// annotations. A "mustonlyhave" ACM policy will fight with OLM
+	// over these annotations/lables. Allow the user to set the
+	// compliance type to avoid this condition.
+	objTemplate.ComplianceType = resource.pgtSourceFile.ComplianceType
+	objTemplate.ObjectDefinition = resource.builtCR
+
+	return objTemplate
+}

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericNamespace.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericNamespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: generic-ns
+  annotations:
+    workload.openshift.io/allowed: management
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericOperatorGroup.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericOperatorGroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: generic-operators
+  namespace: generic-ns
+spec:
+  targetNamespaces:
+  - generic-ns

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericSubscription.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericSubscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: generic-operator-subscription
+  namespace: generic-ns
+spec:
+  channel: "4.9"
+  name: generic-operator
+  source: "redhat-operators"
+  sourceNamespace: openshift-marketplace

--- a/ztp/policygenerator/utils/filesHandler.go
+++ b/ztp/policygenerator/utils/filesHandler.go
@@ -11,10 +11,11 @@ type FilesHandler struct {
 	sourceDir string
 	tempDir   string
 	outDir    string
+	resDir    string
 }
 
 func NewFilesHandler(sourceDir string, tempDir string, outDir string) *FilesHandler {
-	return &FilesHandler{sourceDir: sourceDir, tempDir: tempDir, outDir: outDir}
+	return &FilesHandler{sourceDir: sourceDir, tempDir: tempDir, outDir: outDir, resDir: ""}
 }
 
 func (fHandler *FilesHandler) WriteFile(filePath string, content []byte) error {
@@ -51,6 +52,11 @@ func (fHandler *FilesHandler) ReadSourceFile(fileName string) ([]byte, error) {
 	return fHandler.readFile(fHandler.sourceDir + "/" + fileName)
 }
 
+// Optional override of the base directory containing the resources directory. Used for testing.
+func (fHandler *FilesHandler) SetResourceBaseDir(path string) {
+	fHandler.resDir = path
+}
+
 func (fHandler *FilesHandler) ReadResourceFile(fileName string) ([]byte, error) {
 	var dir = ""
 	var err error = nil
@@ -65,10 +71,13 @@ func (fHandler *FilesHandler) ReadResourceFile(fileName string) ([]byte, error) 
 
 	// added fail safe for test runs as `os.Executable()` will fail for tests
 	if err != nil {
-
-		dir, err = os.Getwd()
-		if err != nil {
-			return nil, err
+		if fHandler.resDir != "" {
+			dir = fHandler.resDir
+		} else {
+			dir, err = os.Getwd()
+			if err != nil {
+				return nil, err
+			}
 		}
 		ret, err = fHandler.readFile(dir + "/" + ResourcesDir + "/" + fileName)
 	}

--- a/ztp/policygenerator/utils/utils.go
+++ b/ztp/policygenerator/utils/utils.go
@@ -32,11 +32,25 @@ type PolicyGenTempSpec struct {
 }
 
 type SourceFile struct {
-	FileName   string                 `yaml:"fileName"`
-	PolicyName string                 `yaml:"policyName,omitempty"`
-	Metadata   MetaData               `yaml:"metadata,omitempty"`
-	Spec       map[string]interface{} `yaml:"spec,omitempty"`
-	Data       map[string]interface{} `yaml:"data,omitempty"`
+	FileName       string                 `yaml:"fileName"`
+	PolicyName     string                 `yaml:"policyName,omitempty"`
+	ComplianceType string                 `yaml:"complianceType,omitempty"`
+	Metadata       MetaData               `yaml:"metadata,omitempty"`
+	Spec           map[string]interface{} `yaml:"spec,omitempty"`
+	Data           map[string]interface{} `yaml:"data,omitempty"`
+}
+
+// Provide custom YAML unmarshal for SourceFile which provides default values
+func (rv *SourceFile) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type Defaulted SourceFile
+	var defaults = Defaulted{
+		ComplianceType: "mustonlyhave",
+	}
+
+	out := defaults
+	err := unmarshal(&out)
+	*rv = SourceFile(out)
+	return err
 }
 
 type AcmPolicy struct {

--- a/ztp/ran-crd/policy-gen-template-crd.yaml
+++ b/ztp/ran-crd/policy-gen-template-crd.yaml
@@ -74,6 +74,13 @@ spec:
                           Note; Having empty policyName OR not assign it will make the generator
                                 to create only the CR without adding the ACM policy template.
                         type: string
+                      complianceType:
+                        description: |
+                          The complianceType will be set on the underlying ConfigurationPolicy and
+                          determines how the CR built from this sourceFile is reconciled against the
+                          cluster.
+                        type: string
+                        default: mustonlyhave
                       metadata:
                         type: object
                         properties:


### PR DESCRIPTION
Using a compliance type of "mustonlyhave" for Namespace CRs leads to
conflicts between the ACM policy governance engine and OLM. OLM updates
annotations and labels on operator namespaces which then get removed by
the "mustonlyhave" compliance type. This PR overrides complianceType on
Namespaces to "musthave".

Signed-off-by: Ian Miller <imiller@redhat.com>