### PR TITLE
Bug 2040791: ztp: Change the default PolicyGenerator to generate inform, not enforce policies

### DIFF
--- a/ztp/policygenerator/policyGen/policyBuilder_test.go
+++ b/ztp/policygenerator/policyGen/policyBuilder_test.go
@@ -311,52 +311,11 @@ spec:
 
 	assert.Contains(t, policies, "test1/test1-gen-sub-policy")
 	policy := policies["test1/test1-gen-sub-policy"].(utils.AcmPolicy)
-	assert.Equal(t, policy.Spec.RemediationAction, "enforce")
-	assert.Equal(t, policy.Spec.PolicyTemplates[0].ObjDef.Spec.RemediationAction, "enforce")
-}
-
-func TestNamespaceRemediationActionPGTLevel(t *testing.T) {
-	input := `
-apiVersion: ran.openshift.io/v1
-kind: PolicyGenTemplate
-metadata:
-  name: "test1"
-  namespace: "test1"
-spec:
-  bindingRules:
-    justfortest: "true"
-  remediationAction: "inform"
-  sourceFiles:
-    # Create operators policies that will be installed in all clusters
-    - fileName: GenericNamespace.yaml
-      policyName: "gen-sub-policy"
-    - fileName: GenericSubscription.yaml
-      policyName: "gen-sub-policy"
-    - fileName: GenericOperatorGroup.yaml
-      policyName: "gen-sub-policy"
-`
-	// Read in the test PGT
-	pgt := utils.PolicyGenTemplate{}
-	_ = yaml.Unmarshal([]byte(input), &pgt)
-
-	// Set up the files handler to pick up local source-crs and skip any output
-	fHandler := utils.NewFilesHandler("./testData/GenericSourceFiles", "/dev/null", "/dev/null")
-
-	// Run the PGT through the generator
-	pBuilder := NewPolicyBuilder(fHandler)
-	policies, err := pBuilder.Build(pgt)
-
-	// Validate the run
-	assert.Nil(t, err)
-	assert.NotNil(t, policies)
-
-	assert.Contains(t, policies, "test1/test1-gen-sub-policy")
-	policy := policies["test1/test1-gen-sub-policy"].(utils.AcmPolicy)
 	assert.Equal(t, policy.Spec.RemediationAction, "inform")
 	assert.Equal(t, policy.Spec.PolicyTemplates[0].ObjDef.Spec.RemediationAction, "inform")
 }
 
-func TestNamespaceRemediationActionOverride(t *testing.T) {
+func TestNamespaceRemediationActionPGTLevel(t *testing.T) {
 	input := `
 apiVersion: ran.openshift.io/v1
 kind: PolicyGenTemplate
@@ -371,13 +330,10 @@ spec:
     # Create operators policies that will be installed in all clusters
     - fileName: GenericNamespace.yaml
       policyName: "gen-sub-policy"
-      remediationAction: "inform"
     - fileName: GenericSubscription.yaml
       policyName: "gen-sub-policy"
-      remediationAction: "inform"
     - fileName: GenericOperatorGroup.yaml
       policyName: "gen-sub-policy"
-      remediationAction: "inform"
 `
 	// Read in the test PGT
 	pgt := utils.PolicyGenTemplate{}
@@ -396,8 +352,52 @@ spec:
 
 	assert.Contains(t, policies, "test1/test1-gen-sub-policy")
 	policy := policies["test1/test1-gen-sub-policy"].(utils.AcmPolicy)
-	assert.Equal(t, policy.Spec.RemediationAction, "inform")
-	assert.Equal(t, policy.Spec.PolicyTemplates[0].ObjDef.Spec.RemediationAction, "inform")
+	assert.Equal(t, policy.Spec.RemediationAction, "enforce")
+	assert.Equal(t, policy.Spec.PolicyTemplates[0].ObjDef.Spec.RemediationAction, "enforce")
+}
+
+func TestNamespaceRemediationActionOverride(t *testing.T) {
+	input := `
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "test1"
+  namespace: "test1"
+spec:
+  bindingRules:
+    justfortest: "true"
+  remediationAction: "inform"
+  sourceFiles:
+    # Create operators policies that will be installed in all clusters
+    - fileName: GenericNamespace.yaml
+      policyName: "gen-sub-policy"
+      remediationAction: "enforce"
+    - fileName: GenericSubscription.yaml
+      policyName: "gen-sub-policy"
+      remediationAction: "enforce"
+    - fileName: GenericOperatorGroup.yaml
+      policyName: "gen-sub-policy"
+      remediationAction: "enforce"
+`
+	// Read in the test PGT
+	pgt := utils.PolicyGenTemplate{}
+	_ = yaml.Unmarshal([]byte(input), &pgt)
+
+	// Set up the files handler to pick up local source-crs and skip any output
+	fHandler := utils.NewFilesHandler("./testData/GenericSourceFiles", "/dev/null", "/dev/null")
+
+	// Run the PGT through the generator
+	pBuilder := NewPolicyBuilder(fHandler)
+	policies, err := pBuilder.Build(pgt)
+
+	// Validate the run
+	assert.Nil(t, err)
+	assert.NotNil(t, policies)
+
+	assert.Contains(t, policies, "test1/test1-gen-sub-policy")
+	policy := policies["test1/test1-gen-sub-policy"].(utils.AcmPolicy)
+	assert.Equal(t, policy.Spec.RemediationAction, "enforce")
+	assert.Equal(t, policy.Spec.PolicyTemplates[0].ObjDef.Spec.RemediationAction, "enforce")
 }
 
 func TestNamespaceRemediationActionConflict(t *testing.T) {

--- a/ztp/policygenerator/policyGen/policyTemplate.go
+++ b/ztp/policygenerator/policyGen/policyTemplate.go
@@ -11,7 +11,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
 spec:
-    remediationAction: enforce
+    remediationAction: inform
     disabled: false
     policy-templates:
         - objectDefinition:

--- a/ztp/policygenerator/utils/utils.go
+++ b/ztp/policygenerator/utils/utils.go
@@ -42,8 +42,8 @@ type PolicyGenTempSpec struct {
 func (pgt *PolicyGenTempSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type PolicyGenTemplateSpec PolicyGenTempSpec
 	var defaults = PolicyGenTemplateSpec{
-		WrapInPolicy:      true, //Generate ACM wrapped policies by default
-		RemediationAction: "enforce",
+		WrapInPolicy:      true,     //Generate ACM wrapped policies by default
+		RemediationAction: "inform", // Generate inform policies by default
 		ComplianceType:    DefaultComplianceType,
 	}
 

--- a/ztp/ran-crd/policy-gen-template-crd.yaml
+++ b/ztp/ran-crd/policy-gen-template-crd.yaml
@@ -71,7 +71,7 @@ spec:
                     They are directly applied to the cluster by default. This can be overriden
                     by the changes to remediationAction in the sourceFiles object.
                   type: string
-                  default: enforce
+                  default: inform
                 sourceFiles:
                   type: array
                   items:


### PR DESCRIPTION
By changing the default in the tool, we ensure that users upgrading for
4.9 to 4.10 do not accidentally regenerate new enforce policies that
affect preexitsing clusters.  Likewise no action needs to be taken to
update existing common or group policies from older versions of the
tool (at least not to update the remediationAction part), minimizing the
number of manual actions a user needs to take when upgrading from 4.9 to
4.10.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/cc @imiller0 @serngawy
/hold until the approach is decided (between this and #909)
