### PR TITLE
ztp: Add ztp-deploy-wave annotation in source CR

### DIFF
--- a/ztp/Makefile
+++ b/ztp/Makefile
@@ -1,6 +1,6 @@
-.PHONY: ci-job test-policygen checkExtraManifests test-policygen-kustomize test-siteconfig test-siteconfig-kustomize
+.PHONY: ci-job test-policygen checkExtraManifests checkSourceCRsAnnotation test-policygen-kustomize test-siteconfig test-siteconfig-kustomize
 
-ci-job: test-policygen checkExtraManifests test-policygen-kustomize test-siteconfig test-siteconfig-kustomize
+ci-job: test-policygen checkExtraManifests checkSourceCRsAnnotation test-policygen-kustomize test-siteconfig test-siteconfig-kustomize
 
 test-policygen:
 	@echo "ZTP: Build policy generator and run test"
@@ -8,6 +8,16 @@ test-policygen:
 
 checkExtraManifests:
 	$(MAKE) -C ./extra-manifests-builder check
+
+checkSourceCRsAnnotation:
+	for sourcefile in ./source-crs/*.yaml;do \
+		if [[ "$${sourcefile}" != *"MachineConfig"* ]];then \
+			if ! grep -qE "ran.openshift.io/ztp-deploy-wave" "$${sourcefile}";then \
+				echo "Error: missing annotation 'ran.openshift.io/ztp-deploy-wave' in $${sourcefile}"; \
+				exit 1; \
+			fi; \
+		fi; \
+	done; \
 
 test-policygen-kustomize:
 	@echo "ZTP: Build policy generator kustomize plugin and run test"

--- a/ztp/source-crs/AcceleratorsNS.yaml
+++ b/ztp/source-crs/AcceleratorsNS.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: vran-acceleration-operators
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"

--- a/ztp/source-crs/AcceleratorsOperGroup.yaml
+++ b/ztp/source-crs/AcceleratorsOperGroup.yaml
@@ -2,7 +2,9 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: vran-operators 
-  namespace: vran-acceleration-operators 
+  namespace: vran-acceleration-operators
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   targetNamespaces:
   - vran-acceleration-operators

--- a/ztp/source-crs/AcceleratorsSubscription.yaml
+++ b/ztp/source-crs/AcceleratorsSubscription.yaml
@@ -2,7 +2,9 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: sriov-fec-subscription 
-  namespace: vran-acceleration-operators 
+  namespace: vran-acceleration-operators
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   channel: stable 
   name: sriov-fec 

--- a/ztp/source-crs/AmqInstance.yaml
+++ b/ztp/source-crs/AmqInstance.yaml
@@ -4,6 +4,8 @@ kind: Interconnect
 metadata:
   name: amq-router
   namespace: amq-router
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "100"
 spec:
   deploymentPlan:
     placement: Any

--- a/ztp/source-crs/AmqSubscription.yaml
+++ b/ztp/source-crs/AmqSubscription.yaml
@@ -4,6 +4,8 @@ kind: Subscription
 metadata:
   name: amq7-interconnect-subscription
   namespace: amq-router
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   channel: 1.10.x
   name:  amq7-interconnect-operator

--- a/ztp/source-crs/AmqSubscriptionNS.yaml
+++ b/ztp/source-crs/AmqSubscriptionNS.yaml
@@ -5,3 +5,4 @@ metadata:
   name: amq-router
   annotations:
     workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "2"

--- a/ztp/source-crs/AmqSubscriptionOperGroup.yaml
+++ b/ztp/source-crs/AmqSubscriptionOperGroup.yaml
@@ -3,6 +3,8 @@ kind: OperatorGroup
 metadata:
   name: amq-router
   namespace: amq-router
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   targetNamespaces:
   - amq-router

--- a/ztp/source-crs/ClusterLogCatSource.yaml
+++ b/ztp/source-crs/ClusterLogCatSource.yaml
@@ -5,6 +5,7 @@ metadata:
     namespace: openshift-marketplace
     annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        ran.openshift.io/ztp-deploy-wave: "1"
 spec:
     displayName: Openshift Cluster Logging Operator
     icon:

--- a/ztp/source-crs/ClusterLogForwarder.yaml
+++ b/ztp/source-crs/ClusterLogForwarder.yaml
@@ -3,6 +3,8 @@ kind: ClusterLogForwarder
 metadata:
   name: instance
   namespace: openshift-logging
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   outputs: $outputs
   inputs:

--- a/ztp/source-crs/ClusterLogNS.yaml
+++ b/ztp/source-crs/ClusterLogNS.yaml
@@ -5,3 +5,4 @@ metadata:
   name: openshift-logging
   annotations:
     workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "2"

--- a/ztp/source-crs/ClusterLogOperGroup.yaml
+++ b/ztp/source-crs/ClusterLogOperGroup.yaml
@@ -4,6 +4,8 @@ kind: OperatorGroup
 metadata:
   name: cluster-logging
   namespace: openshift-logging
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   targetNamespaces:
   - openshift-logging

--- a/ztp/source-crs/ClusterLogSubscription.yaml
+++ b/ztp/source-crs/ClusterLogSubscription.yaml
@@ -3,6 +3,8 @@ kind: Subscription
 metadata:
   name: cluster-logging
   namespace: openshift-logging
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   channel: "stable"
   name: cluster-logging

--- a/ztp/source-crs/ClusterLogging.yaml
+++ b/ztp/source-crs/ClusterLogging.yaml
@@ -3,6 +3,8 @@ kind: ClusterLogging
 metadata:
   name: instance
   namespace: openshift-logging
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   managementState: "Managed"
   curation:

--- a/ztp/source-crs/ConsoleOperatorDisable.yaml
+++ b/ztp/source-crs/ConsoleOperatorDisable.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "false"
     include.release.openshift.io/single-node-developer: "false"
     release.openshift.io/create-only: "true"
+    ran.openshift.io/ztp-deploy-wave: "10"
   name: cluster
 spec:
   logLevel: Normal

--- a/ztp/source-crs/DefaultCatsrc.yaml
+++ b/ztp/source-crs/DefaultCatsrc.yaml
@@ -5,6 +5,7 @@ metadata:
     namespace: openshift-marketplace
     annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        ran.openshift.io/ztp-deploy-wave: "1"
 spec:
     displayName: default-cat-source
     image: $imageUrl

--- a/ztp/source-crs/DisableSnoNetworkDiag.yaml
+++ b/ztp/source-crs/DisableSnoNetworkDiag.yaml
@@ -2,5 +2,7 @@ apiVersion: operator.openshift.io/v1
 kind: Network
 metadata:
   name: cluster
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   disableNetworkDiagnostics: true

--- a/ztp/source-crs/DisconnectedICSP.yaml
+++ b/ztp/source-crs/DisconnectedICSP.yaml
@@ -2,6 +2,8 @@ apiVersion: operator.openshift.io/v1alpha1
 kind: ImageContentSourcePolicy
 metadata:
     name: disconnected-internal-icsp
+    annotations:
+        ran.openshift.io/ztp-deploy-wave: "1"
 spec:
     repositoryDigestMirrors: $mirrors
 

--- a/ztp/source-crs/OperatorHub.yaml
+++ b/ztp/source-crs/OperatorHub.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: OperatorHub
 metadata:
     name: cluster
+    annotations:
+        ran.openshift.io/ztp-deploy-wave: "1"
 spec:
     disableAllDefaultSources: true
 

--- a/ztp/source-crs/PaoSubscription.yaml
+++ b/ztp/source-crs/PaoSubscription.yaml
@@ -3,6 +3,8 @@ kind: Subscription
 metadata:
   name: performance-addon-operator
   namespace: openshift-performance-addon-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   channel: "4.9"
   name: performance-addon-operator

--- a/ztp/source-crs/PaoSubscriptionCatalogSource.yaml
+++ b/ztp/source-crs/PaoSubscriptionCatalogSource.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    ran.openshift.io/ztp-deploy-wave: "1"
 spec:
   displayName: Openshift Performance Addon Operator
   icon:

--- a/ztp/source-crs/PaoSubscriptionNS.yaml
+++ b/ztp/source-crs/PaoSubscriptionNS.yaml
@@ -4,5 +4,6 @@ metadata:
   name: openshift-performance-addon-operator
   annotations:
     workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "2"
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/ztp/source-crs/PaoSubscriptionOperGroup.yaml
+++ b/ztp/source-crs/PaoSubscriptionOperGroup.yaml
@@ -3,3 +3,5 @@ kind: OperatorGroup
 metadata:
   name: performance-addon-operator
   namespace: openshift-performance-addon-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"

--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -2,6 +2,8 @@ apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
   name: $name
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "100"
 spec:
   additionalKernelArgs:
   - "idle=poll"

--- a/ztp/source-crs/PtpCatSource.yaml
+++ b/ztp/source-crs/PtpCatSource.yaml
@@ -5,6 +5,7 @@ metadata:
     namespace: openshift-marketplace
     annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        ran.openshift.io/ztp-deploy-wave: "1"
 spec:
     displayName: ptp-operator-disconnected
     image: $imageUrl

--- a/ztp/source-crs/PtpConfigMaster.yaml
+++ b/ztp/source-crs/PtpConfigMaster.yaml
@@ -5,6 +5,8 @@ kind: PtpConfig
 metadata:
   name: grandmaster
   namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   profile:
   - name: "grandmaster"

--- a/ztp/source-crs/PtpConfigSlave.yaml
+++ b/ztp/source-crs/PtpConfigSlave.yaml
@@ -3,6 +3,8 @@ kind: PtpConfig
 metadata:
   name: slave
   namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   profile:
   - name: "slave"

--- a/ztp/source-crs/PtpConfigSlaveCvl.yaml
+++ b/ztp/source-crs/PtpConfigSlaveCvl.yaml
@@ -4,6 +4,8 @@ kind: PtpConfig
 metadata:
   name: slave
   namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   profile:
   - name: "slave"

--- a/ztp/source-crs/PtpOperatorConfigForEvent.yaml
+++ b/ztp/source-crs/PtpOperatorConfigForEvent.yaml
@@ -3,6 +3,8 @@ kind: PtpOperatorConfig
 metadata:
   name: default
   namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   daemonNodeSelector: {}
   ptpEventConfig:

--- a/ztp/source-crs/PtpSubscription.yaml
+++ b/ztp/source-crs/PtpSubscription.yaml
@@ -4,6 +4,8 @@ kind: Subscription
 metadata:
   name: ptp-operator-subscription
   namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   channel: "4.9"
   name: ptp-operator

--- a/ztp/source-crs/PtpSubscriptionNS.yaml
+++ b/ztp/source-crs/PtpSubscriptionNS.yaml
@@ -5,5 +5,6 @@ metadata:
   name: openshift-ptp
   annotations:
     workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "2"
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/ztp/source-crs/PtpSubscriptionOperGroup.yaml
+++ b/ztp/source-crs/PtpSubscriptionOperGroup.yaml
@@ -3,6 +3,8 @@ kind: OperatorGroup
 metadata:
   name: ptp-operators
   namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   targetNamespaces:
   - openshift-ptp

--- a/ztp/source-crs/ReduceMonitoringFootprint.yaml
+++ b/ztp/source-crs/ReduceMonitoringFootprint.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: cluster-monitoring-config
   namespace: openshift-monitoring
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "1"
 data:
   config.yaml: |
     grafana:

--- a/ztp/source-crs/SriovCatSource.yaml
+++ b/ztp/source-crs/SriovCatSource.yaml
@@ -5,6 +5,7 @@ metadata:
     namespace: openshift-marketplace
     annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        ran.openshift.io/ztp-deploy-wave: "1"
 spec:
     displayName: sriov-network-operator-disconnected
     image: $imageUrl

--- a/ztp/source-crs/SriovNetwork.yaml
+++ b/ztp/source-crs/SriovNetwork.yaml
@@ -3,6 +3,8 @@ kind: SriovNetwork
 metadata:
   name: ""
   namespace: openshift-sriov-network-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "100"
 spec:
   resourceName: ""
   networkNamespace:  openshift-sriov-network-operator

--- a/ztp/source-crs/SriovNetworkNodePolicy.yaml
+++ b/ztp/source-crs/SriovNetworkNodePolicy.yaml
@@ -3,6 +3,8 @@ kind: SriovNetworkNodePolicy
 metadata:
   name: $name
   namespace: openshift-sriov-network-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "100"
 spec:
   # The attributes for Mellanox/Intel based NICs as below.
   #     deviceType: netdevice/vfio-pci

--- a/ztp/source-crs/SriovOperatorConfig.yaml
+++ b/ztp/source-crs/SriovOperatorConfig.yaml
@@ -3,6 +3,8 @@ kind: SriovOperatorConfig
 metadata:
   name: default
   namespace: openshift-sriov-network-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   configDaemonNodeSelector:
     "node-role.kubernetes.io/$mcp": ""

--- a/ztp/source-crs/SriovSubscription.yaml
+++ b/ztp/source-crs/SriovSubscription.yaml
@@ -3,6 +3,8 @@ kind: Subscription
 metadata:
   name: sriov-network-operator-subscription
   namespace: openshift-sriov-network-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   channel: "4.9"
   name: sriov-network-operator

--- a/ztp/source-crs/SriovSubscriptionNS.yaml
+++ b/ztp/source-crs/SriovSubscriptionNS.yaml
@@ -4,5 +4,6 @@ metadata:
   name: openshift-sriov-network-operator
   annotations:
     workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "2"
   labels:
     openshift.io/run-level: "1"

--- a/ztp/source-crs/SriovSubscriptionOperGroup.yaml
+++ b/ztp/source-crs/SriovSubscriptionOperGroup.yaml
@@ -3,6 +3,8 @@ kind: OperatorGroup
 metadata:
   name: sriov-network-operators
   namespace: openshift-sriov-network-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   targetNamespaces:
   - openshift-sriov-network-operator

--- a/ztp/source-crs/StorageCatSource.yaml
+++ b/ztp/source-crs/StorageCatSource.yaml
@@ -5,6 +5,7 @@ metadata:
     namespace: openshift-marketplace
     annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        ran.openshift.io/ztp-deploy-wave: "1"
 spec:
     displayName: Openshift Local Storage Operator
     icon:

--- a/ztp/source-crs/StorageLV.yaml
+++ b/ztp/source-crs/StorageLV.yaml
@@ -3,6 +3,8 @@ kind: "LocalVolume"
 metadata:
   name: "local-disks"
   namespace: "openshift-local-storage"
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   logLevel: Normal
   managementState: Managed

--- a/ztp/source-crs/StorageNS.yaml
+++ b/ztp/source-crs/StorageNS.yaml
@@ -4,3 +4,4 @@ metadata:
   name: openshift-local-storage
   annotations:
     workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "2"

--- a/ztp/source-crs/StorageOperGroup.yaml
+++ b/ztp/source-crs/StorageOperGroup.yaml
@@ -3,6 +3,8 @@ kind: OperatorGroup
 metadata:
   name: openshift-local-storage
   namespace: openshift-local-storage
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   targetNamespaces:
   - openshift-local-storage

--- a/ztp/source-crs/StorageSubscription.yaml
+++ b/ztp/source-crs/StorageSubscription.yaml
@@ -3,6 +3,8 @@ kind: Subscription
 metadata:
   name: local-storage-operator
   namespace: openshift-local-storage
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   channel: "4.9"
   installPlanApproval: Automatic

--- a/ztp/source-crs/TunedPerformancePatch.yaml
+++ b/ztp/source-crs/TunedPerformancePatch.yaml
@@ -3,6 +3,8 @@ kind: Tuned
 metadata:
   name: performance-patch
   namespace: openshift-cluster-node-tuning-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "100"
 spec:
   profile:
     - name: performance-patch


### PR DESCRIPTION
Add 'ran.openshift.io/ztp-deploy-wave' annotation in source CR
to indicate its deploy order. It will be used to set policy's
'ran.openshift.io/ztp-deploy-wave' annotation.

A check added in Makefile to make sure our provided sourceCRs have this wave annotation.

Resources have same wave means they can be applied in one policy.
Resources have different waves means they need to be applied in order and in different policies.

The default resource waves are set according to [PR836](https://github.com/openshift-kni/cnf-features-deploy/pull/836/) which are based on common, group-du and site. We can adjust the default waves if some resources in one group(common/group-du/site) need to be applied in order.

Wave 1(common):
    Catalogsources
    DisconnectedICSP
    Disableoperatorhub
    ReduceMonitoringFootprint

Wave 2(common):
    OperatorNamespaces
    OperatorGroups
    OperatorSubscriptions
 
Wave 10(group-du):
    ClusterLogForwarder
    ClusterLogging
    consoleOperatorDisable
    ptpConfigSlave
    ptpConfigMaster
    ptpConfigSlaveCvl
    ptpOperatorConfigForEvent
    sriovOperatorConfig
    DisableSnoNetworkDiag
    StorageLV
 
 Wave 100(site specifics):
    Amqinstance
    performanceProfile
    SriovNetwork
    SriovNetworkNodePolicy
    TunedPerformancePatch

Jira: https://issues.redhat.com/browse/CNF-3635
Signed-off-by: Angie Wang <angwang@redhat.com> 
/cc @imiller0 @serngawy @browsell 