### PR TITLE
Bug 2038253: ztp: Add bindingExcludedRules in PGT

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
@@ -12,11 +12,6 @@ spec:
   # the Performance Profile needs to be set up to apply to the master MCP:
   mcp: "master"
   sourceFiles:
-    # Create inform policy to validate configuration CRs that will be applied to all 3-node clusters
-    - fileName: validatorCRs/informDuValidator.yaml
-      complianceType: musthave
-      remediationAction: inform
-      policyName: "du-validator-policy-3node"
     - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
       policyName: "config-policy"
       metadata:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-validator-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-validator-ranGen.yaml
@@ -1,0 +1,21 @@
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  # The name will be used to generate the placementBinding and placementRule names as {name}-placementBinding and {name}-placementRule
+  name: "group-du-3node-validator"
+  namespace: "ztp-group"
+spec:
+  # This policy will correspond to all clusters with label specified in bindingRules and
+  # without label specified in bindingExcludedRules.
+  bindingRules:
+    group-du-3node: ""
+  bindingExcludedRules:
+    # The ztp-done label is used in coordination with the Topology Aware Lifecycle Operator(TALO).
+    # Please do not change this label.
+    ztp-done: ""
+  mcp: "master"
+  sourceFiles:
+    # Create inform policy to validate configuration CRs that will be applied to all 3-node clusters
+    - fileName: validatorCRs/informDuValidator.yaml
+      remediationAction: inform
+      policyName: "du-validator-policy"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -11,11 +11,6 @@ spec:
     group-du-sno: ""
   mcp: "master"
   sourceFiles:
-    # Create inform policy to validate configuration CRs that will be applied to all SNO clusters
-    - fileName: validatorCRs/informDuValidator.yaml
-      complianceType: musthave
-      remediationAction: inform
-      policyName: "du-validator-policy-sno"
     - fileName: ConsoleOperatorDisable.yaml
       policyName: "config-policy"
     # Set ClusterLogForwarder & ClusterLogging as example might be better to create another policyTemp-Group

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-validator-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-validator-ranGen.yaml
@@ -1,0 +1,21 @@
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  # The name will be used to generate the placementBinding and placementRule names as {name}-placementBinding and {name}-placementRule
+  name: "group-du-sno-validator"
+  namespace: "ztp-group"
+spec:
+  bindingRules:
+    # This policy will correspond to all clusters with label specified in bindingRules and
+    # without label specified in bindingExcludedRules.
+    group-du-sno: ""
+  bindingExcludedRules:
+    # The ztp-done label is used in coordination with the Topology Aware Lifecycle Operator(TALO).
+    # Please do not change this label.
+    ztp-done: ""
+  mcp: "master"
+  sourceFiles:
+    # Create inform policy to validate configuration CRs that will be applied to all SNO clusters
+    - fileName: validatorCRs/informDuValidator.yaml
+      remediationAction: inform
+      policyName: "du-validator-policy"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
@@ -10,11 +10,6 @@ spec:
     group-du-standard: ""
   mcp: "worker"
   sourceFiles:
-    # Create inform policy to validate configuration CRs that will be applied to all standard clusters
-    - fileName: validatorCRs/informDuValidator.yaml
-      complianceType: musthave
-      remediationAction: inform
-      policyName: "du-validator-policy-standard"
     - fileName: PtpOperatorConfig.yaml
       policyName: "config-policy"
     - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-validator-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-validator-ranGen.yaml
@@ -1,0 +1,21 @@
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  # The name will be used to generate the placementBinding and placementRule names as {name}-placementBinding and {name}-placementRule
+  name: "group-du-standard-validator"
+  namespace: "ztp-group"
+spec:
+  # This policy will correspond to all clusters with label specified in bindingRules and
+  # without label specified in bindingExcludedRules.
+  bindingRules:
+    group-du-standard: ""
+  bindingExcludedRules:
+    # The ztp-done label is used in coordination with the Topology Aware Lifecycle Operator(TALO).
+    # Please do not change this label.
+    ztp-done: ""
+  mcp: "worker"
+  sourceFiles:
+    # Create inform policy to validate configuration CRs that will be applied to all standard clusters
+    - fileName: validatorCRs/informDuValidator.yaml
+      remediationAction: inform
+      policyName: "du-validator-policy"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/kustomization.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/kustomization.yaml
@@ -3,10 +3,16 @@ generators:
 - common-ranGen.yaml
 # This group policy is for all single-node deployments:
 - group-du-sno-ranGen.yaml
+# This group validator policy is for all single-node deployments:
+- group-du-sno-validator-ranGen.yaml
 # This group policy is for all compressed 3-node cluster deployments:
 - group-du-3node-ranGen.yaml
+# This group validator policy is for all compressed 3-node cluster deployments:
+- group-du-3node-validator-ranGen.yaml
 # This group policy is for all standard cluster deployments:
 - group-du-standard-ranGen.yaml
+# This group validator policy is for all standard cluster deployments:
+- group-du-standard-validator-ranGen.yaml
 # These are examples that should be replicated for every individual site:
 - example-sno-site.yaml
 - example-multinode-site.yaml

--- a/ztp/policygenerator/utils/utils.go
+++ b/ztp/policygenerator/utils/utils.go
@@ -2,6 +2,8 @@ package utils
 
 const ExistOper = "Exists"
 const InOper = "In"
+const DoesNotExistOper = "DoesNotExist"
+const NotInOper = "NotIn"
 const CustomResource = "customResource"
 const SourceCRsPath = "source-crs"
 const FileExt = ".yaml"
@@ -31,12 +33,13 @@ type MetaData struct {
 }
 
 type PolicyGenTempSpec struct {
-	BindingRules      map[string]string `yaml:"bindingRules,omitempty"`
-	Mcp               string            `yaml:"mcp,omitempty"`
-	WrapInPolicy      bool              `yaml:"wrapInPolicy,omitempty"`
-	RemediationAction string            `yaml:"remediationAction,omitempty"`
-	ComplianceType    string            `yaml:"complianceType,omitempty"`
-	SourceFiles       []SourceFile      `yaml:"sourceFiles,omitempty"`
+	BindingRules         map[string]string `yaml:"bindingRules,omitempty"`
+	BindingExcludedRules map[string]string `yaml:"bindingExcludedRules,omitempty"`
+	Mcp                  string            `yaml:"mcp,omitempty"`
+	WrapInPolicy         bool              `yaml:"wrapInPolicy,omitempty"`
+	RemediationAction    string            `yaml:"remediationAction,omitempty"`
+	ComplianceType       string            `yaml:"complianceType,omitempty"`
+	SourceFiles          []SourceFile      `yaml:"sourceFiles,omitempty"`
 }
 
 func (pgt *PolicyGenTempSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/ztp/ran-crd/policy-gen-template-crd.yaml
+++ b/ztp/ran-crd/policy-gen-template-crd.yaml
@@ -45,6 +45,13 @@ spec:
                     pairs in this list identify the cluster labels/values to which
                     the policy applies.
                   x-kubernetes-preserve-unknown-fields: true
+                bindingExcludedRules:
+                  type: object
+                  description: |
+                    Placement rule data for generated policies. The key/value
+                    pairs in this list identify the cluster labels/values to which
+                    the policy doesn't apply.
+                  x-kubernetes-preserve-unknown-fields: true
                 complianceType:
                   description: |
                     The complianceType will be set on the underlying

--- a/ztp/source-crs/validatorCRs/informDuValidator.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidator.yaml
@@ -2,6 +2,8 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
   name: $mcp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10000"
 status:
   conditions:
     - type: Updated


### PR DESCRIPTION
This commit includes the changes:
  - Add bindingExcludedRules in PGT crd to support selecting clusters
    which do not contain a label
  - Update PGT examples and move validator policy to three new PGTs
    corresponding to each type of cluster. The policy binds to the
    group types and to the clusters without "ztp-done" label.
  - Add a very large wave in validator source CR so validator policy
    will be added at the end of policies in generated UOCR by TALO

Signed-off-by: Angie Wang <angwang@redhat.com>