### PR TITLE
[release 4.9] cnf-tests: use go install instead of go get for golint

### DIFF
--- a/cnf-tests/hack/build-test-bin.sh
+++ b/cnf-tests/hack/build-test-bin.sh
@@ -16,7 +16,7 @@ export GOFLAGS="${GOFLAGS:-"-mod=vendor"}"
 export PATH=$PATH:$GOPATH/bin
 DONT_REBUILD_TEST_BINS="${DONT_REBUILD_TEST_BINS:-false}"
 
-if ! which gingko; then
+if ! which ginkgo; then
 	echo "Downloading ginkgo tool"
 	go install github.com/onsi/ginkgo/ginkgo
 fi

--- a/cnf-tests/hack/lint.sh
+++ b/cnf-tests/hack/lint.sh
@@ -5,7 +5,7 @@
 which golint
 if [ $? -ne 0 ]; then
 	echo "Downloading golint tool"
-	go get -u golang.org/x/lint/golint
+	go install golang.org/x/lint/golint
 fi
 
 RETVAL=0


### PR DESCRIPTION
Signed-off-by: Sebastian Sch <sebassch@gmail.com>