### PR TITLE
ztp: Support existing customer Storage config

### DIFF
--- a/ztp/source-crs/StorageClass.yaml
+++ b/ztp/source-crs/StorageClass.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+  name: example-storage-class
+provisioner: kubernetes.io/no-provisioner
+reclaimPolicy: Delete

--- a/ztp/source-crs/StorageLocalVolume.yaml
+++ b/ztp/source-crs/StorageLocalVolume.yaml
@@ -1,0 +1,1 @@
+StorageLV.yaml


### PR DESCRIPTION
Existing customers use StorageLocalVolume rather than StorageLV. Add
symlink to allow either naming for this file for backwards
compatibility.

Some customers want to annotate a StorageClass as the default class. We
need to provide the StorageClass CR to allow this annotation (rather
than relying on its implicit creation along with the LocalVolume).

Signed-off-by: Ian Miller <imiller@redhat.com>