### PR TITLE
features: Point PTP operator to 4.9 channel

### DIFF
--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-grandmaster.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-grandmaster.yaml
@@ -8,7 +8,7 @@ spec:
   - name: "grandmaster"
 # The interface name is hardware-specific    
     interface: "eno1"
-    ptp4lOpts: "-2 --summary_interval 0"
+    ptp4lOpts: "-2 --summary_interval -4"
     phc2sysOpts: "-a -r -r -n 24"
     ptp4lConf: |
       [global]
@@ -61,7 +61,7 @@ spec:
       unicast_req_duration 3600
       use_syslog 1
       verbose 0
-      summary_interval 0
+      summary_interval -4
       kernel_leap 1
       check_fup_sync 0
       #

--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-slave.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-slave.yaml
@@ -61,7 +61,7 @@ spec:
       unicast_req_duration 3600
       use_syslog 1
       verbose 0
-      summary_interval 0
+      summary_interval -4
       kernel_leap 1
       check_fup_sync 0
       #


### PR DESCRIPTION
New validations for PTP require logSyncInterval to match
summary_interval.

Signed-off-by: Ian Miller <imiller@redhat.com>