### PR TITLE
ztp: CNF-3661 Reduce number of policies

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
@@ -15,47 +15,47 @@ spec:
       policyName: "du-validator-policy"
     # Create operators policies that will be installed in all clusters
     - fileName: SriovSubscription.yaml
-      policyName: "sriov-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: SriovSubscriptionNS.yaml
-      policyName: "sriov-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: SriovSubscriptionOperGroup.yaml
-      policyName: "sriov-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: PtpSubscription.yaml
-      policyName: "ptp-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: PtpSubscriptionNS.yaml
-      policyName: "ptp-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: PtpSubscriptionOperGroup.yaml
-      policyName: "ptp-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: PaoSubscription.yaml
-      policyName: "pao-sub-policy"
+      policyName: "subscriptions-policy"
       spec:
       # Changing the channel value will upgrade/downgrade the operator installed version.
         channel: "4.9"
     - fileName: PaoSubscriptionNS.yaml
-      policyName: "pao-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: PaoSubscriptionOperGroup.yaml
-      policyName: "pao-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: ClusterLogNS.yaml
-      policyName: "log-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: ClusterLogOperGroup.yaml
-      policyName: "log-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: ClusterLogSubscription.yaml
-      policyName: "log-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: StorageNS.yaml
-      policyName: "storage-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: StorageOperGroup.yaml
-      policyName: "storage-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: StorageSubscription.yaml
-      policyName: "storage-sub-policy"
+      policyName: "subscriptions-policy"
     - fileName: ReduceMonitoringFootprint.yaml
-      policyName: "mon-offload-policy"
+      policyName: "config-policy"
     #
     # These CRs are in support of installation from a disconnected registry
     #
     - fileName: OperatorHub.yaml
-      policyName: "registry-policy"
+      policyName: "config-policy"
     - fileName: DefaultCatsrc.yaml
-      policyName: "registry-policy"
+      policyName: "config-policy"
       # The Subscriptions all point to redhat-operators. The OperatorHub CR
       # disables the defaults and this CR replaces redhat-operators with a
       # CatalogSource pointing to the disconnected registry. Including both of
@@ -66,7 +66,7 @@ spec:
         displayName: disconnected-redhat-operators
         image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.9
     - fileName: DisconnectedICSP.yaml
-      policyName: "registry-policy"
+      policyName: "config-policy"
       spec:
         repositoryDigestMirrors:
         - mirrors:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
@@ -10,14 +10,14 @@ spec:
   mcp: "master"
   sourceFiles:
     - fileName: SriovNetwork.yaml
-      policyName: "sriov-nw-fh-policy"
+      policyName: "config-policy"
       metadata:
         name: "sriov-nw-du-fh"
       spec:
         resourceName: du_fh
         vlan: 140
     - fileName: SriovNetworkNodePolicy.yaml
-      policyName: "sriov-nnp-fh-policy"
+      policyName: "config-policy"
       metadata:
         name: "sriov-nnp-du-fh"
       spec:
@@ -29,14 +29,14 @@ spec:
         priority: 10
         resourceName: du_fh
     - fileName: SriovNetwork.yaml
-      policyName: "sriov-nw-mh-policy"
+      policyName: "config-policy"
       metadata:
         name: "sriov-nw-du-mh"
       spec:
         resourceName: du_mh
         vlan: 150
     - fileName: SriovNetworkNodePolicy.yaml
-      policyName: "sriov-nnp-mh-policy"
+      policyName: "config-policy"
       metadata:
         name: "sriov-nnp-du-mh"
       spec:
@@ -48,7 +48,7 @@ spec:
         priority: 10
         resourceName: du_mh
     - fileName: PerformanceProfile.yaml
-      policyName: "perfprofile-policy"
+      policyName: "config-policy"
       metadata:
         name: openshift-node-performance-profile
       spec:
@@ -61,7 +61,7 @@ spec:
             - size: 1G
               count: 32
     - fileName: TunedPerformancePatch.yaml
-      policyName: "tuned-perf-patch-policy"
+      policyName: "config-policy"
       spec:
         profile:
           - name: performance-patch

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -11,10 +11,10 @@ spec:
   mcp: "master"
   sourceFiles:
     - fileName: ConsoleOperatorDisable.yaml
-      policyName: "console-policy"
+      policyName: "config-policy"
     # Set ClusterLogForwarder & ClusterLogging as example might be better to create another policyTemp-Group
     - fileName: ClusterLogForwarder.yaml
-      policyName: "log-forwarder-policy"
+      policyName: "config-policy"
       spec:
         outputs:
           - type: "kafka"
@@ -33,7 +33,7 @@ spec:
             outputRefs:
              - kafka-open
     - fileName: ClusterLogging.yaml
-      policyName: "log-policy"
+      policyName: "config-policy"
       spec:
         curation:
           curator:
@@ -43,7 +43,7 @@ spec:
             type: "fluentd"
             fluentd: {}
     - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
-      policyName: "ptp-config-policy"
+      policyName: "config-policy"
       metadata:
         name: "du-ptp-slave"
       spec:
@@ -54,11 +54,11 @@ spec:
           ptp4lOpts: "-2 -s --summary_interval -4"
           phc2sysOpts: "-a -r -n 24"
     - fileName: SriovOperatorConfig.yaml
-      policyName: "sriov-conf-policy"
+      policyName: "config-policy"
       spec:
         disableDrain: true
     - fileName: StorageLV.yaml
-      policyName: "local-disks-policy"
+      policyName: "config-policy"
       spec:
         storageClassDevices:
           - storageClassName: "example-storage-class-1"


### PR DESCRIPTION
The current reference PolicyGenTemplates (common, group, and test-sno) result in ~20 policies being created for the cluster. Managing this number of policies per cluster results in increased CPU use on the spoke cluster and scaling issues in the hub.

The work of this story is to reduce the number of policies created by using a common policy name for all policies in each of the common-ranGen.yaml, group-du-sno-ranGen.yaml, and test-sno.yaml files. 

Naming convention --> 
```
subscriptions-policy -- Containing all the Namespace, OperatorGroup and Subscription CRs
config-policy -- Containing the rest (OperatorHub, ImageContentSourcePolicy, ReduceMonitoring, etc)
```

-----------------
Before -->
```
[root@jumphost1 ~]# kubectl get policy -n common
NAME                                REMEDIATION ACTION   COMPLIANCE STATE   AGE
common-log-sub-policy       enforce              NonCompliant       2d22h
common-mon-offload-policy   enforce              Compliant          2d22h
common-pao-sub-policy       enforce              NonCompliant       2d22h
common-ptp-sub-policy       enforce              Compliant          2d22h
common-sriov-sub-policy     enforce              Compliant          2d22h
```

After --> 
```
[root@jumphost1 ~]# kubectl get policy -n common
NAME                                REMEDIATION ACTION   COMPLIANCE STATE   AGE
common-config-policy       enforce              NonCompliant       2d22h
```