### PR TITLE
Bug 2040799: Set summary_interval and logSyncInterval to 0

### DIFF
--- a/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-grandmaster.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-grandmaster.yaml
@@ -36,7 +36,7 @@ spec:
       # Port Data Set
       #
       logAnnounceInterval -3
-      logSyncInterval -4
+      logSyncInterval 0
       logMinDelayReqInterval -4
       logMinPdelayReqInterval -4
       announceReceiptTimeout 3

--- a/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-slave.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-slave.yaml
@@ -7,7 +7,7 @@ spec:
   profile:
   - name: "slave"
     interface: "ens1f0"
-    ptp4lOpts: "-2 -s --summary_interval -4"
+    ptp4lOpts: "-2 -s --summary_interval 0"
     phc2sysOpts: "-a -r -n 24"
     ptp4lConf: |
       [global]
@@ -33,7 +33,7 @@ spec:
       # Port Data Set
       #
       logAnnounceInterval -3
-      logSyncInterval -4
+      logSyncInterval 0
       logMinDelayReqInterval -4
       logMinPdelayReqInterval -4
       announceReceiptTimeout 3

--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-grandmaster.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-grandmaster.yaml
@@ -8,7 +8,7 @@ spec:
   - name: "grandmaster"
 # The interface name is hardware-specific    
     interface: "eno1"
-    ptp4lOpts: "-2 --summary_interval -4"
+    ptp4lOpts: "-2 --summary_interval 0"
     phc2sysOpts: "-a -r -r -n 24"
     ptp4lConf: |
       [global]
@@ -34,7 +34,7 @@ spec:
       # Port Data Set
       #
       logAnnounceInterval -3
-      logSyncInterval -4
+      logSyncInterval 0
       logMinDelayReqInterval -4
       logMinPdelayReqInterval -4
       announceReceiptTimeout 3
@@ -61,7 +61,7 @@ spec:
       unicast_req_duration 3600
       use_syslog 1
       verbose 0
-      summary_interval -4
+      summary_interval 0
       kernel_leap 1
       check_fup_sync 0
       #

--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-slave.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-slave.yaml
@@ -8,7 +8,7 @@ spec:
   - name: "slave"
 # The interface name is hardware-specific  
     interface: "eno1"
-    ptp4lOpts: "-2 -s --summary_interval -4"
+    ptp4lOpts: "-2 -s --summary_interval 0"
     phc2sysOpts: "-a -r -n 24"
     ptp4lConf: |
       [global]
@@ -34,7 +34,7 @@ spec:
       # Port Data Set
       #
       logAnnounceInterval -3
-      logSyncInterval -4
+      logSyncInterval 0
       logMinDelayReqInterval -4
       logMinPdelayReqInterval -4
       announceReceiptTimeout 3
@@ -61,7 +61,7 @@ spec:
       unicast_req_duration 3600
       use_syslog 1
       verbose 0
-      summary_interval -4
+      summary_interval 0
       kernel_leap 1
       check_fup_sync 0
       #

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
@@ -26,7 +26,7 @@ spec:
         - name: "slave"
           # This interface must match the hardware in this group
           interface: "ens5f0"
-          ptp4lOpts: "-2 -s --summary_interval -4"
+          ptp4lOpts: "-2 -s --summary_interval 0"
           phc2sysOpts: "-a -r -n 24"
     - fileName: SriovOperatorConfig.yaml
       policyName: "config-policy"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -57,7 +57,7 @@ spec:
         - name: "slave"
           # This interface must match the hardware in this group
           interface: "ens5f0"
-          ptp4lOpts: "-2 -s --summary_interval -4"
+          ptp4lOpts: "-2 -s --summary_interval 0"
           phc2sysOpts: "-a -r -n 24"
     - fileName: SriovOperatorConfig.yaml
       policyName: "config-policy"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
@@ -26,7 +26,7 @@ spec:
         - name: "slave"
           # This interface must match the hardware in this group
           interface: "ens5f0"
-          ptp4lOpts: "-2 -s --summary_interval -4"
+          ptp4lOpts: "-2 -s --summary_interval 0"
           phc2sysOpts: "-a -r -n 24"
     - fileName: SriovOperatorConfig.yaml
       policyName: "config-policy"

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
@@ -55,7 +55,7 @@ spec:
         profile:
         - name: "slave"
           interface: "ens5f0"
-          ptp4lOpts: "-2 -s --summary_interval -4"
+          ptp4lOpts: "-2 -s --summary_interval 0"
           phc2sysOpts: "-a -r -n 24"
     - fileName: SriovOperatorConfig.yaml
       policyName: "sriov-operconfig-policy"

--- a/ztp/policygenerator/testData/TestPtpConfig/sourcePolicies/TestPtpConfig.yaml
+++ b/ztp/policygenerator/testData/TestPtpConfig/sourcePolicies/TestPtpConfig.yaml
@@ -33,7 +33,7 @@ spec:
         # Port Data Set
         #
         logAnnounceInterval -3
-        logSyncInterval -4
+        logSyncInterval 0
         logMinDelayReqInterval -4
         logMinPdelayReqInterval -4
         announceReceiptTimeout 3

--- a/ztp/policygenerator/testData/TestPtpConfig/templates/TestPtpConfig.yaml
+++ b/ztp/policygenerator/testData/TestPtpConfig/templates/TestPtpConfig.yaml
@@ -22,7 +22,7 @@ spec:
         profile:
           - name: "slave"
             interface: "ens5f0"
-            ptp4lOpts: "-2 -s --summary_interval -4"
+            ptp4lOpts: "-2 -s --summary_interval 0"
             phc2sysOpts: "-a -r -n 24"
     - fileName: TestPtpConfig.yaml
       policyName: ""
@@ -32,5 +32,5 @@ spec:
         profile:
           - name: "slave"
             interface: "ens5f0"
-            ptp4lOpts: "-2 -s --summary_interval -4"
+            ptp4lOpts: "-2 -s --summary_interval 0"
             phc2sysOpts: "-a -r -n 24"

--- a/ztp/source-crs/PtpConfigMaster.yaml
+++ b/ztp/source-crs/PtpConfigMaster.yaml
@@ -38,7 +38,7 @@ spec:
       # Port Data Set
       #
       logAnnounceInterval -3
-      logSyncInterval -4
+      logSyncInterval 0
       logMinDelayReqInterval -4
       logMinPdelayReqInterval -4
       announceReceiptTimeout 3

--- a/ztp/source-crs/PtpConfigSlave.yaml
+++ b/ztp/source-crs/PtpConfigSlave.yaml
@@ -10,7 +10,7 @@ spec:
   - name: "slave"
     # The interface name is hardware-specific
     interface: $interface
-    ptp4lOpts: "-2 -s --summary_interval -4"
+    ptp4lOpts: "-2 -s --summary_interval 0"
     phc2sysOpts: "-a -r -n 24"
     ptp4lConf: |
       [global]
@@ -36,7 +36,7 @@ spec:
       # Port Data Set
       #
       logAnnounceInterval -3
-      logSyncInterval -4
+      logSyncInterval 0
       logMinDelayReqInterval -4
       logMinPdelayReqInterval -4
       announceReceiptTimeout 3

--- a/ztp/source-crs/PtpConfigSlaveCvl.yaml
+++ b/ztp/source-crs/PtpConfigSlaveCvl.yaml
@@ -11,7 +11,7 @@ spec:
   - name: "slave"
     # The interface name is hardware-specific
     interface: $interface
-    ptp4lOpts: "-2 -s --summary_interval -4"
+    ptp4lOpts: "-2 -s --summary_interval 0"
     phc2sysOpts: "-a -r -n 24"
     ptp4lConf: |
       [global]
@@ -37,7 +37,7 @@ spec:
       # Port Data Set
       #
       logAnnounceInterval -3
-      logSyncInterval -4
+      logSyncInterval 0
       logMinDelayReqInterval -4
       logMinPdelayReqInterval -4
       announceReceiptTimeout 3


### PR DESCRIPTION
Required that summary_interval == logSyncInterval.
Set to default of 0, which should be changed to -4 events are configured