### PR TITLE
ztp: fix ArgoCD deployment policies-app-project.yaml path

### DIFF
--- a/ztp/gitops-subscriptions/argocd/deployment/kustomization.yaml
+++ b/ztp/gitops-subscriptions/argocd/deployment/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
   - app-project.yaml
-  - policy-app-project.yaml
+  - policies-app-project.yaml
   - gitops-policy-rolebinding.yaml
   - gitops-cluster-rolebinding.yaml
   - clusters-app.yaml


### PR DESCRIPTION
Fix ArgoCD deployment kustomization.yaml to include the correct policies-app-project.yaml path.