### PR TITLE
oot-driver: remove the patch package install

### DIFF
--- a/tools/oot-driver/charts/iavf-driver-0.0.1/Dockerfile-driver.SRO
+++ b/tools/oot-driver/charts/iavf-driver-0.0.1/Dockerfile-driver.SRO
@@ -23,7 +23,7 @@ COPY files/kernel ./files/kernel
 COPY signing-keys /signing-key/
 
 RUN dnf install -y  \
-make gcc patch cpio kmod
+make gcc cpio kmod
 
 RUN if [[ "${KERNEL_SOURCE}" == *"file"* ]]; then \
 [[ "${KVER}" == *"rt"* ]] && export RT="rt-" || export RT=""; \
@@ -34,7 +34,6 @@ fi
 WORKDIR files/driver
 
 RUN if [[ ${DOWNLOAD_DRIVER} == "true" ]]; then \
-wget https://netix.dl.sourceforge.net/project/e1000/ice%20stable/$ICE_DRIVER_VERSION/ice-$ICE_DRIVER_VERSION.tar.gz; \
 wget https://netix.dl.sourceforge.net/project/e1000/iavf%20stable/$IAVF_DRIVER_VERSION/iavf-$IAVF_DRIVER_VERSION.tar.gz; \
 fi
 

--- a/tools/oot-driver/charts/ice-driver-0.0.1/Dockerfile-driver.SRO
+++ b/tools/oot-driver/charts/ice-driver-0.0.1/Dockerfile-driver.SRO
@@ -23,7 +23,7 @@ COPY files/kernel ./files/kernel
 COPY signing-keys /signing-key/
 
 RUN dnf install -y  \
-make gcc patch cpio kmod
+make gcc cpio kmod
 
 RUN if [[ "${KERNEL_SOURCE}" == *"file"* ]]; then \
 [[ "${KVER}" == *"rt"* ]] && export RT="rt-" || export RT=""; \


### PR DESCRIPTION
we need to remove the patch package install because in the CI
there is no access to the yum repos

error:
```
[1/2] STEP 15/22: RUN dnf install -y  make gcc patch cpio kmod
Updating Subscription Management repositories.
Unable to read consumer identity
Subscription Manager is operating in container mode.

This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.

rhel-8-baseos                                   0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'rhel-8-baseos':
  - Curl error (6): Couldn't resolve host name for http://base-4-10-rhel8.ocp.svc/rhel-8-baseos/repodata/repomd.xml [Could not resolve host: base-4-10-rhel8.ocp.svc]
Error: Failed to download metadata for repo 'rhel-8-baseos': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
rhel-8-appstream                                0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'rhel-8-appstream':
  - Curl error (6): Couldn't resolve host name for http://base-4-10-rhel8.ocp.svc/rhel-8-appstream/repodata/repomd.xml [Could not resolve host: base-4-10-rhel8.ocp.svc]
Error: Failed to download metadata for repo 'rhel-8-appstream': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
rhel-8-server-ose                               0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'rhel-8-server-ose':
  - Curl error (6): Couldn't resolve host name for http://base-4-10-rhel8.ocp.svc/rhel-8-server-ose/repodata/repomd.xml [Could not resolve host: base-4-10-rhel8.ocp.svc]
Error: Failed to download metadata for repo 'rhel-8-server-ose': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
rhel-8-fast-datapath                            0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'rhel-8-fast-datapath':
  - Curl error (6): Couldn't resolve host name for http://base-4-10-rhel8.ocp.svc/rhel-8-fast-datapath/repodata/repomd.xml [Could not resolve host: base-4-10-rhel8.ocp.svc]
Error: Failed to download metadata for repo 'rhel-8-fast-datapath': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
rhel-8-fast-datapath-aarch64                    0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'rhel-8-fast-datapath-aarch64':
  - Curl error (6): Couldn't resolve host name for http://base-4-10-rhel8.ocp.svc/rhel-8-fast-datapath-aarch64/repodata/repomd.xml [Could not resolve host: base-4-10-rhel8.ocp.svc]
Error: Failed to download metadata for repo 'rhel-8-fast-datapath-aarch64': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
rhel-8-nfv                                      0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'rhel-8-nfv':
  - Curl error (6): Couldn't resolve host name for http://base-4-10-rhel8.ocp.svc/rhel-8-nfv/repodata/repomd.xml [Could not resolve host: base-4-10-rhel8.ocp.svc]
Error: Failed to download metadata for repo 'rhel-8-nfv': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
rhel-8-advanced-virt                            0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'rhel-8-advanced-virt':
  - Curl error (6): Couldn't resolve host name for http://base-4-10-rhel8.ocp.svc/rhel-8-advanced-virt/repodata/repomd.xml [Could not resolve host: base-4-10-rhel8.ocp.svc]
Error: Failed to download metadata for repo 'rhel-8-advanced-virt': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
rhel-8-ansible-2.9                              0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'rhel-8-ansible-2.9':
  - Curl error (6): Couldn't resolve host name for http://base-4-10-rhel8.ocp.svc/rhel-8-ansible-2.9/repodata/repomd.xml [Could not resolve host: base-4-10-rhel8.ocp.svc]
Error: Failed to download metadata for repo 'rhel-8-ansible-2.9': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
openstack-16-for-rhel-8-rpms                    0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'openstack-16-for-rhel-8-rpms':
  - Curl error (6): Couldn't resolve host name for http://base-4-10-rhel8.ocp.svc/openstack-16-for-rhel-8-rpms/repodata/repomd.xml [Could not resolve host: base-4-10-rhel8.ocp.svc]
Error: Failed to download metadata for repo 'openstack-16-for-rhel-8-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
rhel-8-codeready-builder-rpms                   0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'rhel-8-codeready-builder-rpms':
  - Curl error (6): Couldn't resolve host name for http://base-4-10-rhel8.ocp.svc/rhel-8-codeready-builder-rpms/repodata/repomd.xml [Could not resolve host: base-4-10-rhel8.ocp.svc]
Error: Failed to download metadata for repo 'rhel-8-codeready-builder-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
localdev-openstack-16-for-rhel-8-rpms           0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'localdev-openstack-16-for-rhel-8-rpms':
  - Curl error (6): Couldn't resolve host name for http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16.2/os/repodata/repomd.xml [Could not resolve host: rhsm-pulp.corp.redhat.com]
Error: Failed to download metadata for repo 'localdev-openstack-16-for-rhel-8-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
localdev-rhel-8-appstream-rpms                  0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'localdev-rhel-8-appstream-rpms':
  - Curl error (6): Couldn't resolve host name for http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/x86_64/appstream/os/repodata/repomd.xml [Could not resolve host: rhsm-pulp.corp.redhat.com]
Error: Failed to download metadata for repo 'localdev-rhel-8-appstream-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
localdev-rhel-8-baseos-rpms                     0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'localdev-rhel-8-baseos-rpms':
  - Curl error (6): Couldn't resolve host name for http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/x86_64/baseos/os/repodata/repomd.xml [Could not resolve host: rhsm-pulp.corp.redhat.com]
Error: Failed to download metadata for repo 'localdev-rhel-8-baseos-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
localdev-rhel-8-codeready-builder-rpms          0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'localdev-rhel-8-codeready-builder-rpms':
  - Curl error (6): Couldn't resolve host name for http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/x86_64/codeready-builder/os/repodata/repomd.xml [Could not resolve host: rhsm-pulp.corp.redhat.com]
Error: Failed to download metadata for repo 'localdev-rhel-8-codeready-builder-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
localdev-rhel-8-fast-datapath-rpms              0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'localdev-rhel-8-fast-datapath-rpms':
  - Curl error (6): Couldn't resolve host name for http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/fast-datapath/os/repodata/repomd.xml [Could not resolve host: rhsm-pulp.corp.redhat.com]
Error: Failed to download metadata for repo 'localdev-rhel-8-fast-datapath-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
localdev-rhel-8-rt-rpms                         0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'localdev-rhel-8-rt-rpms':
  - Curl error (6): Couldn't resolve host name for http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.4/x86_64/rt/os/repodata/repomd.xml [Could not resolve host: rhsm-pulp.corp.redhat.com]
Error: Failed to download metadata for repo 'localdev-rhel-8-rt-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
localdev-rhel-8-server-ansible-2.9-rpms         0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'localdev-rhel-8-server-ansible-2.9-rpms':
  - Curl error (6): Couldn't resolve host name for http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2.9/os/repodata/repomd.xml [Could not resolve host: rhsm-pulp.corp.redhat.com]
Error: Failed to download metadata for repo 'localdev-rhel-8-server-ansible-2.9-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
localdev-rhel-8-server-ose-rpms                 0.0  B/s |   0  B     00:00
Errors during downloading metadata for repository 'localdev-rhel-8-server-ose-rpms':
  - Curl error (6): Couldn't resolve host name for http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/4.10-el8/building/x86_64/os/repodata/repomd.xml [Could not resolve host: download.lab.bos.redhat.com]
Error: Failed to download metadata for repo 'localdev-rhel-8-server-ose-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
Ignoring repositories: rhel-8-baseos, rhel-8-appstream, rhel-8-server-ose, rhel-8-fast-datapath, rhel-8-fast-datapath-aarch64, rhel-8-nfv, rhel-8-advanced-virt, rhel-8-ansible-2.9, openstack-16-for-rhel-8-rpms, rhel-8-codeready-builder-rpms, localdev-openstack-16-for-rhel-8-rpms, localdev-rhel-8-appstream-rpms, localdev-rhel-8-baseos-rpms, localdev-rhel-8-codeready-builder-rpms, localdev-rhel-8-fast-datapath-rpms, localdev-rhel-8-rt-rpms, localdev-rhel-8-server-ansible-2.9-rpms, localdev-rhel-8-server-ose-rpms
Package make-1:4.2.1-10.el8.x86_64 is already installed.
Package gcc-8.4.1-1.el8.x86_64 is already installed.
No match for argument: patch
Package cpio-2.12-10.el8.x86_64 is already installed.
Package kmod-25-17.el8.x86_64 is already installed.
Error: Unable to find a match: patch
[2/2] STEP 1/13: FROM registry.access.redhat.com/ubi8:latest
Trying to pull registry.access.redhat.com/ubi8:latest...
Getting image source signatures
error: build error: error building at STEP "RUN dnf install -y  make gcc patch cpio kmod": error while running runtime: exit status 1

```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>