### PR TITLE
ztp: Update PerfProfile api to v2 and add globallyDisableIrqLoadBalancing parameter to the template

### DIFF
--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1
+apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
   name: $name
@@ -17,6 +17,7 @@ spec:
         node: $node
   machineConfigPoolSelector:
     pools.operator.machineconfiguration.openshift.io/$mcp: ""
+  globallyDisableIrqLoadBalancing: true
   net:
     userLevelNetworking: true
   nodeSelector:


### PR DESCRIPTION
This PR adds two things to the PerformanceProfile template.

1. Updates the object apiVersion to v2
2. Adds the globallyDisableIrqLoadBalancing so user can set it to true/false. Default will be true.



Signed-off-by: Mario Vazquez <mavazque@redhat.com>