### PR TITLE
ztp: add missing type for new boolean attribute 'wrapInPolicy'

### DIFF
--- a/ztp/ran-crd/policy-gen-template-crd.yaml
+++ b/ztp/ran-crd/policy-gen-template-crd.yaml
@@ -50,6 +50,7 @@ spec:
                   description: |
                     The MachineConfigPool name that will apply the following CRs.
                 wrapInPolicy:
+                  type: boolean
                   default: true
                   description: |
                     Boolean flag to allow the user to create custom resources wrapped or unwrapped by ACM policies.


### PR DESCRIPTION
ztp: add missing type for new boolean attribute 'wrapInPolicy'
Signed-off-by: Nishant Parekh <nparekh@redhat.com>