### PR TITLE
Bug 2035015: ztp: Do not specify openshift namespaces in the ClusterLogForwarder CR

### DIFF
--- a/ztp/source-crs/ClusterLogForwarder.yaml
+++ b/ztp/source-crs/ClusterLogForwarder.yaml
@@ -9,18 +9,7 @@ spec:
   outputs: $outputs
   inputs:
   - name: infra-logs
-    infrastructure:
-      namespaces:
-      - openshift-apiserver
-      - openshift-cluster-version
-      - openshift-etcd
-      - openshift-kube-scheduler
-      - openshift-monitoring
-      - openshift-performance-addon
-      - openshift-ptp
-      - openshift-machine-config-operator
-      - open-cluster-management-agent
-      - open-cluster-management-agent-addon
+    infrastructure: {}
   pipelines: $pipelines
 
 #apiVersion: "logging.openshift.io/v1"
@@ -35,13 +24,7 @@ spec:
 #      url: tcp://10.46.55.190:9092/test
 #  inputs:
 #  - name: infra-logs
-#    infrastructure:
-#      namespaces:
-#      - openshift-apiserver
-#      - openshift-cluster-version
-#      - openshift-etcd
-#      - openshift-kube-scheduler
-#      - openshift-monitoring
+#    infrastructure: {}
 #  pipelines:
 #    - name: audit-logs
 #      inputRefs:


### PR DESCRIPTION
Because any openshift namespaces are silently dropped when the CR is
applied, there will be an inconsistency between the 'inform' policy and
the actual CR that can never be resolved, resulting in infinite
reconciliations.

Removing these ensures the applied CR matches the policy, and all will
be well.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/cc @imiller0
/hold for testing
