### PR TITLE
[Release 4.7] Bump to use go mod in the openshift CI image build

### DIFF
--- a/hack/build-test-bin.sh
+++ b/hack/build-test-bin.sh
@@ -13,7 +13,7 @@ export GOFLAGS="${GOFLAGS:-"-mod=vendor"}"
 
 export PATH=$PATH:$GOPATH/bin
 
-if ! which gingko; then
+if ! which ginkgo; then
 	echo "Downloading ginkgo tool"
 	go install github.com/onsi/ginkgo/ginkgo
 fi

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -3,7 +3,7 @@ FROM quay.io/fedora/fedora:31-x86_64
 ENV GOPATH /go
 ENV GOBIN /go/bin
 ENV GOCACHE /go/.cache
-ENV GOVERSION 1.15.15
+ENV GOVERSION 1.15.2
 ENV PATH=$PATH:/root/.gimme/versions/go"$GOVERSION".linux.amd64/bin:$GOBIN
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/cnf-features-deploy
 
@@ -25,25 +25,12 @@ RUN mkdir ~/bin && \
     chmod +x /usr/local/bin/gimme && \
     eval "$(gimme $GOVERSION)" && \
     cat $GIMME_ENV >> $HOME/.bashrc && \
-    # get required golang tools and OC client
-    go get github.com/onsi/ginkgo/ginkgo && \
-    go get github.com/onsi/gomega/... && \
-    go get -u golang.org/x/lint/golint && \
     export latest_oc_client_version=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ 2>/dev/null | grep -o \"openshift-client-linux-4.*tar.gz\" | tr -d \") && \
     curl -JL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${latest_oc_client_version} -o oc.tar.gz && \
     tar -xzvf oc.tar.gz && \
     mv oc /usr/local/bin/oc && \
     ln -s /usr/local/bin/oc /usr/local/bin/kubectl && \
     rm -f oc.tar.gz
-
-RUN export TMP_BIN=$(mktemp -d) && \
-    mv $GOBIN/* $TMP_BIN/ && \
-    rm -rf ${GOPATH} ${GOCACHE} && \
-    mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/ && \
-    mkdir -p ${GOBIN} && \
-    chmod -R 775 ${GOPATH} && \
-    mv $TMP_BIN/* ${GOBIN} && \
-    rm -rf $TMP_BIN
 
 WORKDIR ${GOPATH}/src/${GO_PACKAGE_PATH}
 


### PR DESCRIPTION
This is needed to fix

```
STEP 10/15: RUN mkdir ~/bin &&     curl -sL -o /usr/local/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme &&     chmod +x /usr/local/bin/gimme &&     eval "$(gimme $GOVERSION)" &&     cat $GIMME_ENV >> $HOME/.bashrc &&     go get github.com/onsi/ginkgo/ginkgo &&     go get github.com/onsi/gomega/... &&     go get -u golang.org/x/lint/golint &&     export latest_oc_client_version=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ 2>/dev/null | grep -o \"openshift-client-linux-4.*tar.gz\" | tr -d \") &&     curl -JL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${latest_oc_client_version} -o oc.tar.gz &&     tar -xzvf oc.tar.gz &&     mv oc /usr/local/bin/oc &&     ln -s /usr/local/bin/oc /usr/local/bin/kubectl &&     rm -f oc.tar.gz
go version go1.15.15 linux/amd64
go/src/github.com/onsi/ginkgo/ginkgo/testsuite/test_suite.go:54:14: undefined: os.ReadDir
go/src/github.com/onsi/ginkgo/ginkgo/testsuite/test_suite.go:87:30: undefined: os.DirEntry
go/src/github.com/onsi/ginkgo/ginkgo/testsuite/test_suite.go:100:47: undefined: os.DirEntry
go/src/github.com/onsi/ginkgo/ginkgo/testsuite/test_suite.go:106:19: undefined: os.ReadFile
go/src/github.com/onsi/ginkgo/ginkgo/convert/package_rewriter.go:39:19: undefined: os.ReadDir
go/src/github.com/onsi/ginkgo/ginkgo/convert/testfile_rewriter.go:63:8: undefined: os.WriteFile
go/src/github.com/onsi/ginkgo/internal/leafnodes/synchronized_after_suite_node.go:77:15: undefined: io.ReadAll
go/src/github.com/onsi/ginkgo/internal/leafnodes/synchronized_before_suite_node.go:89:16: undefined: io.ReadAll
error: build error: error building at STEP "RUN mkdir ~/bin &&     curl -sL -o /usr/local/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme &&     chmod +x /usr/local/bin/gimme &&     eval "$(gimme $GOVERSION)" &&     cat $GIMME_ENV >> $HOME/.bashrc &&     go get github.com/onsi/ginkgo/ginkgo &&     go get github.com/onsi/gomega/... &&     go get -u golang.org/x/lint/golint &&     export latest_oc_client_version=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ 2>/dev/null | grep -o \"openshift-client-linux-4.*tar.gz\" | tr -d \") &&     curl -JL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${latest_oc_client_version} -o oc.tar.gz &&     tar -xzvf oc.tar.gz &&     mv oc /usr/local/bin/oc &&     ln -s /usr/local/bin/oc /usr/local/bin/kubectl &&     rm -f oc.tar.gz": error while running runtime: exit status 2
[36mINFO[0m[2021-12-23T10:20:30Z] Ran for 1m45s
```

The problem is with go get (without go mod) it's not possible to specifi a version to download, And the latest version of ginkgo switch to use golang 1.17 features

build test

```
STEP 1/13: FROM quay.io/fedora/fedora:31-x86_64
STEP 2/13: ENV GOPATH /go
--> Using cache e73a73762befd235dcc360f3acae2b4b47afbdc12257893344fc1ab2fc084dc0
--> e73a73762be
STEP 3/13: ENV GOBIN /go/bin
--> Using cache dcf9bd3798bb02a46495c564f6ba22bbb555f487ebe6345458313739933b350f
--> dcf9bd3798b
STEP 4/13: ENV GOCACHE /go/.cache
--> Using cache 6cf879409478c436eb06586b8bc21cd3de847cfe9cd0b0b139c21c8d71a0c9a2
--> 6cf87940947
STEP 5/13: ENV GOVERSION 1.15.2
--> 51930671f05
STEP 6/13: ENV GOMEGOVERSION 1.15.0
--> d93cab03e49
STEP 7/13: ENV PATH=$PATH:/root/.gimme/versions/go"$GOVERSION".linux.amd64/bin:$GOBIN
--> 97989d7307f
STEP 8/13: ARG GO_PACKAGE_PATH=github.com/openshift-kni/cnf-features-deploy
--> f99d7f1ca5a
STEP 9/13: RUN dnf -y install     git     make     gettext     which     skopeo     findutils     gcc     python2     && dnf clean all
Fedora Modular 31 - x86_64                      2.9 MB/s | 5.2 MB     00:01
Fedora Modular 31 - x86_64 - Updates            2.1 MB/s | 4.5 MB     00:02
Fedora 31 - x86_64 - Updates                     10 MB/s |  27 MB     00:02
Fedora 31 - x86_64                               18 MB/s |  71 MB     00:03
Dependencies resolved.
================================================================================
 Package                  Arch     Version                      Repo       Size
================================================================================
Installing:
 findutils                x86_64   1:4.6.0-25.fc31              updates   517 k
 gcc                      x86_64   9.3.1-2.fc31                 updates    21 M
 gettext                  x86_64   0.20.1-3.fc31                updates   1.1 M
 git                      x86_64   2.25.4-1.fc31                updates   125 k
 make                     x86_64   1:4.2.1-15.fc31              updates   494 k
 python2                  x86_64   2.7.18-6.fc31                updates    39 k
 skopeo                   x86_64   1:1.2.0-1.fc31               updates   7.0 M
 which                    x86_64   2.21-15.fc31                 fedora     42 k
Upgrading:
 glibc                    x86_64   2.30-13.fc31                 updates   3.5 M
 glibc-common             x86_64   2.30-13.fc31                 updates   702 k
 glibc-minimal-langpack   x86_64   2.30-13.fc31                 updates    44 k
 libxcrypt                x86_64   4.4.17-1.fc31                updates   124 k
Installing dependencies:
 binutils                 x86_64   2.32-33.fc31                 updates   5.1 M
 binutils-gold            x86_64   2.32-33.fc31                 updates   832 k
 containers-common        x86_64   1:1.2.0-1.fc31               updates    47 k
 cpp                      x86_64   9.3.1-2.fc31                 updates   9.8 M
 emacs-filesystem         noarch   1:26.3-1.fc31                updates   8.5 k
 fipscheck                x86_64   1.5.0-7.fc31                 fedora     26 k
 fipscheck-lib            x86_64   1.5.0-7.fc31                 fedora     14 k
 gc                       x86_64   7.6.4-6.fc31                 fedora    104 k
 gdbm                     x86_64   1:1.18.1-1.fc31              fedora    127 k
 gettext-libs             x86_64   0.20.1-3.fc31                updates   287 k
 git-core                 x86_64   2.25.4-1.fc31                updates   4.8 M
 git-core-doc             noarch   2.25.4-1.fc31                updates   2.2 M
 glibc-devel              x86_64   2.30-13.fc31                 updates   1.0 M
 glibc-headers            x86_64   2.30-13.fc31                 updates   442 k
 groff-base               x86_64   1.22.3-21.fc31               updates   1.0 M
 guile22                  x86_64   2.2.6-2.fc31                 fedora    6.6 M
 isl                      x86_64   0.16.1-9.fc31                fedora    871 k
 kernel-headers           x86_64   5.8.18-100.fc31              updates   1.2 M
 less                     x86_64   551-2.fc31                   fedora    154 k
 libatomic_ops            x86_64   7.6.10-2.fc31                fedora     36 k
 libcroco                 x86_64   0.6.13-2.fc31                fedora    112 k
 libedit                  x86_64   3.1-30.20191211cvs.fc31      updates   105 k
 libmpc                   x86_64   1.1.0-4.fc31                 fedora     60 k
 libpkgconf               x86_64   1.6.3-2.fc31                 fedora     37 k
 libtextstyle             x86_64   0.20.1-3.fc31                updates    55 k
 libtool-ltdl             x86_64   2.4.6-31.fc31                fedora     37 k
 libxcrypt-devel          x86_64   4.4.17-1.fc31                updates    32 k
 openssh                  x86_64   8.1p1-1.fc31                 updates   440 k
 openssh-clients          x86_64   8.1p1-1.fc31                 updates   601 k
 perl-Carp                noarch   1.50-439.fc31                fedora     29 k
 perl-Data-Dumper         x86_64   2.174-443.fc31               updates    56 k
 perl-Digest              noarch   1.19-1.fc31                  updates    25 k
 perl-Digest-MD5          x86_64   2.55-439.fc31                fedora     36 k
 perl-Encode              x86_64   4:3.07-457.fc31              updates   1.8 M
 perl-Errno               x86_64   1.30-456.fc31                updates    24 k
 perl-Error               noarch   1:0.17028-1.fc31             fedora     42 k
 perl-Exporter            noarch   5.74-1.fc31                  updates    32 k
 perl-File-Path           noarch   2.17-1.fc31                  updates    35 k
 perl-File-Temp           noarch   1:0.230.900-439.fc31         fedora     60 k
 perl-Getopt-Long         noarch   1:2.52-1.fc31                updates    60 k
 perl-Git                 noarch   2.25.4-1.fc31                updates    44 k
 perl-HTTP-Tiny           noarch   0.076-439.fc31               fedora     55 k
 perl-IO                  x86_64   1.40-456.fc31                updates    90 k
 perl-MIME-Base64         x86_64   3.15-439.fc31                fedora     30 k
 perl-Net-SSLeay          x86_64   1.88-3.fc31                  fedora    355 k
 perl-PathTools           x86_64   3.78-441.fc31                updates    85 k
 perl-Pod-Escapes         noarch   1:1.07-439.fc31              fedora     20 k
 perl-Pod-Perldoc         noarch   3.28.01-442.fc31             fedora     85 k
 perl-Pod-Simple          noarch   1:3.39-2.fc31                fedora    214 k
 perl-Pod-Usage           noarch   4:2.01-1.fc31                updates    41 k
 perl-Scalar-List-Utils   x86_64   3:1.53-439.fc31              updates    66 k
 perl-Socket              x86_64   4:2.030-1.fc31               updates    55 k
 perl-Storable            x86_64   1:3.15-442.fc31              updates    97 k
 perl-Term-ANSIColor      noarch   4.06-440.fc31                fedora     44 k
 perl-Term-Cap            noarch   1.17-439.fc31                fedora     22 k
 perl-TermReadKey         x86_64   2.38-4.fc31                  fedora     36 k
 perl-Text-ParseWords     noarch   3.30-439.fc31                fedora     16 k
 perl-Text-Tabs+Wrap      noarch   2013.0523-439.fc31           fedora     23 k
 perl-Time-Local          noarch   2:1.300-1.fc31               updates    34 k
 perl-URI                 noarch   1.76-5.fc31                  fedora    108 k
 perl-Unicode-Normalize   x86_64   1.26-439.fc31                fedora     97 k
 perl-constant            noarch   1.33-440.fc31                fedora     23 k
 perl-interpreter         x86_64   4:5.30.3-456.fc31            updates   6.1 M
 perl-libnet              noarch   3.11-440.fc31                fedora    117 k
 perl-libs                x86_64   4:5.30.3-456.fc31            updates   1.7 M
 perl-macros              noarch   4:5.30.3-456.fc31            updates    19 k
 perl-parent              noarch   1:0.237-439.fc31             fedora     14 k
 perl-podlators           noarch   1:4.12-2.fc31                fedora    113 k
 perl-threads             x86_64   1:2.22-439.fc31              fedora     58 k
 perl-threads-shared      x86_64   1.60-440.fc31                fedora     44 k
 pkgconf                  x86_64   1.6.3-2.fc31                 fedora     41 k
 pkgconf-m4               noarch   1.6.3-2.fc31                 fedora     15 k
 pkgconf-pkg-config       x86_64   1.6.3-2.fc31                 fedora     11 k
 python2-libs             x86_64   2.7.18-6.fc31                updates   6.0 M
 whois-nls                noarch   5.5.7-1.fc31                 updates    34 k
Installing weak dependencies:
 libxcrypt-compat         x86_64   4.4.17-1.fc31                updates    96 k
 mkpasswd                 x86_64   5.5.7-1.fc31                 updates    41 k
 perl-IO-Socket-IP        noarch   0.39-440.fc31                fedora     42 k
 perl-IO-Socket-SSL       noarch   2.066-7.fc31                 updates   238 k
 perl-Mozilla-CA          noarch   20200520-1.fc31              updates    12 k
 python2-pip              noarch   19.1.1-8.fc31                updates   1.7 M
 python2-setuptools       noarch   41.6.0-1.fc31                updates   584 k

Transaction Summary
================================================================================
Install  90 Packages
Upgrade   4 Packages

Total download size: 92 M
Downloading Packages:
(1/94): containers-common-1.2.0-1.fc31.x86_64.r 122 kB/s |  47 kB     00:00
(2/94): binutils-gold-2.32-33.fc31.x86_64.rpm   1.1 MB/s | 832 kB     00:00
(3/94): emacs-filesystem-26.3-1.fc31.noarch.rpm  40 kB/s | 8.5 kB     00:00
(4/94): binutils-2.32-33.fc31.x86_64.rpm        5.0 MB/s | 5.1 MB     00:01
(5/94): cpp-9.3.1-2.fc31.x86_64.rpm              13 MB/s | 9.8 MB     00:00
(6/94): findutils-4.6.0-25.fc31.x86_64.rpm      2.4 MB/s | 517 kB     00:00
(7/94): gettext-libs-0.20.1-3.fc31.x86_64.rpm   544 kB/s | 287 kB     00:00
(8/94): gettext-0.20.1-3.fc31.x86_64.rpm        1.9 MB/s | 1.1 MB     00:00
(9/94): gcc-9.3.1-2.fc31.x86_64.rpm              26 MB/s |  21 MB     00:00
(10/94): git-2.25.4-1.fc31.x86_64.rpm           699 kB/s | 125 kB     00:00
(11/94): git-core-2.25.4-1.fc31.x86_64.rpm       21 MB/s | 4.8 MB     00:00
(12/94): glibc-devel-2.30-13.fc31.x86_64.rpm    6.9 MB/s | 1.0 MB     00:00
(13/94): git-core-doc-2.25.4-1.fc31.noarch.rpm  8.2 MB/s | 2.2 MB     00:00
(14/94): glibc-headers-2.30-13.fc31.x86_64.rpm  2.6 MB/s | 442 kB     00:00
(15/94): groff-base-1.22.3-21.fc31.x86_64.rpm   8.6 MB/s | 1.0 MB     00:00
(16/94): libtextstyle-0.20.1-3.fc31.x86_64.rpm  513 kB/s |  55 kB     00:00
(17/94): libedit-3.1-30.20191211cvs.fc31.x86_64 941 kB/s | 105 kB     00:00
(18/94): kernel-headers-5.8.18-100.fc31.x86_64. 4.5 MB/s | 1.2 MB     00:00
(19/94): libxcrypt-compat-4.4.17-1.fc31.x86_64. 604 kB/s |  96 kB     00:00
(20/94): libxcrypt-devel-4.4.17-1.fc31.x86_64.r 203 kB/s |  32 kB     00:00
(21/94): mkpasswd-5.5.7-1.fc31.x86_64.rpm       307 kB/s |  41 kB     00:00
(22/94): openssh-8.1p1-1.fc31.x86_64.rpm        2.8 MB/s | 440 kB     00:00
(23/94): make-4.2.1-15.fc31.x86_64.rpm          3.1 MB/s | 494 kB     00:00
(24/94): perl-Digest-1.19-1.fc31.noarch.rpm     318 kB/s |  25 kB     00:00
(25/94): perl-Data-Dumper-2.174-443.fc31.x86_64 664 kB/s |  56 kB     00:00
(26/94): openssh-clients-8.1p1-1.fc31.x86_64.rp 5.5 MB/s | 601 kB     00:00
(27/94): perl-Errno-1.30-456.fc31.x86_64.rpm    293 kB/s |  24 kB     00:00
(28/94): perl-Exporter-5.74-1.fc31.noarch.rpm   377 kB/s |  32 kB     00:00
(29/94): perl-Encode-3.07-457.fc31.x86_64.rpm    18 MB/s | 1.8 MB     00:00
(30/94): perl-File-Path-2.17-1.fc31.noarch.rpm  457 kB/s |  35 kB     00:00
(31/94): perl-Getopt-Long-2.52-1.fc31.noarch.rp 783 kB/s |  60 kB     00:00
(32/94): perl-Git-2.25.4-1.fc31.noarch.rpm      557 kB/s |  44 kB     00:00
(33/94): perl-IO-1.40-456.fc31.x86_64.rpm       1.2 MB/s |  90 kB     00:00
(34/94): perl-IO-Socket-SSL-2.066-7.fc31.noarch 3.0 MB/s | 238 kB     00:00
(35/94): perl-Mozilla-CA-20200520-1.fc31.noarch 157 kB/s |  12 kB     00:00
(36/94): perl-PathTools-3.78-441.fc31.x86_64.rp 1.1 MB/s |  85 kB     00:00
(37/94): perl-Pod-Usage-2.01-1.fc31.noarch.rpm  532 kB/s |  41 kB     00:00
(38/94): perl-Scalar-List-Utils-1.53-439.fc31.x 851 kB/s |  66 kB     00:00
(39/94): perl-Socket-2.030-1.fc31.x86_64.rpm    722 kB/s |  55 kB     00:00
(40/94): perl-Storable-3.15-442.fc31.x86_64.rpm 1.2 MB/s |  97 kB     00:00
(41/94): perl-Time-Local-1.300-1.fc31.noarch.rp 441 kB/s |  34 kB     00:00
(42/94): perl-libs-5.30.3-456.fc31.x86_64.rpm   5.4 MB/s | 1.7 MB     00:00
(43/94): perl-macros-5.30.3-456.fc31.noarch.rpm  52 kB/s |  19 kB     00:00
(44/94): perl-interpreter-5.30.3-456.fc31.x86_6  12 MB/s | 6.1 MB     00:00
(45/94): python2-2.7.18-6.fc31.x86_64.rpm       206 kB/s |  39 kB     00:00
(46/94): python2-libs-2.7.18-6.fc31.x86_64.rpm   19 MB/s | 6.0 MB     00:00
(47/94): python2-setuptools-41.6.0-1.fc31.noarc 2.8 MB/s | 584 kB     00:00
(48/94): python2-pip-19.1.1-8.fc31.noarch.rpm   6.9 MB/s | 1.7 MB     00:00
(49/94): whois-nls-5.5.7-1.fc31.noarch.rpm      374 kB/s |  34 kB     00:00
(50/94): skopeo-1.2.0-1.fc31.x86_64.rpm          20 MB/s | 7.0 MB     00:00
(51/94): fipscheck-1.5.0-7.fc31.x86_64.rpm       41 kB/s |  26 kB     00:00
(52/94): fipscheck-lib-1.5.0-7.fc31.x86_64.rpm   23 kB/s |  14 kB     00:00
(53/94): gc-7.6.4-6.fc31.x86_64.rpm             167 kB/s | 104 kB     00:00
(54/94): gdbm-1.18.1-1.fc31.x86_64.rpm          391 kB/s | 127 kB     00:00
(55/94): less-551-2.fc31.x86_64.rpm             388 kB/s | 154 kB     00:00
(56/94): guile22-2.2.6-2.fc31.x86_64.rpm        7.9 MB/s | 6.6 MB     00:00
(57/94): isl-0.16.1-9.fc31.x86_64.rpm           1.5 MB/s | 871 kB     00:00
(58/94): libatomic_ops-7.6.10-2.fc31.x86_64.rpm 281 kB/s |  36 kB     00:00
(59/94): libcroco-0.6.13-2.fc31.x86_64.rpm      885 kB/s | 112 kB     00:00
(60/94): libmpc-1.1.0-4.fc31.x86_64.rpm         408 kB/s |  60 kB     00:00
(61/94): libpkgconf-1.6.3-2.fc31.x86_64.rpm     230 kB/s |  37 kB     00:00
(62/94): libtool-ltdl-2.4.6-31.fc31.x86_64.rpm  352 kB/s |  37 kB     00:00
(63/94): perl-Carp-1.50-439.fc31.noarch.rpm     304 kB/s |  29 kB     00:00
(64/94): perl-Digest-MD5-2.55-439.fc31.x86_64.r 366 kB/s |  36 kB     00:00
(65/94): perl-Error-0.17028-1.fc31.noarch.rpm   430 kB/s |  42 kB     00:00
(66/94): perl-File-Temp-0.230.900-439.fc31.noar 605 kB/s |  60 kB     00:00
(67/94): perl-HTTP-Tiny-0.076-439.fc31.noarch.r 560 kB/s |  55 kB     00:00
(68/94): perl-IO-Socket-IP-0.39-440.fc31.noarch 436 kB/s |  42 kB     00:00
(69/94): perl-MIME-Base64-3.15-439.fc31.x86_64. 295 kB/s |  30 kB     00:00
(70/94): perl-Net-SSLeay-1.88-3.fc31.x86_64.rpm 3.4 MB/s | 355 kB     00:00
(71/94): perl-Pod-Escapes-1.07-439.fc31.noarch. 206 kB/s |  20 kB     00:00
(72/94): perl-Pod-Perldoc-3.28.01-442.fc31.noar 869 kB/s |  85 kB     00:00
(73/94): perl-Pod-Simple-3.39-2.fc31.noarch.rpm 2.1 MB/s | 214 kB     00:00
(74/94): perl-Term-ANSIColor-4.06-440.fc31.noar 462 kB/s |  44 kB     00:00
(75/94): perl-Term-Cap-1.17-439.fc31.noarch.rpm 228 kB/s |  22 kB     00:00
(76/94): perl-TermReadKey-2.38-4.fc31.x86_64.rp 374 kB/s |  36 kB     00:00
(77/94): perl-Text-ParseWords-3.30-439.fc31.noa 158 kB/s |  16 kB     00:00
(78/94): perl-Text-Tabs+Wrap-2013.0523-439.fc31 237 kB/s |  23 kB     00:00
(79/94): perl-URI-1.76-5.fc31.noarch.rpm        1.1 MB/s | 108 kB     00:00
(80/94): perl-Unicode-Normalize-1.26-439.fc31.x 1.0 MB/s |  97 kB     00:00
(81/94): perl-constant-1.33-440.fc31.noarch.rpm 238 kB/s |  23 kB     00:00
(82/94): perl-libnet-3.11-440.fc31.noarch.rpm   1.2 MB/s | 117 kB     00:00
(83/94): perl-parent-0.237-439.fc31.noarch.rpm  143 kB/s |  14 kB     00:00
(84/94): perl-podlators-4.12-2.fc31.noarch.rpm  1.1 MB/s | 113 kB     00:00
(85/94): perl-threads-2.22-439.fc31.x86_64.rpm  606 kB/s |  58 kB     00:00
(86/94): perl-threads-shared-1.60-440.fc31.x86_ 365 kB/s |  44 kB     00:00
(87/94): pkgconf-1.6.3-2.fc31.x86_64.rpm        309 kB/s |  41 kB     00:00
(88/94): pkgconf-m4-1.6.3-2.fc31.noarch.rpm     113 kB/s |  15 kB     00:00
(89/94): pkgconf-pkg-config-1.6.3-2.fc31.x86_64 100 kB/s |  11 kB     00:00
(90/94): which-2.21-15.fc31.x86_64.rpm          356 kB/s |  42 kB     00:00
(91/94): glibc-minimal-langpack-2.30-13.fc31.x8  76 kB/s |  44 kB     00:00
(92/94): glibc-common-2.30-13.fc31.x86_64.rpm   1.1 MB/s | 702 kB     00:00
(93/94): glibc-2.30-13.fc31.x86_64.rpm          4.4 MB/s | 3.5 MB     00:00
(94/94): libxcrypt-4.4.17-1.fc31.x86_64.rpm     1.2 MB/s | 124 kB     00:00
--------------------------------------------------------------------------------
Total                                            11 MB/s |  92 MB     00:08
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1
  Upgrading        : glibc-common-2.30-13.fc31.x86_64                      1/98
  Upgrading        : glibc-minimal-langpack-2.30-13.fc31.x86_64            2/98
  Running scriptlet: glibc-2.30-13.fc31.x86_64                             3/98
  Upgrading        : glibc-2.30-13.fc31.x86_64                             3/98
  Running scriptlet: glibc-2.30-13.fc31.x86_64                             3/98
  Installing       : binutils-gold-2.32-33.fc31.x86_64                     4/98
  Installing       : binutils-2.32-33.fc31.x86_64                          5/98
  Running scriptlet: binutils-2.32-33.fc31.x86_64                          5/98
  Installing       : libmpc-1.1.0-4.fc31.x86_64                            6/98
  Installing       : cpp-9.3.1-2.fc31.x86_64                               7/98
  Running scriptlet: groff-base-1.22.3-21.fc31.x86_64                      8/98
  Installing       : groff-base-1.22.3-21.fc31.x86_64                      8/98
  Running scriptlet: groff-base-1.22.3-21.fc31.x86_64                      8/98
  Installing       : libedit-3.1-30.20191211cvs.fc31.x86_64                9/98
  Installing       : fipscheck-lib-1.5.0-7.fc31.x86_64                    10/98
  Installing       : fipscheck-1.5.0-7.fc31.x86_64                        11/98
  Installing       : gdbm-1:1.18.1-1.fc31.x86_64                          12/98
  Installing       : isl-0.16.1-9.fc31.x86_64                             13/98
  Installing       : less-551-2.fc31.x86_64                               14/98
  Installing       : libatomic_ops-7.6.10-2.fc31.x86_64                   15/98
  Installing       : gc-7.6.4-6.fc31.x86_64                               16/98
  Installing       : libcroco-0.6.13-2.fc31.x86_64                        17/98
  Installing       : libtextstyle-0.20.1-3.fc31.x86_64                    18/98
  Installing       : gettext-libs-0.20.1-3.fc31.x86_64                    19/98
  Installing       : libpkgconf-1.6.3-2.fc31.x86_64                       20/98
  Installing       : pkgconf-1.6.3-2.fc31.x86_64                          21/98
  Installing       : libtool-ltdl-2.4.6-31.fc31.x86_64                    22/98
  Installing       : pkgconf-m4-1.6.3-2.fc31.noarch                       23/98
  Installing       : pkgconf-pkg-config-1.6.3-2.fc31.x86_64               24/98
  Installing       : whois-nls-5.5.7-1.fc31.noarch                        25/98
  Upgrading        : libxcrypt-4.4.17-1.fc31.x86_64                       26/98
  Installing       : mkpasswd-5.5.7-1.fc31.x86_64                         27/98
  Installing       : perl-Exporter-5.74-1.fc31.noarch                     28/98
  Installing       : perl-Carp-1.50-439.fc31.noarch                       29/98
  Installing       : perl-libs-4:5.30.3-456.fc31.x86_64                   30/98
  Installing       : perl-Scalar-List-Utils-3:1.53-439.fc31.x86_64        31/98
  Installing       : perl-parent-1:0.237-439.fc31.noarch                  32/98
  Installing       : perl-Text-ParseWords-3.30-439.fc31.noarch            33/98
  Installing       : perl-Term-ANSIColor-4.06-440.fc31.noarch             34/98
  Installing       : perl-Unicode-Normalize-1.26-439.fc31.x86_64          35/98
  Installing       : perl-Errno-1.30-456.fc31.x86_64                      36/98
  Installing       : perl-Socket-4:2.030-1.fc31.x86_64                    37/98
  Installing       : perl-macros-4:5.30.3-456.fc31.noarch                 38/98
  Installing       : perl-Text-Tabs+Wrap-2013.0523-439.fc31.noarch        39/98
  Installing       : perl-File-Path-2.17-1.fc31.noarch                    40/98
  Installing       : perl-IO-1.40-456.fc31.x86_64                         41/98
  Installing       : perl-PathTools-3.78-441.fc31.x86_64                  42/98
  Installing       : perl-constant-1.33-440.fc31.noarch                   43/98
  Installing       : perl-threads-1:2.22-439.fc31.x86_64                  44/98
  Installing       : perl-threads-shared-1.60-440.fc31.x86_64             45/98
  Installing       : perl-interpreter-4:5.30.3-456.fc31.x86_64            46/98
  Installing       : perl-MIME-Base64-3.15-439.fc31.x86_64                47/98
  Installing       : perl-IO-Socket-IP-0.39-440.fc31.noarch               48/98
  Installing       : perl-Time-Local-2:1.300-1.fc31.noarch                49/98
  Installing       : perl-File-Temp-1:0.230.900-439.fc31.noarch           50/98
  Installing       : perl-Digest-1.19-1.fc31.noarch                       51/98
  Installing       : perl-Digest-MD5-2.55-439.fc31.x86_64                 52/98
  Installing       : perl-Net-SSLeay-1.88-3.fc31.x86_64                   53/98
  Installing       : perl-Data-Dumper-2.174-443.fc31.x86_64               54/98
  Installing       : perl-Storable-1:3.15-442.fc31.x86_64                 55/98
  Installing       : perl-Error-1:0.17028-1.fc31.noarch                   56/98
  Installing       : perl-Pod-Escapes-1:1.07-439.fc31.noarch              57/98
  Installing       : perl-Term-Cap-1.17-439.fc31.noarch                   58/98
  Installing       : perl-TermReadKey-2.38-4.fc31.x86_64                  59/98
  Installing       : perl-Mozilla-CA-20200520-1.fc31.noarch               60/98
  Installing       : perl-HTTP-Tiny-0.076-439.fc31.noarch                 61/98
  Installing       : perl-libnet-3.11-440.fc31.noarch                     62/98
  Installing       : perl-IO-Socket-SSL-2.066-7.fc31.noarch               63/98
  Installing       : perl-URI-1.76-5.fc31.noarch                          64/98
  Installing       : perl-Encode-4:3.07-457.fc31.x86_64                   65/98
  Installing       : perl-Pod-Simple-1:3.39-2.fc31.noarch                 66/98
  Installing       : perl-Getopt-Long-1:2.52-1.fc31.noarch                67/98
  Installing       : perl-podlators-1:4.12-2.fc31.noarch                  68/98
  Installing       : perl-Pod-Perldoc-3.28.01-442.fc31.noarch             69/98
  Installing       : perl-Pod-Usage-4:2.01-1.fc31.noarch                  70/98
  Installing       : libxcrypt-compat-4.4.17-1.fc31.x86_64                71/98
  Installing       : python2-libs-2.7.18-6.fc31.x86_64                    72/98
  Installing       : python2-setuptools-41.6.0-1.fc31.noarch              73/98
  Installing       : python2-2.7.18-6.fc31.x86_64                         74/98
  Installing       : python2-pip-19.1.1-8.fc31.noarch                     75/98
  Running scriptlet: openssh-8.1p1-1.fc31.x86_64                          76/98
  Installing       : openssh-8.1p1-1.fc31.x86_64                          76/98
  Installing       : openssh-clients-8.1p1-1.fc31.x86_64                  77/98
  Installing       : git-core-2.25.4-1.fc31.x86_64                        78/98
  Installing       : git-core-doc-2.25.4-1.fc31.noarch                    79/98
  Installing       : guile22-2.2.6-2.fc31.x86_64                          80/98
  Running scriptlet: guile22-2.2.6-2.fc31.x86_64                          80/98
  Installing       : kernel-headers-5.8.18-100.fc31.x86_64                81/98
  Running scriptlet: glibc-headers-2.30-13.fc31.x86_64                    82/98
  Installing       : glibc-headers-2.30-13.fc31.x86_64                    82/98
  Installing       : libxcrypt-devel-4.4.17-1.fc31.x86_64                 83/98
  Installing       : glibc-devel-2.30-13.fc31.x86_64                      84/98
  Installing       : emacs-filesystem-1:26.3-1.fc31.noarch                85/98
  Installing       : perl-Git-2.25.4-1.fc31.noarch                        86/98
  Installing       : git-2.25.4-1.fc31.x86_64                             87/98
  Installing       : containers-common-1:1.2.0-1.fc31.x86_64              88/98
  Installing       : skopeo-1:1.2.0-1.fc31.x86_64                         89/98
  Installing       : gcc-9.3.1-2.fc31.x86_64                              90/98
  Installing       : make-1:4.2.1-15.fc31.x86_64                          91/98
  Installing       : gettext-0.20.1-3.fc31.x86_64                         92/98
  Installing       : findutils-1:4.6.0-25.fc31.x86_64                     93/98
  Installing       : which-2.21-15.fc31.x86_64                            94/98
  Cleanup          : libxcrypt-4.4.16-3.fc31.x86_64                       95/98
  Cleanup          : glibc-2.30-11.fc31.x86_64                            96/98
  Cleanup          : glibc-minimal-langpack-2.30-11.fc31.x86_64           97/98
  Cleanup          : glibc-common-2.30-11.fc31.x86_64                     98/98
  Running scriptlet: glibc-common-2.30-11.fc31.x86_64                     98/98
  Verifying        : binutils-2.32-33.fc31.x86_64                          1/98
  Verifying        : binutils-gold-2.32-33.fc31.x86_64                     2/98
  Verifying        : containers-common-1:1.2.0-1.fc31.x86_64               3/98
  Verifying        : cpp-9.3.1-2.fc31.x86_64                               4/98
  Verifying        : emacs-filesystem-1:26.3-1.fc31.noarch                 5/98
  Verifying        : findutils-1:4.6.0-25.fc31.x86_64                      6/98
  Verifying        : gcc-9.3.1-2.fc31.x86_64                               7/98
  Verifying        : gettext-0.20.1-3.fc31.x86_64                          8/98
  Verifying        : gettext-libs-0.20.1-3.fc31.x86_64                     9/98
  Verifying        : git-2.25.4-1.fc31.x86_64                             10/98
  Verifying        : git-core-2.25.4-1.fc31.x86_64                        11/98
  Verifying        : git-core-doc-2.25.4-1.fc31.noarch                    12/98
  Verifying        : glibc-devel-2.30-13.fc31.x86_64                      13/98
  Verifying        : glibc-headers-2.30-13.fc31.x86_64                    14/98
  Verifying        : groff-base-1.22.3-21.fc31.x86_64                     15/98
  Verifying        : kernel-headers-5.8.18-100.fc31.x86_64                16/98
  Verifying        : libedit-3.1-30.20191211cvs.fc31.x86_64               17/98
  Verifying        : libtextstyle-0.20.1-3.fc31.x86_64                    18/98
  Verifying        : libxcrypt-compat-4.4.17-1.fc31.x86_64                19/98
  Verifying        : libxcrypt-devel-4.4.17-1.fc31.x86_64                 20/98
  Verifying        : make-1:4.2.1-15.fc31.x86_64                          21/98
  Verifying        : mkpasswd-5.5.7-1.fc31.x86_64                         22/98
  Verifying        : openssh-8.1p1-1.fc31.x86_64                          23/98
  Verifying        : openssh-clients-8.1p1-1.fc31.x86_64                  24/98
  Verifying        : perl-Data-Dumper-2.174-443.fc31.x86_64               25/98
  Verifying        : perl-Digest-1.19-1.fc31.noarch                       26/98
  Verifying        : perl-Encode-4:3.07-457.fc31.x86_64                   27/98
  Verifying        : perl-Errno-1.30-456.fc31.x86_64                      28/98
  Verifying        : perl-Exporter-5.74-1.fc31.noarch                     29/98
  Verifying        : perl-File-Path-2.17-1.fc31.noarch                    30/98
  Verifying        : perl-Getopt-Long-1:2.52-1.fc31.noarch                31/98
  Verifying        : perl-Git-2.25.4-1.fc31.noarch                        32/98
  Verifying        : perl-IO-1.40-456.fc31.x86_64                         33/98
  Verifying        : perl-IO-Socket-SSL-2.066-7.fc31.noarch               34/98
  Verifying        : perl-Mozilla-CA-20200520-1.fc31.noarch               35/98
  Verifying        : perl-PathTools-3.78-441.fc31.x86_64                  36/98
  Verifying        : perl-Pod-Usage-4:2.01-1.fc31.noarch                  37/98
  Verifying        : perl-Scalar-List-Utils-3:1.53-439.fc31.x86_64        38/98
  Verifying        : perl-Socket-4:2.030-1.fc31.x86_64                    39/98
  Verifying        : perl-Storable-1:3.15-442.fc31.x86_64                 40/98
  Verifying        : perl-Time-Local-2:1.300-1.fc31.noarch                41/98
  Verifying        : perl-interpreter-4:5.30.3-456.fc31.x86_64            42/98
  Verifying        : perl-libs-4:5.30.3-456.fc31.x86_64                   43/98
  Verifying        : perl-macros-4:5.30.3-456.fc31.noarch                 44/98
  Verifying        : python2-2.7.18-6.fc31.x86_64                         45/98
  Verifying        : python2-libs-2.7.18-6.fc31.x86_64                    46/98
  Verifying        : python2-pip-19.1.1-8.fc31.noarch                     47/98
  Verifying        : python2-setuptools-41.6.0-1.fc31.noarch              48/98
  Verifying        : skopeo-1:1.2.0-1.fc31.x86_64                         49/98
  Verifying        : whois-nls-5.5.7-1.fc31.noarch                        50/98
  Verifying        : fipscheck-1.5.0-7.fc31.x86_64                        51/98
  Verifying        : fipscheck-lib-1.5.0-7.fc31.x86_64                    52/98
  Verifying        : gc-7.6.4-6.fc31.x86_64                               53/98
  Verifying        : gdbm-1:1.18.1-1.fc31.x86_64                          54/98
  Verifying        : guile22-2.2.6-2.fc31.x86_64                          55/98
  Verifying        : isl-0.16.1-9.fc31.x86_64                             56/98
  Verifying        : less-551-2.fc31.x86_64                               57/98
  Verifying        : libatomic_ops-7.6.10-2.fc31.x86_64                   58/98
  Verifying        : libcroco-0.6.13-2.fc31.x86_64                        59/98
  Verifying        : libmpc-1.1.0-4.fc31.x86_64                           60/98
  Verifying        : libpkgconf-1.6.3-2.fc31.x86_64                       61/98
  Verifying        : libtool-ltdl-2.4.6-31.fc31.x86_64                    62/98
  Verifying        : perl-Carp-1.50-439.fc31.noarch                       63/98
  Verifying        : perl-Digest-MD5-2.55-439.fc31.x86_64                 64/98
  Verifying        : perl-Error-1:0.17028-1.fc31.noarch                   65/98
  Verifying        : perl-File-Temp-1:0.230.900-439.fc31.noarch           66/98
  Verifying        : perl-HTTP-Tiny-0.076-439.fc31.noarch                 67/98
  Verifying        : perl-IO-Socket-IP-0.39-440.fc31.noarch               68/98
  Verifying        : perl-MIME-Base64-3.15-439.fc31.x86_64                69/98
  Verifying        : perl-Net-SSLeay-1.88-3.fc31.x86_64                   70/98
  Verifying        : perl-Pod-Escapes-1:1.07-439.fc31.noarch              71/98
  Verifying        : perl-Pod-Perldoc-3.28.01-442.fc31.noarch             72/98
  Verifying        : perl-Pod-Simple-1:3.39-2.fc31.noarch                 73/98
  Verifying        : perl-Term-ANSIColor-4.06-440.fc31.noarch             74/98
  Verifying        : perl-Term-Cap-1.17-439.fc31.noarch                   75/98
  Verifying        : perl-TermReadKey-2.38-4.fc31.x86_64                  76/98
  Verifying        : perl-Text-ParseWords-3.30-439.fc31.noarch            77/98
  Verifying        : perl-Text-Tabs+Wrap-2013.0523-439.fc31.noarch        78/98
  Verifying        : perl-URI-1.76-5.fc31.noarch                          79/98
  Verifying        : perl-Unicode-Normalize-1.26-439.fc31.x86_64          80/98
  Verifying        : perl-constant-1.33-440.fc31.noarch                   81/98
  Verifying        : perl-libnet-3.11-440.fc31.noarch                     82/98
  Verifying        : perl-parent-1:0.237-439.fc31.noarch                  83/98
  Verifying        : perl-podlators-1:4.12-2.fc31.noarch                  84/98
  Verifying        : perl-threads-1:2.22-439.fc31.x86_64                  85/98
  Verifying        : perl-threads-shared-1.60-440.fc31.x86_64             86/98
  Verifying        : pkgconf-1.6.3-2.fc31.x86_64                          87/98
  Verifying        : pkgconf-m4-1.6.3-2.fc31.noarch                       88/98
  Verifying        : pkgconf-pkg-config-1.6.3-2.fc31.x86_64               89/98
  Verifying        : which-2.21-15.fc31.x86_64                            90/98
  Verifying        : glibc-2.30-13.fc31.x86_64                            91/98
  Verifying        : glibc-2.30-11.fc31.x86_64                            92/98
  Verifying        : glibc-common-2.30-13.fc31.x86_64                     93/98
  Verifying        : glibc-common-2.30-11.fc31.x86_64                     94/98
  Verifying        : glibc-minimal-langpack-2.30-13.fc31.x86_64           95/98
  Verifying        : glibc-minimal-langpack-2.30-11.fc31.x86_64           96/98
  Verifying        : libxcrypt-4.4.17-1.fc31.x86_64                       97/98
  Verifying        : libxcrypt-4.4.16-3.fc31.x86_64                       98/98

Upgraded:
  glibc-2.30-13.fc31.x86_64                   glibc-common-2.30-13.fc31.x86_64
  glibc-minimal-langpack-2.30-13.fc31.x86_64  libxcrypt-4.4.17-1.fc31.x86_64

Installed:
  binutils-2.32-33.fc31.x86_64
  binutils-gold-2.32-33.fc31.x86_64
  containers-common-1:1.2.0-1.fc31.x86_64
  cpp-9.3.1-2.fc31.x86_64
  emacs-filesystem-1:26.3-1.fc31.noarch
  findutils-1:4.6.0-25.fc31.x86_64
  fipscheck-1.5.0-7.fc31.x86_64
  fipscheck-lib-1.5.0-7.fc31.x86_64
  gc-7.6.4-6.fc31.x86_64
  gcc-9.3.1-2.fc31.x86_64
  gdbm-1:1.18.1-1.fc31.x86_64
  gettext-0.20.1-3.fc31.x86_64
  gettext-libs-0.20.1-3.fc31.x86_64
  git-2.25.4-1.fc31.x86_64
  git-core-2.25.4-1.fc31.x86_64
  git-core-doc-2.25.4-1.fc31.noarch
  glibc-devel-2.30-13.fc31.x86_64
  glibc-headers-2.30-13.fc31.x86_64
  groff-base-1.22.3-21.fc31.x86_64
  guile22-2.2.6-2.fc31.x86_64
  isl-0.16.1-9.fc31.x86_64
  kernel-headers-5.8.18-100.fc31.x86_64
  less-551-2.fc31.x86_64
  libatomic_ops-7.6.10-2.fc31.x86_64
  libcroco-0.6.13-2.fc31.x86_64
  libedit-3.1-30.20191211cvs.fc31.x86_64
  libmpc-1.1.0-4.fc31.x86_64
  libpkgconf-1.6.3-2.fc31.x86_64
  libtextstyle-0.20.1-3.fc31.x86_64
  libtool-ltdl-2.4.6-31.fc31.x86_64
  libxcrypt-compat-4.4.17-1.fc31.x86_64
  libxcrypt-devel-4.4.17-1.fc31.x86_64
  make-1:4.2.1-15.fc31.x86_64
  mkpasswd-5.5.7-1.fc31.x86_64
  openssh-8.1p1-1.fc31.x86_64
  openssh-clients-8.1p1-1.fc31.x86_64
  perl-Carp-1.50-439.fc31.noarch
  perl-Data-Dumper-2.174-443.fc31.x86_64
  perl-Digest-1.19-1.fc31.noarch
  perl-Digest-MD5-2.55-439.fc31.x86_64
  perl-Encode-4:3.07-457.fc31.x86_64
  perl-Errno-1.30-456.fc31.x86_64
  perl-Error-1:0.17028-1.fc31.noarch
  perl-Exporter-5.74-1.fc31.noarch
  perl-File-Path-2.17-1.fc31.noarch
  perl-File-Temp-1:0.230.900-439.fc31.noarch
  perl-Getopt-Long-1:2.52-1.fc31.noarch
  perl-Git-2.25.4-1.fc31.noarch
  perl-HTTP-Tiny-0.076-439.fc31.noarch
  perl-IO-1.40-456.fc31.x86_64
  perl-IO-Socket-IP-0.39-440.fc31.noarch
  perl-IO-Socket-SSL-2.066-7.fc31.noarch
  perl-MIME-Base64-3.15-439.fc31.x86_64
  perl-Mozilla-CA-20200520-1.fc31.noarch
  perl-Net-SSLeay-1.88-3.fc31.x86_64
  perl-PathTools-3.78-441.fc31.x86_64
  perl-Pod-Escapes-1:1.07-439.fc31.noarch
  perl-Pod-Perldoc-3.28.01-442.fc31.noarch
  perl-Pod-Simple-1:3.39-2.fc31.noarch
  perl-Pod-Usage-4:2.01-1.fc31.noarch
  perl-Scalar-List-Utils-3:1.53-439.fc31.x86_64
  perl-Socket-4:2.030-1.fc31.x86_64
  perl-Storable-1:3.15-442.fc31.x86_64
  perl-Term-ANSIColor-4.06-440.fc31.noarch
  perl-Term-Cap-1.17-439.fc31.noarch
  perl-TermReadKey-2.38-4.fc31.x86_64
  perl-Text-ParseWords-3.30-439.fc31.noarch
  perl-Text-Tabs+Wrap-2013.0523-439.fc31.noarch
  perl-Time-Local-2:1.300-1.fc31.noarch
  perl-URI-1.76-5.fc31.noarch
  perl-Unicode-Normalize-1.26-439.fc31.x86_64
  perl-constant-1.33-440.fc31.noarch
  perl-interpreter-4:5.30.3-456.fc31.x86_64
  perl-libnet-3.11-440.fc31.noarch
  perl-libs-4:5.30.3-456.fc31.x86_64
  perl-macros-4:5.30.3-456.fc31.noarch
  perl-parent-1:0.237-439.fc31.noarch
  perl-podlators-1:4.12-2.fc31.noarch
  perl-threads-1:2.22-439.fc31.x86_64
  perl-threads-shared-1.60-440.fc31.x86_64
  pkgconf-1.6.3-2.fc31.x86_64
  pkgconf-m4-1.6.3-2.fc31.noarch
  pkgconf-pkg-config-1.6.3-2.fc31.x86_64
  python2-2.7.18-6.fc31.x86_64
  python2-libs-2.7.18-6.fc31.x86_64
  python2-pip-19.1.1-8.fc31.noarch
  python2-setuptools-41.6.0-1.fc31.noarch
  skopeo-1:1.2.0-1.fc31.x86_64
  which-2.21-15.fc31.x86_64
  whois-nls-5.5.7-1.fc31.noarch

Complete!
35 files removed
--> daf0575363e
STEP 10/13: RUN mkdir ~/bin &&     curl -sL -o /usr/local/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme &&     chmod +x /usr/local/bin/gimme &&     eval "$(gimme $GOVERSION)" &&     cat $GIMME_ENV >> $HOME/.bashrc &&     go mod init test &&     go get github.com/onsi/ginkgo/ginkgo@v${GOVERSION} &&     go get github.com/onsi/gomega/...@v${GOMEGOVERSION} &&     go get -u golang.org/x/lint/golint &&     export latest_oc_client_version=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ 2>/dev/null | grep -o \"openshift-client-linux-4.*tar.gz\" | tr -d \") &&     curl -JL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${latest_oc_client_version} -o oc.tar.gz &&     tar -xzvf oc.tar.gz &&     mv oc /usr/local/bin/oc &&     ln -s /usr/local/bin/oc /usr/local/bin/kubectl &&     rm -f oc.tar.gz
go version go1.15.2 linux/amd64
go: creating new go.mod: module test
go: downloading github.com/onsi/ginkgo v1.15.2
go: found github.com/onsi/ginkgo/ginkgo in github.com/onsi/ginkgo v1.15.2
go: downloading github.com/nxadm/tail v1.4.8
go: downloading golang.org/x/sys v0.0.0-20210112080510-489259a85091
go: downloading golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e
go: downloading gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: downloading github.com/fsnotify/fsnotify v1.4.9
go: downloading github.com/onsi/gomega v1.10.1
go: downloading github.com/golang/protobuf v1.4.2
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading gopkg.in/yaml.v2 v2.3.0
go: downloading golang.org/x/net v0.0.0-20201021035429-f5854403a974
go: downloading google.golang.org/protobuf v1.23.0
go: downloading golang.org/x/text v0.3.3
go: downloading github.com/onsi/gomega v1.15.0
go: downloading github.com/golang/protobuf v1.5.2
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
go: downloading google.golang.org/protobuf v1.26.0
go: downloading golang.org/x/text v0.3.6
go: downloading golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
go: found golang.org/x/lint/golint in golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
go: golang.org/x/tools upgrade => v0.1.8
go: downloading golang.org/x/tools v0.1.8
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 47.1M  100 47.1M    0     0  26.0M      0  0:00:01  0:00:01 --:--:-- 26.0M
README.md
oc
kubectl
--> 6f789d70dc6
STEP 11/13: RUN export TMP_BIN=$(mktemp -d) &&     mv $GOBIN/* $TMP_BIN/ &&     rm -rf ${GOPATH} ${GOCACHE} &&     mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/ &&     mkdir -p ${GOBIN} &&     chmod -R 775 ${GOPATH} &&     mv $TMP_BIN/* ${GOBIN} &&     rm -rf $TMP_BIN
--> ee771dcbd63
STEP 12/13: WORKDIR ${GOPATH}/src/${GO_PACKAGE_PATH}
--> 7f3f92b4388
STEP 13/13: ENTRYPOINT [ "/bin/bash" ]
COMMIT test
--> 8771135bda4
Successfully tagged localhost/test:latest
8771135bda4407190d79efbde8d959dff487240167ababa258833501a7ca731f

```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>