### PR TITLE
features: Fix typo in bfd configmap

### DIFF
--- a/feature-configs/demo/local_bfd/02_configmap_master.yaml
+++ b/feature-configs/demo/local_bfd/02_configmap_master.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-Kind: ConfigMap
+kind: ConfigMap
 data:
   daemons: |+
     # This file tells the frr package which daemons to start.


### PR DESCRIPTION
Change from "Kind" to "kind" in the configmap yaml