### PR TITLE
infra: decrease feature-wait timeout

### DIFF
--- a/hack/feature-wait.sh
+++ b/hack/feature-wait.sh
@@ -13,7 +13,7 @@ if [ "$FEATURES" == "" ]; then
 fi
 
 ATTEMPTS=0
-MAX_ATTEMPTS=200
+MAX_ATTEMPTS=15
 all_ready=false
 export TEST_SUITES="validationsuite"
 export FAIL_FAST="-ginkgo.failFast"


### PR DESCRIPTION
in the past each cycle was really fast, so we needed 200 attempts just
to be on the safe side.
now that we're using the validation suite, each cycle takes 1-10 minutes
so 20 attempts are more than enough
