### PR TITLE
oot-driver: address lingering containers during reboot cycles

### DIFF
--- a/tools/oot-driver/files/script/oot-driver
+++ b/tools/oot-driver/files/script/oot-driver
@@ -9,10 +9,10 @@ podman pull --authfile /var/lib/kubelet/config.json ${IMAGE}:${KERNEL} 2>&1
 
 load_kmods() {
 
-    podman run -i --privileged -v /lib/modules/${KERNEL}/kernel/drivers/:/lib/modules/${KERNEL}/kernel/drivers/ ${IMAGE}:${KERNEL} load.sh
+    podman run --network=host --rm -i --privileged -v /lib/modules/${KERNEL}/kernel/drivers/:/lib/modules/${KERNEL}/kernel/drivers/ ${IMAGE}:${KERNEL} load.sh
 }
 unload_kmods() {
-    podman run -i --privileged -v /lib/modules/${KERNEL}/kernel/drivers/:/lib/modules/${KERNEL}/kernel/drivers/ ${IMAGE}:${KERNEL} unload.sh
+    podman run --network=host --rm -i --privileged -v /lib/modules/${KERNEL}/kernel/drivers/:/lib/modules/${KERNEL}/kernel/drivers/ ${IMAGE}:${KERNEL} unload.sh
 }
 
 case "${ACTION}" in


### PR DESCRIPTION
addresses known problems experienced with a partner, where reboot cycles leave podman containers resident.  the resident containers can go to 2048, and then it stops working for the partner.  this cleans them up and prevents an infrequent problem with iptables forwarding chains, when switching to the out-of-tree ice driver.