### PR TITLE
cnf-tests: Fix ptp prometheus test

### DIFF
--- a/cnf-tests/testsuites/e2esuite/ptp/prometheus.go
+++ b/cnf-tests/testsuites/e2esuite/ptp/prometheus.go
@@ -45,7 +45,7 @@ type metric struct {
 
 func collectPrometheusMetrics(uniqueMetricKeys []string) map[string][]string {
 	prometheusPods, err := client.Client.Pods(openshiftMonitoringNamespace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: "app=prometheus",
+		LabelSelector: "app.kubernetes.io/name=prometheus",
 	})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(len(prometheusPods.Items)).NotTo(BeZero())


### PR DESCRIPTION
This commit updates the label to find the prometheus pods in the openshift-monitoring namespace.

In OCP 4.10 they remove the `app: prometheus` label instead there is the `app.kubernetes.io/name=prometheus` label

Signed-off-by: Sebastian Sch <sebassch@gmail.com>