### PR TITLE
Bug 2036990: Adjust ztp-done policy to work with multi-node clusters (plus 50-nto-* MC)

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
@@ -8,11 +8,6 @@ spec:
   bindingRules:
     common: "true"
   sourceFiles:
-    # Create inform policy to validate configuration CRs that will be applied to all clusters
-    - fileName: validatorCRs/informDuValidator.yaml
-      complianceType: musthave
-      remediationAction: inform
-      policyName: "du-validator-policy"
     # Create operators policies that will be installed in all clusters
     - fileName: SriovSubscription.yaml
       policyName: "subscriptions-policy"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
@@ -11,6 +11,11 @@ spec:
   # the Performance Profile needs to be set up to apply to the master MCP:
   mcp: "master"
   sourceFiles:
+    # Create inform policy to validate configuration CRs that will be applied to all 3-node clusters
+    - fileName: validatorCRs/informDuValidator.yaml
+      complianceType: musthave
+      remediationAction: inform
+      policyName: "du-validator-policy-3node"
     - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
       policyName: "config-policy"
       metadata:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -10,6 +10,11 @@ spec:
     group-du-sno: ""
   mcp: "master"
   sourceFiles:
+    # Create inform policy to validate configuration CRs that will be applied to all SNO clusters
+    - fileName: validatorCRs/informDuValidator.yaml
+      complianceType: musthave
+      remediationAction: inform
+      policyName: "du-validator-policy-sno"
     - fileName: ConsoleOperatorDisable.yaml
       policyName: "config-policy"
     # Set ClusterLogForwarder & ClusterLogging as example might be better to create another policyTemp-Group

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
@@ -9,6 +9,11 @@ spec:
     group-du-standard: ""
   mcp: "worker"
   sourceFiles:
+    # Create inform policy to validate configuration CRs that will be applied to all standard clusters
+    - fileName: validatorCRs/informDuValidator.yaml
+      complianceType: musthave
+      remediationAction: inform
+      policyName: "du-validator-policy-standard"
     - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
       policyName: "config-policy"
       metadata:

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -22,14 +22,7 @@ status:
   syncStatus: Succeeded
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: ptp-operator
+  name: linuxptp-daemon
   namespace: openshift-ptp
-status:
-  conditions:
-    - type: Available
-      status: "True"
-      reason: MinimumReplicasAvailable
-  availableReplicas: 1
-  readyReplicas: 1

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -9,12 +9,13 @@ spec:
     matchLabels:
       machineconfiguration.openshift.io/role: master
 status:
-  unavailableMachineCount: 0
   conditions:
     - type: Updated
       status: "True"
     - type: Updating
       status: "False"
+  degradedMachineCount: 0
+  unavailableMachineCount: 0
   configuration:
     source:
       - apiVersion: machineconfiguration.openshift.io/v1

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -1,13 +1,5 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
-metadata:
-  labels:
-    pools.operator.machineconfiguration.openshift.io/master: ""
-  name: master
-spec:
-  machineConfigSelector:
-    matchLabels:
-      machineconfiguration.openshift.io/role: master
 status:
   conditions:
     - type: Updated

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -46,27 +46,3 @@ status:
       reason: MinimumReplicasAvailable
   availableReplicas: 1
   readyReplicas: 1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: performance-operator
-  namespace: openshift-performance-addon-operator
-status:
-  conditions:
-    - type: Available
-      status: "True"
-      reason: MinimumReplicasAvailable
-  availableReplicas: 1
-  readyReplicas: 1
----
-apiVersion: performance.openshift.io/v2
-kind: PerformanceProfile
-status:
-  conditions:
-    - type: Available
-      status: "True"
-    - type: Degraded
-      status: "False"
-    - type: Progressing
-      status: "False"

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -20,21 +20,6 @@ status:
     source:
       - apiVersion: machineconfiguration.openshift.io/v1
         kind: MachineConfig
-        name: container-mount-namespace-and-kubelet-conf-master
-      - apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
-        name: load-sctp-module-master
-      - apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
-        name: 02-master-workload-partitioning
-      - apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
-        name: 04-accelerated-container-startup-master
-      - apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
-        name: 05-chronyd-dynamic-master
-      - apiVersion: machineconfiguration.openshift.io/v1
-        kind: MachineConfig
         name: 50-performance-openshift-node-performance-profile
 ---
 apiVersion: apps/v1

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -1,5 +1,7 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
+metadata:
+  name: $mcp
 status:
   conditions:
     - type: Updated
@@ -13,6 +15,9 @@ status:
       - apiVersion: machineconfiguration.openshift.io/v1
         kind: MachineConfig
         name: 50-performance-openshift-node-performance-profile
+      - apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        name: 50-nto-$mcp
 ---
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodeState

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -70,28 +70,3 @@ status:
       status: "False"
     - type: Progressing
       status: "False"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: kube-apiserver-operator
-  namespace: openshift-kube-apiserver-operator
-status:
-  conditions:
-    - type: Available
-      status: "True"
-  availableReplicas: 1
-  readyReplicas: 1
----
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    apiserver: "true"
-    app: openshift-kube-apiserver
-  namespace: openshift-kube-apiserver
-status:
-  conditions:
-    - type: Ready
-      status: "True"
-  phase: Running

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -14,19 +14,6 @@ status:
         kind: MachineConfig
         name: 50-performance-openshift-node-performance-profile
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: sriov-network-operator
-  namespace: openshift-sriov-network-operator
-status:
-  conditions:
-    - type: Available
-      status: "True"
-      reason: MinimumReplicasAvailable
-  availableReplicas: 1
-  readyReplicas: 1
----
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodeState
 metadata:

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -9,8 +9,6 @@ spec:
     matchLabels:
       machineconfiguration.openshift.io/role: master
 status:
-  readyMachineCount: 1
-  updatedMachineCount: 1
   unavailableMachineCount: 0
   conditions:
     - type: Updated


### PR DESCRIPTION
- ztp: ztp-done policy: Do not rely on specific node counts
- ztp: ztp-done policy: Ensure MCP degradedMachineCount == 0
- ztp: ztp-done policy: remove day-0 MachineConfig checks
- ztp: ztp-done policy: Check for the PAO MachineConfig in any MCP pool
- ztp: ztp-done policy: Remove any kube-apiserver checks
- ztp: ztp-done policy: Remove redundant PAO checks
- ztp: ztp-done policy: Remove redundant SRIOV checks
- ztp: ztp-done policy: Check PTP daemonset, not PTP deployment
- ztp: ztp-done policy: Check for the 50-nto-[worker|master] MachineConfig
