### PR TITLE
Bug 2036990: Adjust ztp-done policy to work with multi-node clusters

### DIFF
--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -22,14 +22,7 @@ status:
   syncStatus: Succeeded
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: ptp-operator
+  name: linuxptp-daemon
   namespace: openshift-ptp
-status:
-  conditions:
-    - type: Available
-      status: "True"
-      reason: MinimumReplicasAvailable
-  availableReplicas: 1
-  readyReplicas: 1

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -9,12 +9,13 @@ spec:
     matchLabels:
       machineconfiguration.openshift.io/role: master
 status:
-  unavailableMachineCount: 0
   conditions:
     - type: Updated
       status: "True"
     - type: Updating
       status: "False"
+  degradedMachineCount: 0
+  unavailableMachineCount: 0
   configuration:
     source:
       - apiVersion: machineconfiguration.openshift.io/v1

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -1,13 +1,5 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
-metadata:
-  labels:
-    pools.operator.machineconfiguration.openshift.io/master: ""
-  name: master
-spec:
-  machineConfigSelector:
-    matchLabels:
-      machineconfiguration.openshift.io/role: master
 status:
   conditions:
     - type: Updated

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -46,27 +46,3 @@ status:
       reason: MinimumReplicasAvailable
   availableReplicas: 1
   readyReplicas: 1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: performance-operator
-  namespace: openshift-performance-addon-operator
-status:
-  conditions:
-    - type: Available
-      status: "True"
-      reason: MinimumReplicasAvailable
-  availableReplicas: 1
-  readyReplicas: 1
----
-apiVersion: performance.openshift.io/v2
-kind: PerformanceProfile
-status:
-  conditions:
-    - type: Available
-      status: "True"
-    - type: Degraded
-      status: "False"
-    - type: Progressing
-      status: "False"

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -20,21 +20,6 @@ status:
     source:
       - apiVersion: machineconfiguration.openshift.io/v1
         kind: MachineConfig
-        name: container-mount-namespace-and-kubelet-conf-master
-      - apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
-        name: load-sctp-module-master
-      - apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
-        name: 02-master-workload-partitioning
-      - apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
-        name: 04-accelerated-container-startup-master
-      - apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
-        name: 05-chronyd-dynamic-master
-      - apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
         name: 50-performance-openshift-node-performance-profile
 ---
 apiVersion: apps/v1

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -70,28 +70,3 @@ status:
       status: "False"
     - type: Progressing
       status: "False"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: kube-apiserver-operator
-  namespace: openshift-kube-apiserver-operator
-status:
-  conditions:
-    - type: Available
-      status: "True"
-  availableReplicas: 1
-  readyReplicas: 1
----
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    apiserver: "true"
-    app: openshift-kube-apiserver
-  namespace: openshift-kube-apiserver
-status:
-  conditions:
-    - type: Ready
-      status: "True"
-  phase: Running

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -14,19 +14,6 @@ status:
         kind: MachineConfig
         name: 50-performance-openshift-node-performance-profile
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: sriov-network-operator
-  namespace: openshift-sriov-network-operator
-status:
-  conditions:
-    - type: Available
-      status: "True"
-      reason: MinimumReplicasAvailable
-  availableReplicas: 1
-  readyReplicas: 1
----
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodeState
 metadata:

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -9,8 +9,6 @@ spec:
     matchLabels:
       machineconfiguration.openshift.io/role: master
 status:
-  readyMachineCount: 1
-  updatedMachineCount: 1
   unavailableMachineCount: 0
   conditions:
     - type: Updated


### PR DESCRIPTION
* ztp: ztp-done policy: Check PTP daemonset, not PTP deployment
* ztp: ztp-done policy: Remove redundant SRIOV checks
* ztp: ztp-done policy: Remove redundant PAO checks
* ztp: ztp-done policy: Remove any kube-apiserver checks
* ztp: ztp-done policy: Check for the PAO MachineConfig in any MCP pool
* ztp: ztp-done policy: remove day-0 MachineConfig checks
* ztp: ztp-done policy: Ensure MCP degradedMachineCount == 0
* ztp: ztp-done policy: Do not rely on specific node counts
