### PR TITLE
ztp: Update PerformanceProfile source-cr to api v2

### DIFF
--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1
+apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
   name: $name


### PR DESCRIPTION
The current api version for PerformanceProfile is v2. 
Signed-off-by: Ian Miller <imiller@redhat.com>