### PR TITLE
bug 2035318: added upstream field in the clusterVerion CR

### DIFF
--- a/ztp/source-crs/ClusterVersion.yaml
+++ b/ztp/source-crs/ClusterVersion.yaml
@@ -6,6 +6,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "100"
 spec:
   channel: $channel
+  upstream: $upstream
   desiredUpdate:
     force: false
     version: $version


### PR DESCRIPTION
added upstream field in the clusterVerion CR to enable upgrade_graph configuration.

Signed-off-by: Nishant Parekh <nparekh@redhat.com>