### PR TITLE
ztp: Remove PtpOperatorConfig from SNO and 3node example PGTs

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
@@ -16,8 +16,6 @@ spec:
       complianceType: musthave
       remediationAction: inform
       policyName: "du-validator-policy-3node"
-    - fileName: PtpOperatorConfig.yaml
-      policyName: "config-policy"
     - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
       policyName: "config-policy"
       metadata:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -47,8 +47,6 @@ spec:
           logs:
             type: "fluentd"
             fluentd: {}
-    - fileName: PtpOperatorConfig.yaml
-      policyName: "config-policy"
     - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
       policyName: "config-policy"
       metadata:


### PR DESCRIPTION
This isn't needed for those platforms since all nodes are masters and
all nodes should want the PTP daemon running.  It's only critical for
standard clusters where we want to restrict PTP to workers only.  So
moving this simplifies things for users especially when upgrading from
4.9 to 4.10.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/cc @imiller0
