### PR TITLE
Bug 2039981: ztp: Ensure standard cluster masters do not get stalld

### DIFF
--- a/ztp/source-crs/TunedPerformancePatch.yaml
+++ b/ztp/source-crs/TunedPerformancePatch.yaml
@@ -22,6 +22,6 @@ spec:
         service.stalld=start,enable
   recommend:
     - machineConfigLabels:
-        machineconfiguration.openshift.io/role: "master"
+        machineconfiguration.openshift.io/role: "$mcp"
       priority: 19
       profile: performance-patch


### PR DESCRIPTION
By fixing the MCP alignment of the TunedPerformancePatch, masters in
standard clusters no longer get this unexpected configuration change.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
