### PR TITLE
[release-4.7] install ginkgo as part of the openshift-ci dockerfile

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -25,6 +25,9 @@ RUN mkdir ~/bin && \
     chmod +x /usr/local/bin/gimme && \
     eval "$(gimme $GOVERSION)" && \
     cat $GIMME_ENV >> $HOME/.bashrc && \
+    go mod init tmp && \
+    go get github.com/onsi/ginkgo/ginkgo@v1.15.2 && \
+    go get github.com/onsi/gomega/...@v1.15 && \
     go get -u golang.org/x/lint/golint && \
     export latest_oc_client_version=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ 2>/dev/null | grep -o \"openshift-client-linux-4.*tar.gz\" | tr -d \") && \
     curl -JL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${latest_oc_client_version} -o oc.tar.gz && \


### PR DESCRIPTION
```
which: no ginkgo in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.gimme/versions/go1.15.2.linux.amd64/bin:/go/bin:/go/bin:/go/bin:/go/bin)
Downloading ginkgo tool
go: downloading github.com/onsi/ginkgo v1.14.1
go: downloading golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
go: downloading github.com/nxadm/tail v1.4.4
go: downloading gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: downloading github.com/fsnotify/fsnotify v1.4.9
Compiling functests...
Failed to compile functests:

go: inconsistent vendoring in /go/src/github.com/openshift-kni/cnf-features-deploy:
	github.com/coreos/go-systemd@v0.0.0-20191104093116-d3cd4ed1dbcf: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/coreos/ignition@v0.35.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/emicklei/go-restful@v2.12.0+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/ghodss/yaml@v1.0.1-0.20190212211648-25d852aebe32: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/ishidawataru/sctp@v0.0.0-20191218070446-00ab2ac2db07: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/k8snetworkplumbingwg/network-attachment-definition-client@v0.0.0-20200626054723-37f83d1996bc: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/k8snetworkplumbingwg/sriov-network-operator@v0.0.0-00010101000000-000000000000: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/onsi/ginkgo@v1.14.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/onsi/gomega@v1.10.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openshift-kni/performance-addon-operators@v0.0.0-20201208165454-633ad82b0f7a: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openshift/api@v3.9.1-0.20191213091414-3fbf6bcf78e8+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openshift/client-go@v0.0.0-20200827190008-3062137373b5: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openshift/cluster-node-tuning-operator@v0.0.0-20200914165052-a39511828cf0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openshift/machine-config-operator@v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/openshift/ptp-operator@v0.0.0-20201120171427-2939e545cdde: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/spf13/cobra@v1.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	go4.org@v0.0.0-20200411211856-f5505b9728dd: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	golang.org/x/sys@v0.0.0-20200625212154-ddb9806d33ae: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/api@v0.19.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/apiextensions-apiserver@v0.19.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/apimachinery@v0.19.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/client-go@v12.0.0+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/klog@v1.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/kubelet@v0.19.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/kubernetes@v1.18.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/utils@v0.0.0-20200729134348-d5654de09c73: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	kubevirt.io/qe-tools@v0.1.6: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	sigs.k8s.io/controller-runtime@v0.6.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/api: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/apiextensions-apiserver: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/apimachinery: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/apiserver: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/cli-runtime: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/client-go: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/cloud-provider: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/cluster-bootstrap: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/code-generator: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/component-base: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/cri-api: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/csi-translation-lib: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/kube-aggregator: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/kube-controller-manager: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/kube-proxy: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/kube-scheduler: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/kubectl: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/kubelet: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/kubernetes: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/legacy-cloud-providers: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/metrics: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	k8s.io/sample-apiserver: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/cri-o/cri-o: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/go-log/log: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/gorilla/websocket: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/mtrmac/gpgme: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/api: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/client-go: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/cluster-node-tuning-operator: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/library-go: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/machine-config-operator: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	golang.org/x/tools: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/k8snetworkplumbingwg/sriov-network-operator: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift-kni/performance-addon-operators: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/ptp-operator: is replaced in go.mod, but not marked as replaced in vendor/modules.txt

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory

/go/src/github.com/openshift-kni/cnf-features-deploy
/go/src/github.com/openshift-kni/cnf-features-deploy
make: *** [Makefile:76: check-tests-nodesc] Error 1
{"component":"entrypoint","error":"wrapped process failed: exit status 2","file":"prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2021-12-26T14:45:44Z"} 
[36mINFO[0m[2021-12-26T14:45:49Z] Ran for 4m52s                                
[31mERRO[0m[2021-12-26T14:45:49Z] Some steps failed:                           
[31mERRO[0m[2021-12-26T14:45:49Z] 
  * could not run steps: step ci failed: test "ci" failed: the pod ci-op-j4n3wgbz/ci failed after 1m16s (failed containers: test): ContainerFailed one or more containers exited

Container test exited with code 2, reason Error
---
ced in vendor/modules.txt
	k8s.io/sample-apiserver: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/cri-o/cri-o: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/go-log/log: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/gorilla/websocket: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/mtrmac/gpgme: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/api: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/client-go: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/cluster-node-tuning-operator: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/library-go: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/machine-config-operator: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	golang.org/x/tools: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/k8snetworkplumbingwg/sriov-network-operator: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift-kni/performance-addon-operators: is replaced in go.mod, but not marked as replaced in vendor/modules.txt
	github.com/openshift/ptp-operator: is replaced in go.mod, but not marked as replaced in vendor/modules.txt

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>