### PR TITLE
ztp: Fix policygenerator and siteconfig Makefiles

### DIFF
--- a/ztp/policygenerator/Makefile
+++ b/ztp/policygenerator/Makefile
@@ -1,9 +1,11 @@
 export GOFLAGS := $(if $(GOFLAGS),$(GOFLAGS),-mod=vendor)
 
 .PHONY: fmt build test vet all clean
+all: fmt vet build test
+
 
 fmt:
-	go fmt ./...
+	gofmt -l -w -s .
 
 build:
 	go build ./
@@ -13,8 +15,6 @@ test:
 
 vet:
 	go vet ./...
-
-all: fmt vet build test
 
 clean:
 	rm policygenerator

--- a/ztp/siteconfig-generator/Makefile
+++ b/ztp/siteconfig-generator/Makefile
@@ -1,6 +1,7 @@
 export GOFLAGS := $(if $(GOFLAGS),$(GOFLAGS),-mod=vendor)
 
 .PHONY: build test vet fmt all
+all: vet fmt build test
 
 build:
 	go build ./
@@ -12,8 +13,4 @@ vet:
 	go vet ./...
 
 fmt:
-	go fmt ./...
-
-
-all: vet fmt build test
-
+	gofmt -l -w -s .


### PR DESCRIPTION
This makes the fmt command match what out github ci requires, and makes
"all" the default target.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
