### PR TITLE
features: Move our mount namespace execstart last

### DIFF
--- a/feature-configs/deploy/container-mount-namespace/container-private-mounts/mc-container-mount-namespace.yaml
+++ b/feature-configs/deploy/container-mount-namespace/container-private-mounts/mc-container-mount-namespace.yaml
@@ -38,7 +38,7 @@ spec:
           ExecStop=umount -R ${RUNTIME_DIRECTORY}
       - name: crio.service
         dropins:
-        - name: 20-container-mount-namespace.conf
+        - name: 90-container-mount-namespace.conf
           contents: |
             [Unit]
             Wants=container-mount-namespace.service
@@ -52,7 +52,7 @@ spec:
                 ${ORIG_EXECSTART}"
       - name: kubelet.service
         dropins:
-        - name: 20-container-mount-namespace.conf
+        - name: 90-container-mount-namespace.conf
           contents: |
             [Unit]
             Wants=container-mount-namespace.service


### PR DESCRIPTION
There is a collision with a drop-in owned by MCO which also edits crio's
commandline by replacing ExecStart.  It turns out that the drop-in is
redundant with the environment variable that's already being set, so it
is safe for us to move our ExecStart later in the drop-in order and
simply replace the incompatible one.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
