### PR TITLE
ztp: move sno PerformanceProfile to group

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
@@ -47,31 +47,3 @@ spec:
         numVfs: 8
         priority: 10
         resourceName: du_mh
-    - fileName: PerformanceProfile.yaml
-      policyName: "config-policy"
-      metadata:
-        name: openshift-node-performance-profile
-      spec:
-        cpu:
-          isolated: "2-19,22-39"
-          reserved: "0-1,20-21"
-        hugepages:
-          defaultHugepagesSize: 1G
-          pages:
-            - size: 1G
-              count: 32
-    - fileName: TunedPerformancePatch.yaml
-      policyName: "config-policy"
-      spec:
-        profile:
-          - name: performance-patch
-            data: |
-              [main]
-              summary=Configuration changes profile inherited from performance created tuned
-              include=openshift-node-performance-openshift-node-performance-profile
-              [bootloader]
-              cmdline_crash=nohz_full=2-19,22-39
-              [sysctl]
-              kernel.timer_migration=1
-              [service]
-              service.stalld=start,enable

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -73,3 +73,34 @@ spec:
               - /dev/sdb2
     - fileName: DisableSnoNetworkDiag.yaml
       policyName: "config-policy"
+    - fileName: PerformanceProfile.yaml
+      policyName: "config-policy"
+      metadata:
+        name: openshift-node-performance-profile
+      spec:
+        cpu:
+          # These must be tailored for the specific hardware platform
+          isolated: "2-19,22-39"
+          reserved: "0-1,20-21"
+        hugepages:
+          defaultHugepagesSize: 1G
+          pages:
+            - size: 1G
+              count: 32
+    - fileName: TunedPerformancePatch.yaml
+      policyName: "config-policy"
+      spec:
+        profile:
+          - name: performance-patch
+            # The 'include' line must match the PerformanceProfile metadata.name above (openshift-node-performance-${metadata.name})
+            # And the cmdline_crash CPU set must match the 'isolated' set in the PerformanceProfile above
+            data: |
+              [main]
+              summary=Configuration changes profile inherited from performance created tuned
+              include=openshift-node-performance-openshift-node-performance-profile
+              [bootloader]
+              cmdline_crash=nohz_full=2-19,22-39
+              [sysctl]
+              kernel.timer_migration=1
+              [service]
+              service.stalld=start,enable

--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -3,7 +3,7 @@ kind: PerformanceProfile
 metadata:
   name: $name
   annotations:
-    ran.openshift.io/ztp-deploy-wave: "100"
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   additionalKernelArgs:
   - "idle=poll"

--- a/ztp/source-crs/TunedPerformancePatch.yaml
+++ b/ztp/source-crs/TunedPerformancePatch.yaml
@@ -4,10 +4,12 @@ metadata:
   name: performance-patch
   namespace: openshift-cluster-node-tuning-operator
   annotations:
-    ran.openshift.io/ztp-deploy-wave: "100"
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   profile:
     - name: performance-patch
+      # The 'include' line must match the associated PerformanceProfile name
+      # And the cmdline_crash CPU set must match the 'isolated' set in the associated PerformanceProfile
       data: |
         [main]
         summary=Configuration changes profile inherited from performance created tuned


### PR DESCRIPTION
Performance profiles will generally apply to an entire group of machines, so let's model this.
