### PR TITLE
Add ZTP MachineConfig which sets iommu kernelArgs

### DIFF
--- a/ztp/source-crs/MachineConfigIommu.yaml
+++ b/ztp/source-crs/MachineConfigIommu.yaml
@@ -1,0 +1,13 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 06-iommu-config
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+  kernelArguments:
+    - intel_iommu=on
+    - iommu=pt

--- a/ztp/source-crs/extra-manifest/06-iommu-config.yaml
+++ b/ztp/source-crs/extra-manifest/06-iommu-config.yaml
@@ -1,0 +1,1 @@
+../MachineConfigIommu.yaml


### PR DESCRIPTION
To avoid issues caused by SR-IOV operator rebooting SNO cluster to apply iommu kernelArgs create a MachineConfig that sets them up at deployment time.

More details of the issue can be found in:
https://bugzilla.redhat.com/show_bug.cgi?id=2021151