### PR TITLE
ztp/entrypoint reshuffle

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: "ztp-common"
 spec:
   bindingRules:
+    # These policies will correspond to all clusters with this label:
     common: "true"
   sourceFiles:
     # Create operators policies that will be installed in all clusters

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-multinode-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-multinode-site.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: "ztp-site"
 spec:
   bindingRules:
+    # These policies will correspond to all clusters with this label:
     sites: "example-multinode"
   mcp: "worker"
   sourceFiles:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: "ztp-site"
 spec:
   bindingRules:
+    # These policies will correspond to all clusters with this label:
     sites: "example-sno"
   mcp: "master"
   sourceFiles:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: "ztp-group"
 spec:
   bindingRules:
+    # These policies will correspond to all clusters with this label:
     group-du-3node: ""
   # Because 3-node clusters are both workers and masters, and the MCP pool for master binds more strongly than that for worker,
   # the Performance Profile needs to be set up to apply to the master MCP:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: "ztp-group"
 spec:
   bindingRules:
+    # These policies will correspond to all clusters with this label:
     group-du-sno: ""
   mcp: "master"
   sourceFiles:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: "ztp-group"
 spec:
   bindingRules:
+    # These policies will correspond to all clusters with this label:
     group-du-standard: ""
   mcp: "worker"
   sourceFiles:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
@@ -15,9 +15,14 @@ spec:
   - clusterName: "example-3node"
     networkType: "OVNKubernetes"
     clusterLabels:
-      group-du: ""
+      # These example cluster labels correspond to the bindingRules in the PolicyGenTemplate examples in ../policygentemplates:
+      # ../policygentemplates/common-ranGen.yaml will apply to all clusters with 'common: true'
       common: true
-      sites : "example-3node"
+      # ../policygentemplates/group-du-3node-ranGen.yaml will apply to all clusters with 'group-du-3node: ""'
+      group-du-3node: ""
+      # ../policygentemplates/example-multinode-site.yaml will apply to all clusters with 'sites: "example-multinode"'
+      # Normally this should match or contain the cluster name so it only applies to a single cluster
+      sites : "example-multinode"
     clusterNetwork:
       - cidr: 1001:1::/48
         hostPrefix: 64

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
@@ -21,10 +21,9 @@ spec:
     clusterNetwork:
       - cidr: 1001:1::/48
         hostPrefix: 64
+    # For 3-node and standard clusters with static IPs, the API and Ingress IPs must be configured here
     apiVIP: 1111:2222:3333:4444::1:1
     ingressVIP: 1111:2222:3333:4444::1:2
-    machineNetwork:
-      - cidr: 1111:2222:3333:4444::/64
     serviceNetwork:
       - 1001:2::/112
     additionalNTPSources:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -15,8 +15,13 @@ spec:
   - clusterName: "example-sno"
     networkType: "OVNKubernetes"
     clusterLabels:
-      group-du-sno: ""
+      # These example cluster labels correspond to the bindingRules in the PolicyGenTemplate examples in ../policygentemplates:
+      # ../policygentemplates/common-ranGen.yaml will apply to all clusters with 'common: true'
       common: true
+      # ../policygentemplates/group-du-sno-ranGen.yaml will apply to all clusters with 'group-du-sno: ""'
+      group-du-sno: ""
+      # ../policygentemplates/example-sno-site.yaml will apply to all clusters with 'sites: "example-sno"'
+      # Normally this should match or contain the cluster name so it only applies to a single cluster
       sites : "example-sno"
     clusterNetwork:
       - cidr: 1001:1::/48

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -53,7 +53,12 @@ spec:
                 ipv6:
                   enabled: true
                   address:
+                  # For SNO sites with static IP addresses, the node-specific, API and Ingress IPs should all be configured on the interface
                   - ip: 1111:2222:3333:4444::aaaa:1
+                    prefix-length: 64
+                  - ip: 1111:2222:3333:4444::1:1
+                    prefix-length: 64
+                  - ip: 1111:2222:3333:4444::1:2
                     prefix-length: 64
             dns-resolver:
               config:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
@@ -15,9 +15,14 @@ spec:
   - clusterName: "example-standard"
     networkType: "OVNKubernetes"
     clusterLabels:
-      group-du: ""
+      # These example cluster labels correspond to the bindingRules in the PolicyGenTemplate examples in ../policygentemplates:
+      # ../policygentemplates/common-ranGen.yaml will apply to all clusters with 'common: true'
       common: true
-      sites : "example-standard"
+      # ../policygentemplates/group-du-standard-ranGen.yaml will apply to all clusters with 'group-du-standard: ""'
+      group-du-standard: ""
+      # ../policygentemplates/example-multinode-site.yaml will apply to all clusters with 'sites: "example-multinode"'
+      # Normally this should match or contain the cluster name so it only applies to a single cluster
+      sites : "example-multinode"
     clusterNetwork:
       - cidr: 1001:1::/48
         hostPrefix: 64

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
@@ -21,10 +21,9 @@ spec:
     clusterNetwork:
       - cidr: 1001:1::/48
         hostPrefix: 64
+    # For 3-node and standard clusters with static IPs, the API and Ingress IPs must be configured here
     apiVIP: 1111:2222:3333:4444::1:1
     ingressVIP: 1111:2222:3333:4444::1:2
-    machineNetwork:
-      - cidr: 1111:2222:3333:4444::/64
     serviceNetwork:
       - 1001:2::/112
     additionalNTPSources:

--- a/ztp/policygenerator/README.md
+++ b/ztp/policygenerator/README.md
@@ -4,6 +4,8 @@ The full list of the CRs that ztp RAN solution provide to deploy ACM policies ar
   1. Overlay: The given CRs that will be constructed into ACM policy may have some or all of their contents replaced by values specified in the PolicyGenTemplate.
   1. Grouping: Policies defined in the PolicyGenTemplate will be created under the same namespace and share the same PlacmentRules and PlacementBinding.
 
+By default, the policies created have `remediationAction: inform`, so that other tooling or direct user interaction can be used to opt-in to when these policies apply to individual clusters. This can be overridden by adding `remediationAction: enforce` to the PolicyGenTemplate spec.
+
 - Example 1: Consider the PolicyGenTemplate below to create ACM policies for both [ConsoleOperatorDisable.yaml](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/source-crs/ConsoleOperatorDisable.yaml) and [ClusterLogging.yaml](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/source-crs/ClusterLogging.yaml).
 ```
 apiVersion: ran.openshift.io/v1
@@ -72,9 +74,9 @@ spec:
               logLevel: Normal
               managementState: Removed
               operatorLogLevel: Normal
-        remediationAction: enforce
+        remediationAction: inform
         severity: low
-  remediationAction: enforce
+  remediationAction: inform
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
@@ -117,9 +119,9 @@ spec:
                   schedule: 30 3 * * *
                 type: curator
               managementState: Managed
-        remediationAction: enforce
+        remediationAction: inform
         severity: low
-  remediationAction: enforce
+  remediationAction: inform
 ```
 
 The placement binding and rules of the generated policies will be:

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -44,4 +44,6 @@ RUN chown -R 1001:1001 $WD && \
 COPY --from=builder  /PolicyGenTemplate $PGT_WD
 COPY --from=builder  /SiteConfig $SITECONFIG_WD
 COPY --chown=1001 exportkustomize.sh /
+COPY entrypoints/* /usr/bin
 USER 1001
+CMD entrypoints

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -24,6 +24,7 @@ ENV WD=/home/ztp
 ENV TEMP=/tmp/ztp-temp
 ENV PGT_WD=/kustomize/plugin/ran.openshift.io/v1/policygentemplate
 ENV SITECONFIG_WD=/kustomize/plugin/ran.openshift.io/v1/siteconfig
+RUN microdnf install tar
 RUN mkdir -p $WD
 RUN mkdir -p $TEMP
 RUN mkdir -p $PGT_WD

--- a/ztp/resource-generator/entrypoints/entrypoints
+++ b/ztp/resource-generator/entrypoints/entrypoints
@@ -27,9 +27,14 @@ template and example distribution
 
 You can export these templates and examples by running the following commands:
 
-    $ ZSG=\$(podman create ztp-site-generator:latest)
-    $ podman cp \$ZSG:/home/ztp ./out
-    $ podman rm -f \$ZSG
+    $ podman run --rm ztp-site-generator:latest extract /home/ztp --tar | tar x -C ./out
+
+extract
+-------
+EOF
+extract --help
+
+cat <<EOF
 
 /extractKustomize.sh
 -------------------
@@ -37,6 +42,4 @@ You can export these templates and examples by running the following commands:
 Used by the ArgoCD deployment patching logic, this entrypoint copies
 the kustomize plugins for SiteConfig and PolicyGenTemplate and
 aupporting resources into the proper kustomize directory structure.
-
 EOF
-

--- a/ztp/resource-generator/entrypoints/entrypoints
+++ b/ztp/resource-generator/entrypoints/entrypoints
@@ -1,0 +1,42 @@
+#!/bin/bash
+cat <<EOF
+ztp-site-generator container help
+=================================
+
+This container is the primary distribution mechanism for the Red Hat
+Zero Touch Provisioning (ztp) solution.
+
+The main container entrypoints are:
+
+template and example distribution
+---------------------------------
+
+/home/ztp
+  ├── argocd
+  │   ├── deployment
+  │   │   - Yaml files that configure the hub cluster and ArgoCD with our kustomize plugins
+  │   └── example
+  │       ├── policygentemplates
+  │       │   - Example PolicyGenTemplate files for all supported DU configurations
+  │       └── siteconfig
+  │           - Example SiteConfig files for all supported cluster types
+  ├── extra-manifest
+  │   - The set of extra manifests that are applied at day-0 by SiteConfig
+  └── source-crs
+      - The set of CRs that are available to be configured via PolicyGenTemplate
+
+You can export these templates and examples by running the following commands:
+
+    $ ZSG=\$(podman create ztp-site-generator:latest)
+    $ podman cp \$ZSG:/home/ztp ./out
+    $ podman rm -f \$ZSG
+
+/extractKustomize.sh
+-------------------
+
+Used by the ArgoCD deployment patching logic, this entrypoint copies
+the kustomize plugins for SiteConfig and PolicyGenTemplate and
+aupporting resources into the proper kustomize directory structure.
+
+EOF
+

--- a/ztp/resource-generator/entrypoints/extract
+++ b/ztp/resource-generator/entrypoints/extract
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copies the given source directory to either the given destination path, or to stdout via tar.
+
+if [[ $1 == "-h" || $1 == "--help" || $1 == "help" ]]; then
+    echo "ztp-site-generator content exporter"
+    echo
+    echo "Usage:"
+    echo
+    echo "  $(basename $0) srcPath --tar"
+    echo "    Export the given directory structure to stdout as a tar stream (should be redirected)"
+    echo "    Example:"
+    echo "      podman run \$THIS_CONTAINER export /home/ztp --tar | tar -C ./out"
+    echo
+    echo "  $(basename $0) srcPath dstPath"
+    echo "    Export the given directory structure to the destination path (should be mounted as a container volume)"
+    echo "    Example:"
+    echo "      podman run \$THIS_CONTAINER -v ./out:/out:Z export /home/ztp /out"
+    exit 1
+fi
+
+srcPath=$1
+case $srcPath in
+    /kustomize | /home/ztp | /home/ztp/*)
+        ;;
+    *)
+        echo "Source path must be one of: /kustomize /home/ztp[/...]"
+        exit 1
+esac
+
+dstPath=$2
+if [[ $dstPath == "--tar" ]]; then
+    tar c -C $srcPath .
+elif [[ ! -e $dstPath ]]; then
+    echo "Destination path $dstPath could not be found (did you mount this volume in the container?)"
+    exit 1
+else
+    cp -r $srcPath $dstPath
+fi
+


### PR DESCRIPTION
- ztp: Add a default 'help' endpoint to the resource-generator container
- ztp: Add a new entrypoint to make extracting directories from the ZTP container easier to do

(Note: Also build on the changes in #925; diffs will be clearer once that merges)