### PR TITLE
ztp: Remove incorrect labels from reference PGT

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/kustomization.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/kustomization.yaml
@@ -1,7 +1,7 @@
 generators:
 - common-ranGen.yaml
 - group-du-sno-ranGen.yaml
-- test-sno.yaml
+- example-sno.yaml
 
 resources:
 - ns.yaml

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/ns.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/ns.yaml
@@ -1,20 +1,14 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    name: ztp-common
   name: ztp-common
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    name: ztp-common
   name: ztp-group
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    name: ztp-common
   name: ztp-site


### PR DESCRIPTION
The labels will get created automatically as needed. Remove the
incorrect values.

Signed-off-by: Ian Miller <imiller@redhat.com>