### PR TITLE
ztp: Add ztp-deploy-wave annotation in generated policy

### DIFF
--- a/ztp/policygenerator/policyGen/policyBuilderOverlay_test.go
+++ b/ztp/policygenerator/policyGen/policyBuilderOverlay_test.go
@@ -1,8 +1,9 @@
 package policyGen
 
 import (
-	utils "github.com/openshift-kni/cnf-features-deploy/ztp/policygenerator/utils"
 	"testing"
+
+	utils "github.com/openshift-kni/cnf-features-deploy/ztp/policygenerator/utils"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
@@ -74,6 +75,19 @@ spec:
 	assert.Equal(t, objDef["kind"], "JustForTest")
 	assert.NotNil(t, objDef["spec"])
 	assert.Nil(t, objDef["data"])
+	assert.NotNil(t, objDef["metadata"])
+
+	annotations := objDef["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})
+	assert.NotNil(t, annotations)
+	assert.Equal(t, len(annotations), 2)
+	assert.Equal(t, annotations["annot-key1"], "annot-value1")
+	assert.Equal(t, annotations["annot-key2"], "annot-value2")
+
+	labels := objDef["metadata"].(map[string]interface{})["labels"].(map[string]interface{})
+	assert.NotNil(t, labels)
+	assert.Equal(t, len(labels), 2)
+	assert.Equal(t, labels["label-key1"], "label-value1")
+	assert.Equal(t, labels["label-key2"], "label-value2")
 
 	topSimple, topList, topMap, subMap := validateBaselineStructure(t, objDef["spec"])
 	assert.Equal(t, topSimple, "tbd")
@@ -103,6 +117,13 @@ spec:
   sourceFiles:
     - fileName: GenericCR.yaml
       policyName: "gen-policy1"
+      metadata:
+        labels:
+          label-key1: label-newvalue
+          label-key3: label-value3
+        annotations:
+          annot-key2: annot-newvalue
+          annot-key3: annot-value3
       spec:
         topSimple: hello
         topList:
@@ -122,6 +143,21 @@ spec:
 	assert.NotNil(t, objDef)
 	assert.Equal(t, objDef["kind"], "JustForTest")
 	assert.NotNil(t, objDef["spec"])
+	assert.NotNil(t, objDef["metadata"])
+
+	annotations := objDef["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})
+	assert.NotNil(t, annotations)
+	assert.Equal(t, len(annotations), 3)
+	assert.Equal(t, annotations["annot-key1"], "annot-value1")
+	assert.Equal(t, annotations["annot-key2"], "annot-newvalue")
+	assert.Equal(t, annotations["annot-key3"], "annot-value3")
+
+	labels := objDef["metadata"].(map[string]interface{})["labels"].(map[string]interface{})
+	assert.NotNil(t, labels)
+	assert.Equal(t, len(labels), 3)
+	assert.Equal(t, labels["label-key1"], "label-newvalue")
+	assert.Equal(t, labels["label-key2"], "label-value2")
+	assert.Equal(t, labels["label-key3"], "label-value3")
 
 	topSimple, topList, topMap, subMap := validateBaselineStructure(t, objDef["spec"])
 	assert.Equal(t, topSimple, "hello")
@@ -225,7 +261,7 @@ spec:
 	assert.Equal(t, subMap["newKey"], "newValue")
 }
 
-// Test case where user provides overlay which adds a section (spec/data) which
+// Test case where user provides overlay which adds a section (spec/data/annotations/labels) which
 // was not in the source-cr
 func TestAddedSection(t *testing.T) {
 	input := `
@@ -310,6 +346,11 @@ spec:
   sourceFiles:
     - fileName: GenericDataCR.yaml
       policyName: "gen-policy1"
+      metadata:
+        labels:
+          label-key1: label-value1
+        annotations:
+          annot-key1: annot-value1
       spec:
         key5: value5
 `
@@ -324,4 +365,8 @@ spec:
 	assert.Equal(t, objDef["data"].(map[string]interface{})["justData"], true)
 	assert.NotNil(t, objDef["spec"])
 	assert.Equal(t, objDef["spec"].(map[string]interface{})["key5"], "value5")
+	assert.NotNil(t, objDef["metadata"].(map[string]interface{})["annotations"])
+	assert.Equal(t, objDef["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})["annot-key1"], "annot-value1")
+	assert.NotNil(t, objDef["metadata"].(map[string]interface{})["labels"])
+	assert.Equal(t, objDef["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["label-key1"], "label-value1")
 }

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericCR.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericCR.yaml
@@ -4,6 +4,12 @@ kind: JustForTest
 metadata:
   name: test123
   namespace: generic-ns
+  labels:
+    label-key1: label-value1
+    label-key2: label-value2
+  annotations:
+    annot-key1: annot-value1
+    annot-key2: annot-value2
 spec:
   topSimple: tbd
   topList:

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericConfig.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericConfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: generic.openshift.io/v1
+kind: generic
+metadata:
+  name: instance
+  namespace: openshift-generic
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  managementState: "Managed"

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericConfigWithoutWave.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericConfigWithoutWave.yaml
@@ -1,0 +1,7 @@
+apiVersion: generic.openshift.io/v1
+kind: generic
+metadata:
+  name: instance
+  namespace: openshift-generic
+spec:
+  managementState: "Managed"

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericNamespace.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericNamespace.yaml
@@ -5,5 +5,6 @@ metadata:
   name: generic-ns
   annotations:
     workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "1"
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericOperatorGroup.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericOperatorGroup.yaml
@@ -3,6 +3,8 @@ kind: OperatorGroup
 metadata:
   name: generic-operators
   namespace: generic-ns
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "1"
 spec:
   targetNamespaces:
   - generic-ns

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericSubscription.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericSubscription.yaml
@@ -4,6 +4,8 @@ kind: Subscription
 metadata:
   name: generic-operator-subscription
   namespace: generic-ns
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "1"
 spec:
   channel: "4.9"
   name: generic-operator

--- a/ztp/policygenerator/utils/utils.go
+++ b/ztp/policygenerator/utils/utils.go
@@ -6,6 +6,7 @@ const CustomResource = "customResource"
 const SourceCRsPath = "source-crs"
 const FileExt = ".yaml"
 const UnsetStringValue = "__unset_value__"
+const ZtpDeployWaveAnnotation = "ran.openshift.io/ztp-deploy-wave"
 
 // ComplianceType of "mustonlyhave" uses significant CPU to enforce. Default to
 // "musthave" so that we realize the CPU reductions unless explicitly told otherwise


### PR DESCRIPTION
In order to make ClusterGroupUpgrade operator determine the policies
deploy order, 'ran.openshift.io/ztp-deploy-wave' annotation is added
to each policy according to the sourceCRs wave annotation.
See, https://github.com/openshift-kni/cnf-features-deploy/pull/862

Resources have different waves means they need to be applied in order, so
one policy cannot have resources with different waves. PolicyGen will raise
error if it happens.
The wave annotation can be overwritten/added via PGT. 

Jira: https://issues.redhat.com/browse/CNF-3635
Signed-off-by: Angie Wang <angwang@redhat.com>
/cc @imiller0 @serngawy @browsell 