### PR TITLE
ztp: Add templated MC objects for every defined role

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/testdata/role-templates/good.yaml.tmpl
+++ b/ztp/siteconfig-generator/siteConfig/testdata/role-templates/good.yaml.tmpl
@@ -1,0 +1,1 @@
+rendered-{{ .Role }}: data


### PR DESCRIPTION
For any templated MachineConfig, we need to replicate it for every role
in the cluster.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
