### PR TITLE
Bug 2041639: ztp: Add DisableSnoNetworkDiag to group-du-sno PolicyGenTemplate

### DIFF
--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/group-du-sno-ranGen.yaml
@@ -77,3 +77,5 @@ spec:
           machineconfiguration.openshift.io/role: master
     - fileName: StorageLV.yaml
       policyName: "local-disks-policy"
+    - fileName: DisableSnoNetworkDiag.yaml
+      policyName: "config-policy"

--- a/ztp/ztp-policy-generator/testPolicyGenTemplate/group-du-sno-ranGen.yaml
+++ b/ztp/ztp-policy-generator/testPolicyGenTemplate/group-du-sno-ranGen.yaml
@@ -70,7 +70,7 @@ spec:
         labels:
           machineconfiguration.openshift.io/role: master
     - fileName: DisableSnoNetworkDiag.yaml
-      policyname: "disable-network-diag"
+      policyName: "disable-network-diag"
       metadata:
         labels:
           machineconfiguration.openshift.io/role: master


### PR DESCRIPTION
This is a back port of the fix in master branch that is missing in release-4.9