### PR TITLE
Bug 2009233: ztp: Support complianceType for full PGT

### DIFF
--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/common-ranGen.yaml
@@ -19,14 +19,12 @@ spec:
       policyName: "sriov-sub-policy"
     - fileName: SriovSubscriptionNS.yaml
       policyName: "sriov-sub-policy"
-      complianceType: musthave
     - fileName: SriovSubscriptionOperGroup.yaml
       policyName: "sriov-sub-policy"
     - fileName: PtpSubscription.yaml
       policyName: "ptp-sub-policy"
     - fileName: PtpSubscriptionNS.yaml
       policyName: "ptp-sub-policy"
-      complianceType: musthave
     - fileName: PtpSubscriptionOperGroup.yaml
       policyName: "ptp-sub-policy"
     - fileName: PaoSubscription.yaml
@@ -36,16 +34,16 @@ spec:
         channel: "4.9"
     - fileName: PaoSubscriptionNS.yaml
       policyName: "pao-sub-policy"
-      complianceType: musthave
     - fileName: PaoSubscriptionOperGroup.yaml
       policyName: "pao-sub-policy"
+    - fileName: ClusterLogNS.yaml
+      policyName: "log-sub-policy"
     - fileName: ClusterLogOperGroup.yaml
       policyName: "log-sub-policy"
     - fileName: ClusterLogSubscription.yaml
       policyName: "log-sub-policy"
     - fileName: StorageNS.yaml
       policyName: "storage-sub-policy"
-      complianceType: musthave
     - fileName: StorageOperGroup.yaml
       policyName: "storage-sub-policy"
     - fileName: StorageSubscription.yaml

--- a/ztp/policygenerator/policyGen/policyBuilder.go
+++ b/ztp/policygenerator/policyGen/policyBuilder.go
@@ -21,8 +21,9 @@ type PolicyBuilder struct {
 // struct used to keep the user PGT sourceFile data with the actual built CR
 // from that source file.
 type generatedCR struct {
-	pgtSourceFile utils.SourceFile
-	builtCR       map[string]interface{}
+	globalComplianceType string
+	pgtSourceFile        utils.SourceFile
+	builtCR              map[string]interface{}
 }
 
 func NewPolicyBuilder(fileHandler *utils.FilesHandler) *PolicyBuilder {
@@ -78,7 +79,11 @@ func (pbuilder *PolicyBuilder) Build(policyGenTemp utils.PolicyGenTemplate) (map
 				// data as needed by low level methods setting various policy attributes
 				annotatedResources := make([]generatedCR, len(resources))
 				for idx, cr := range resources {
-					annotatedResources[idx] = generatedCR{pgtSourceFile: sFile, builtCR: cr}
+					annotatedResources[idx] = generatedCR{
+						globalComplianceType: policyGenTemp.Spec.ComplianceType,
+						pgtSourceFile:        sFile,
+						builtCR:              cr,
+					}
 				}
 				if sFile.PolicyName != "" && policies[output] == nil {
 					// Generate new policy

--- a/ztp/policygenerator/policyGen/policyHelper.go
+++ b/ztp/policygenerator/policyGen/policyHelper.go
@@ -65,11 +65,17 @@ func CheckNameLength(namespace string, name string) error {
 func BuildObjectTemplate(resource generatedCR) utils.ObjectTemplates {
 	objTemplate := utils.ObjectTemplates{}
 
-	// BZ 2009233 Namespaces will be updated by OLM with labels and
-	// annotations. A "mustonlyhave" ACM policy will fight with OLM
-	// over these annotations/lables. Allow the user to set the
-	// compliance type to avoid this condition.
-	objTemplate.ComplianceType = resource.pgtSourceFile.ComplianceType
+	// BZ 2009233 Namespaces, Subscriptions and OperatorGroups will be updated by OLM
+	// with labels and annotations. A "mustonlyhave" ACM policy will fight with OLM
+	// over these annotations/labels. Allow the user to set the compliance type to
+	// avoid this condition. The most specific complianceType setting given by the
+	// user will take precedence. Default to musthave so that we realize the CPU
+	// reductions unless explicitly told otherwise
+	complianceType := resource.globalComplianceType
+	if resource.pgtSourceFile.ComplianceType != utils.UnsetStringValue {
+		complianceType = resource.pgtSourceFile.ComplianceType
+	}
+	objTemplate.ComplianceType = complianceType
 	objTemplate.ObjectDefinition = resource.builtCR
 
 	return objTemplate

--- a/ztp/policygenerator/policyGenerator.go
+++ b/ztp/policygenerator/policyGenerator.go
@@ -38,7 +38,7 @@ func InitiatePolicyGen(tempPath string, sourcePath string, outPath string, stdou
 	fHandler := utils.NewFilesHandler(sourcePath, tempPath, outPath)
 	files, err := fHandler.GetTempFiles()
 	if err != nil {
-		log.Printf("Could not get file list from %s: %s", sourcePath, err)
+		log.Printf("Could not get file list from %s: %s", tempPath, err)
 		// The 'files' slice will be empty, so just continue on.
 	}
 

--- a/ztp/policygenerator/utils/utils.go
+++ b/ztp/policygenerator/utils/utils.go
@@ -8,6 +8,10 @@ const ResourcesDir = "resources"
 const FileExt = ".yaml"
 const UnsetStringValue = "__unset_value__"
 
+// ComplianceType of "mustonlyhave" uses significant CPU to enforce. Default to
+// "musthave" so that we realize the CPU reductions unless explicitly told otherwise
+const DefaultComplianceType = "musthave"
+
 type KindType struct {
 	Kind string `yaml:"kind"`
 }
@@ -31,6 +35,7 @@ type PolicyGenTempSpec struct {
 	Mcp               string            `yaml:"mcp,omitempty"`
 	WrapInPolicy      bool              `yaml:"wrapInPolicy,omitempty"`
 	RemediationAction string            `yaml:"remediationAction,omitempty"`
+	ComplianceType    string            `yaml:"complianceType,omitempty"`
 	SourceFiles       []SourceFile      `yaml:"sourceFiles,omitempty"`
 }
 
@@ -39,6 +44,7 @@ func (pgt *PolicyGenTempSpec) UnmarshalYAML(unmarshal func(interface{}) error) e
 	var defaults = PolicyGenTemplateSpec{
 		WrapInPolicy:      true, //Generate ACM wrapped policies by default
 		RemediationAction: "enforce",
+		ComplianceType:    DefaultComplianceType,
 	}
 
 	out := defaults
@@ -61,7 +67,7 @@ type SourceFile struct {
 func (rv *SourceFile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type Defaulted SourceFile
 	var defaults = Defaulted{
-		ComplianceType:    "mustonlyhave",
+		ComplianceType:    UnsetStringValue,
 		RemediationAction: UnsetStringValue,
 	}
 

--- a/ztp/ran-crd/policy-gen-template-crd.yaml
+++ b/ztp/ran-crd/policy-gen-template-crd.yaml
@@ -45,6 +45,14 @@ spec:
                     pairs in this list identify the cluster labels/values to which
                     the policy applies.
                   x-kubernetes-preserve-unknown-fields: true
+                complianceType:
+                  description: |
+                    The complianceType will be set on the underlying
+                    ConfigurationPolicy for all sourceFiles in this template. This
+                    value determines how the CRs built from this template are
+                    reconciled against the cluster.
+                  type: string
+                  default: musthave
                 mcp:
                   type: string
                   description: |
@@ -98,11 +106,12 @@ spec:
                         type: string
                       complianceType:
                         description: |
-                          The complianceType will be set on the underlying ConfigurationPolicy and
-                          determines how the CR built from this sourceFile is reconciled against the
-                          cluster.
+                          The complianceType will be set on the underlying ConfigurationPolicy
+                          and determines how the CR built from this sourceFile is reconciled
+                          against the cluster. This value takes precedence over complianceType
+                          at the Spec level. If this value is omitted the value from the Spec
+                          level is used.
                         type: string
-                        default: mustonlyhave
                       metadata:
                         type: object
                         properties:

--- a/ztp/source-crs/ClusterLogNS.yaml
+++ b/ztp/source-crs/ClusterLogNS.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    workload.openshift.io/allowed: management

--- a/ztp/source-crs/ClusterLogOperGroup.yaml
+++ b/ztp/source-crs/ClusterLogOperGroup.yaml
@@ -1,11 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-logging
-  annotations:
-    workload.openshift.io/allowed: management
----
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:


### PR DESCRIPTION
Give the user control over the complianceType for all CRs in a
PolicyGenTemplate and change the default to "musthave". This ensures
that, by default, we realize the CPU savings on managed clusters,
but provide a path for users to choose "mustonlyhave" policies
when needed. The difference in CPU use for managing "mustonlyhave"
policies for the current feature set is ~0.8 cpu as measured by
the prometheus query:
```
sum(pod:container_cpu_usage:sum{namespace=~"openshift-logging|openshift-authentication-operator|openshift-kube-controller-manager|openshift-kube-apiserver|openshift-apiserver|open-cluster-management-agent|open-cluster-management-agent-addon"})
```

Signed-off-by: Ian Miller <imiller@redhat.com>