### PR TITLE
Bug 2033440: cnf-tests: Update gatekeeper config definition

### DIFF
--- a/feature-configs/deploy/gatekeeper/config.yaml
+++ b/feature-configs/deploy/gatekeeper/config.yaml
@@ -3,13 +3,5 @@ kind: Gatekeeper
 metadata:
   name: gatekeeper
 spec:
-  audit:
-    logLevel: INFO
-    replicas: 1
-  image:
-    image: registry.redhat.io/rhacm2/gatekeeper-rhel8@sha256:63bd1bbb6f825fc45f2c7dc71f5f2bf118621a6b5dad8de4ad4e50eb5c720118
   mutatingWebhook: Enabled
   validatingWebhook: Enabled
-  webhook:
-    logLevel: INFO
-    replicas: 1


### PR DESCRIPTION
Use the default gatekeeper operator config in the tests.
The additional properties are optional and are not required.
Using a replica count of one will cause issues with the PodDisruptionBudget when we try to move the pod to a different node (https://bugzilla.redhat.com/2033440)