### PR TITLE
features: Update PTP config to pass validations

### DIFF
--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-grandmaster.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-grandmaster.yaml
@@ -8,7 +8,7 @@ spec:
   - name: "grandmaster"
 # The interface name is hardware-specific    
     interface: "eno1"
-    ptp4lOpts: "-2 --summary_interval 0"
+    ptp4lOpts: "-2 --summary_interval -4"
     phc2sysOpts: "-a -r -r -n 24"
     ptp4lConf: |
       [global]
@@ -34,7 +34,7 @@ spec:
       # Port Data Set
       #
       logAnnounceInterval -3
-      logSyncInterval 0
+      logSyncInterval -4
       logMinDelayReqInterval -4
       logMinPdelayReqInterval -4
       announceReceiptTimeout 3
@@ -61,7 +61,7 @@ spec:
       unicast_req_duration 3600
       use_syslog 1
       verbose 0
-      summary_interval 0
+      summary_interval -4
       kernel_leap 1
       check_fup_sync 0
       #

--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-slave.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-slave.yaml
@@ -61,7 +61,7 @@ spec:
       unicast_req_duration 3600
       use_syslog 1
       verbose 0
-      summary_interval 0
+      summary_interval -4
       kernel_leap 1
       check_fup_sync 0
       #


### PR DESCRIPTION
The ptp-operator has a new validating webhook which ensures that the
parameters in the PTP config are valid. The parameters used in CI don't
conform so CI fails. In specific the summary_interval and
logSyncInterval need to be set to the same value. The CI is being
updated to use -4 to match the "right" setting when "fast event
notification" is being used.
Validator:
https://github.com/openshift/ptp-operator/blob/master/api/v1/ptpconfig_webhook.go#L122-L124

Signed-off-by: Ian Miller <imiller@redhat.com>