### PR TITLE
cnf-tests: Fix ovs_qos flake

### DIFF
--- a/cnf-tests/testsuites/e2esuite/ovs_qos/ovs_qos.go
+++ b/cnf-tests/testsuites/e2esuite/ovs_qos/ovs_qos.go
@@ -52,7 +52,7 @@ const (
 	// IngressMCName contains the name of the ingress MC applied by the ovs_qos tests
 	IngressMCName = "qos-ingress"
 	// LimitMultiplier is the multiplier to get the MC limit rate without discovery
-	LimitMultiplier = 0.7
+	LimitMultiplier = 0.3 // TODO: see commit message
 )
 
 var (


### PR DESCRIPTION
Recently we're seeing 'Validate MCO removed egress/ingress'
tests flaking. From inspecting the logs the following
situation can happen in a test:

We delete the ingress MC, we see that the QoS is deleted from
the node, then we try to validate that the ingress limitation is
really deleted by creating the sender-receiver pods again.
Then we check that the traffic rate that arrives to the
receiver surpasses the ingressBitLimit that was set before.
This could be misleading, because if for some reason
the sender sends in a rate below what was set as the
ingressBitLimit, the test would fail thinking that
the ingress QoS still applies in the node.

Setting the limitMultiplier lower could significantly
reduce the chances of that happening.

Maybe TODO: redo how we check that the rate set by
the QoS is enforced/not enforced.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>