### PR TITLE
cnf-tests: fix the dpdk command indentation

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -1073,35 +1073,35 @@ func CreateSriovNetwork(sriovDevice *sriovv1.InterfaceExt, sriovNetworkName stri
 
 func dpdkWorkloadCommand(dpdkResourceName, testpmdCommand string, runningTime int) string {
 	return fmt.Sprintf(`set -ex
-	export CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
-	echo ${CPU}
-	echo ${PCIDEVICE_OPENSHIFT_IO_%s}
-	
-	cat <<EOF >test.sh
-	spawn %s
-	set timeout 10000
-	expect "testpmd>"
-	send -- "port stop 0\r"
-	expect "testpmd>"
-	send -- "port detach 0\r"
-	expect "testpmd>"
-	send -- "port attach ${PCIDEVICE_OPENSHIFT_IO_%s}\r"
-	expect "testpmd>"
-	send -- "port start 0\r"
-	expect "testpmd>"
-	send -- "start\r"
-	expect "testpmd>"
-	sleep %d
-	send -- "stop\r"
-	expect "testpmd>"
-	send -- "quit\r"
-	expect eof
-	EOF
-	
-	expect -f test.sh
-	
-	sleep INF
-	`, dpdkResourceName, testpmdCommand, dpdkResourceName, runningTime)
+export CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
+echo ${CPU}
+echo ${PCIDEVICE_OPENSHIFT_IO_%s}
+
+cat <<EOF >test.sh
+spawn %s
+set timeout 10000
+expect "testpmd>"
+send -- "port stop 0\r"
+expect "testpmd>"
+send -- "port detach 0\r"
+expect "testpmd>"
+send -- "port attach ${PCIDEVICE_OPENSHIFT_IO_%s}\r"
+expect "testpmd>"
+send -- "port start 0\r"
+expect "testpmd>"
+send -- "start\r"
+expect "testpmd>"
+sleep %d
+send -- "stop\r"
+expect "testpmd>"
+send -- "quit\r"
+expect eof
+EOF
+
+expect -f test.sh
+
+sleep INF
+`, dpdkResourceName, testpmdCommand, dpdkResourceName, runningTime)
 }
 
 func createDPDKWorkload(nodeSelector map[string]string, command string, isServer bool, additionalCapabilities []corev1.Capability, mac string) (*corev1.Pod, error) {


### PR DESCRIPTION
example output:
```
++ cat /sys/fs/cgroup/cpuset/cpuset.cpus
+ export CPU=8,10,48,50
+ CPU=8,10,48,50
+ echo 8,10,48,50
8,10,48,50
+ echo 0000:3b:00.4
0000:3b:00.4
/bin/bash: line 29: warning: here-document at line 5 delimited by end-of-file (wanted `EOF')
+ cat
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>