### PR TITLE
ztp: update default subscription CRs

### DIFF
--- a/ztp/source-crs/AcceleratorsSubscription.yaml
+++ b/ztp/source-crs/AcceleratorsSubscription.yaml
@@ -10,5 +10,8 @@ spec:
   name: sriov-fec 
   source: certified-operators 
   sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown
 
 

--- a/ztp/source-crs/AmqSubscription.yaml
+++ b/ztp/source-crs/AmqSubscription.yaml
@@ -11,3 +11,6 @@ spec:
   name:  amq7-interconnect-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/ztp/source-crs/ClusterLogSubscription.yaml
+++ b/ztp/source-crs/ClusterLogSubscription.yaml
@@ -10,3 +10,6 @@ spec:
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/ztp/source-crs/PaoSubscription.yaml
+++ b/ztp/source-crs/PaoSubscription.yaml
@@ -10,3 +10,6 @@ spec:
   name: performance-addon-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/ztp/source-crs/PtpSubscription.yaml
+++ b/ztp/source-crs/PtpSubscription.yaml
@@ -11,3 +11,6 @@ spec:
   name: ptp-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/ztp/source-crs/SriovSubscription.yaml
+++ b/ztp/source-crs/SriovSubscription.yaml
@@ -10,4 +10,6 @@ spec:
   name: sriov-network-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/ztp/source-crs/StorageSubscription.yaml
+++ b/ztp/source-crs/StorageSubscription.yaml
@@ -7,8 +7,9 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   channel: "4.9"
-  installPlanApproval: Automatic
   name: local-storage-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown


### PR DESCRIPTION
Update each subscription CR with default "installPlanApproval"
set to Manual. With this configuration, installPlan will not be
installed automatically. TALO needs to find the right installPlan
and approve it.

Also add check of "AtLatestKnown" status in subscriptions, so
a new version of z-stream operator pushed to the registry will
cause the sub policy to be non-compliant then TALO is able to
know when to start upgrade and trigger upgrade.

Jira: https://issues.redhat.com/browse/CNF-4073
Signed-off-by: Angie Wang <angwang@redhat.com>