### PR TITLE
ztp: Added support for defining OCP release per cluster

### DIFF
--- a/ztp/ran-crd/site-config-crd.yaml
+++ b/ztp/ran-crd/site-config-crd.yaml
@@ -43,7 +43,9 @@ spec:
                       description: "name of the pullSecret secret"
                       type: string
                 clusterImageSetNameRef:
-                  description: Reference to the cluster image set.
+                  description: | 
+                    Reference to the cluster image set. This is the OCP release that will be used unless
+                    the cluster specifies a different clusterImageSetNameRef.
                   type: string
                 sshPublicKey:
                   description: sshPublicKey will be added to all cluster hosts for use in debugging.
@@ -84,6 +86,11 @@ spec:
                         enum:
                           - OVNKubernetes
                           - OpenShiftSDN
+                      clusterImageSetNameRef:
+                        description: |
+                          Reference to the cluster image set. This is the OCP release that will be used to
+                          deploy the cluster. It overrides the clusterImageSetNameRef define at site level.
+                        type: string
                       clusterLabels:
                         description: |
                           clusterLabels specify the the day2 configuration policies that will get applied on the cluster. The following labels example should be included in order to match the policy generatroe policies rules.

--- a/ztp/siteconfig-generator/siteConfig/clusterCRs.go
+++ b/ztp/siteconfig-generator/siteConfig/clusterCRs.go
@@ -22,7 +22,7 @@ spec:
   clusterDeploymentRef:
     name: siteconfig.Spec.Clusters.ClusterName
   imageSetRef:
-    name: siteconfig.Spec.ClusterImageSetNameRef
+    name: siteconfig.Spec.Clusters.ClusterImageSetNameRef
   apiVIP: siteconfig.Spec.Clusters.ApiVIP
   ingressVIP: siteconfig.Spec.Clusters.IngressVIP
   networking:

--- a/ztp/siteconfig-generator/siteConfig/siteConfig.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig.go
@@ -103,6 +103,7 @@ type Clusters struct {
 	DiskEncryption         DiskEncryption    `yaml:"diskEncryption"`
 	ProxySettings          ProxySettings     `yaml:"proxy,omitempty"`
 	ExtraManifestPath      string            `yaml:"extraManifestPath"`
+	ClusterImageSetNameRef string            `yaml:"clusterImageSetNameRef,omitempty"`
 
 	NumMasters  uint8
 	NumWorkers  uint8

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
@@ -61,6 +61,15 @@ func (scbuilder *SiteConfigBuilder) Build(siteConfigTemp SiteConfig) (map[string
 			return clustersCRs, errors.New("Error: Repeated Cluster Name " + siteConfigTemp.Metadata.Name + "/" + cluster.ClusterName)
 		}
 		siteConfigTemp.Spec.Clusters[id].NetworkType = "{\"networking\":{\"networkType\":\"" + cluster.NetworkType + "\"}}"
+
+		if siteConfigTemp.Spec.ClusterImageSetNameRef == "" && siteConfigTemp.Spec.Clusters[id].ClusterImageSetNameRef == "" {
+			return clustersCRs, errors.New("Error: Site and cluster clusterImageSetNameRef cannot be empty " + siteConfigTemp.Metadata.Name + "/" + cluster.ClusterName)
+		}
+		// If cluster has not set a clusterImageSetNameRef we use the site one
+		if siteConfigTemp.Spec.Clusters[id].ClusterImageSetNameRef == "" {
+			siteConfigTemp.Spec.Clusters[id].ClusterImageSetNameRef = siteConfigTemp.Spec.ClusterImageSetNameRef
+		}
+
 		clusterCRs, err := scbuilder.getClusterCRs(id, siteConfigTemp)
 		if err != nil {
 			return clustersCRs, err


### PR DESCRIPTION
This PR adds support for configuring specific OCP versions for specific clusters within the site. If cluster does not define specific OCP release, the OCP release specified at site level will be used. This is useful when you want to deploy clusters with different OCP releases in the same site, i.e: OCP 4.8.X and OCP 4.9.X. As of today, without this feature you're required to have two different SiteConfigs even if they're the same "physical" site.

Signed-off-by: Mario Vazquez <mavazque@redhat.com>