### PR TITLE
ztp: Clean up StorageLV source-crs and SNO example

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -59,5 +59,17 @@ spec:
         disableDrain: true
     - fileName: StorageLV.yaml
       policyName: "local-disks-policy"
+      spec:
+        storageClassDevices:
+          - storageClassName: "example-storage-class-1"
+            volumeMode: Filesystem
+            fsType: xfs
+            devicePaths:
+              - /dev/sdb1
+          - storageClassName: "example-storage-class-2"
+            volumeMode: Filesystem
+            fsType: xfs
+            devicePaths:
+              - /dev/sdb2
     - fileName: DisableSnoNetworkDiag.yaml
       policyName: "config-policy"

--- a/ztp/source-crs/StorageLV.yaml
+++ b/ztp/source-crs/StorageLV.yaml
@@ -7,7 +7,8 @@ spec:
   logLevel: Normal
   managementState: Managed
   storageClassDevices:
-    - storageClassName: "fs-sc"
+    # The list of storage classes and associated devicePaths need to be specified like this example:
+    - storageClassName: "example-storage-class"
       volumeMode: Filesystem
       fsType: xfs
       # The below must be adjusted to the hardware
@@ -27,7 +28,7 @@ spec:
 #   resources:
 #     requests:
 #       storage: 100Gi 
-#   storageClassName: fs-sc 
+#   storageClassName: example-storage-class
 #---
 ## 2. Create a pod that mounts it
 # apiVersion: v1


### PR DESCRIPTION
This makes the example in source-crs for StorageLV a bit more generic,
with a group policy example that looks more like what customers would
likely be doing.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
