### PR TITLE
ztp: Move KlusterletAddonConfig out of SiteConfig and into PGT

### DIFF
--- a/ztp/Makefile
+++ b/ztp/Makefile
@@ -11,13 +11,17 @@ checkExtraManifests:
 
 checkSourceCRsAnnotation:
 	for sourcefile in ./source-crs/*.yaml;do \
-		if [[ "$${sourcefile}" != *"MachineConfig"* ]];then \
-			if ! grep -qE "ran.openshift.io/ztp-deploy-wave" "$${sourcefile}";then \
-				echo "Error: missing annotation 'ran.openshift.io/ztp-deploy-wave' in $${sourcefile}"; \
-				exit 1; \
-			fi; \
-		fi; \
-	done; \
+	  case "$${sourcefile}" in \
+	    ( *MachineConfig* | \
+	      *KlusterletAddonConfig* )\
+	    continue; \
+	    ;;\
+	  esac; \
+	  if ! grep -qE "ran.openshift.io/ztp-deploy-wave" "$${sourcefile}"; then \
+	    echo "Error: missing annotation 'ran.openshift.io/ztp-deploy-wave' in $${sourcefile}"; \
+	    exit 1; \
+	  fi; \
+	done
 
 test-policygen-kustomize:
 	@echo "ZTP: Build policy generator kustomize plugin and run test"

--- a/ztp/gitops-subscriptions/argocd/deployment/app-project.yaml
+++ b/ztp/gitops-subscriptions/argocd/deployment/app-project.yaml
@@ -29,8 +29,6 @@ spec:
     kind: ClusterDeployment
   - group: 'metal3.io'
     kind: BareMetalHost
-  - group: 'agent.open-cluster-management.io'
-    kind: KlusterletAddonConfig
   - group: 'cluster.open-cluster-management.io'
     kind: ManagedCluster
   - group: 'ran.openshift.io'

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-multinode-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-multinode-site.yaml
@@ -9,6 +9,17 @@ spec:
     sites: "example-multinode"
   mcp: "worker"
   sourceFiles:
+    - fileName: KlusterletAddonConfig.yaml
+      policyName: "" # Intentionally blank so it applies directly to the hub
+      # Both sets of 'name' and 'clusterName', and 'namespace' and
+      # 'clusterNamespace' must match the name and namespace of the
+      # corresponding SiteConfig for this site:
+      metadata:
+        name: "example-sno"
+        namespace: "example-sno"
+      spec:
+        clusterName: "example-sno"
+        clusterNamespace: "example-sno"
     - fileName: SriovNetwork.yaml
       policyName: "config-policy"
       metadata:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
@@ -9,6 +9,17 @@ spec:
     sites: "example-sno"
   mcp: "master"
   sourceFiles:
+    - fileName: KlusterletAddonConfig.yaml
+      policyName: "" # Intentionally blank so it applies directly to the hub
+      # Both sets of 'name' and 'clusterName', and 'namespace' and
+      # 'clusterNamespace' must match the name and namespace of the
+      # corresponding SiteConfig for this site:
+      metadata:
+        name: "example-sno"
+        namespace: "example-sno"
+      spec:
+        clusterName: "example-sno"
+        clusterNamespace: "example-sno"
     - fileName: SriovNetwork.yaml
       policyName: "config-policy"
       metadata:

--- a/ztp/siteconfig-generator/README.md
+++ b/ztp/siteconfig-generator/README.md
@@ -4,7 +4,6 @@ The siteconfig-generator library makes cluster deployment easier by generating t
   - AgentClusterInstall
   - ClusterDeployment
   - NMStateConfig
-  - KlusterletAddonConfig
   - ManagedCluster
   - InfraEnv
   - BareMetalHost

--- a/ztp/siteconfig-generator/siteConfig/clusterCRs.go
+++ b/ztp/siteconfig-generator/siteConfig/clusterCRs.go
@@ -139,28 +139,4 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
 spec:
   hubAcceptsClient: true
----
-apiVersion: agent.open-cluster-management.io/v1
-kind: KlusterletAddonConfig
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
-  name: siteconfig.Spec.Clusters.ClusterName
-  namespace: siteconfig.Spec.Clusters.ClusterName
-spec:
-  clusterName: siteconfig.Spec.Clusters.ClusterName
-  clusterNamespace: siteconfig.Spec.Clusters.ClusterName
-  clusterLabels:
-    cloud: auto-detect
-    vendor: auto-detect
-  applicationManager:
-    enabled: false
-  certPolicyController:
-    enabled: false
-  iamPolicyController:
-    enabled: false
-  policyController:
-    enabled: true
-  searchCollector:
-    enabled: false
 `

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterTestOutput.yaml
@@ -670,27 +670,3 @@ metadata:
     name: cluster1
 spec:
     hubAcceptsClient: true
----
-apiVersion: agent.open-cluster-management.io/v1
-kind: KlusterletAddonConfig
-metadata:
-    annotations:
-        argocd.argoproj.io/sync-wave: "2"
-    name: cluster1
-    namespace: cluster1
-spec:
-    applicationManager:
-        enabled: false
-    certPolicyController:
-        enabled: false
-    clusterLabels:
-        cloud: auto-detect
-        vendor: auto-detect
-    clusterName: cluster1
-    clusterNamespace: cluster1
-    iamPolicyController:
-        enabled: false
-    policyController:
-        enabled: true
-    searchCollector:
-        enabled: false

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
@@ -651,27 +651,3 @@ metadata:
     name: cluster1
 spec:
     hubAcceptsClient: true
----
-apiVersion: agent.open-cluster-management.io/v1
-kind: KlusterletAddonConfig
-metadata:
-    annotations:
-        argocd.argoproj.io/sync-wave: "2"
-    name: cluster1
-    namespace: cluster1
-spec:
-    applicationManager:
-        enabled: false
-    certPolicyController:
-        enabled: false
-    clusterLabels:
-        cloud: auto-detect
-        vendor: auto-detect
-    clusterName: cluster1
-    clusterNamespace: cluster1
-    iamPolicyController:
-        enabled: false
-    policyController:
-        enabled: true
-    searchCollector:
-        enabled: false

--- a/ztp/source-crs/KlusterletAddonConfig.yaml
+++ b/ztp/source-crs/KlusterletAddonConfig.yaml
@@ -1,0 +1,21 @@
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+  name: $clusterName
+  namespace: $clusterNamespace
+spec:
+  clusterName: $clusterName
+  clusterNamespace: $clusterNamespace
+  clusterLabels:
+    cloud: auto-detect
+    vendor: auto-detect
+  applicationManager:
+    enabled: false
+  certPolicyController:
+    enabled: false
+  iamPolicyController:
+    enabled: false
+  policyController:
+    enabled: true
+  searchCollector:
+    enabled: false


### PR DESCRIPTION
This will allow customization of the KlusterletAddonConfig for customers
who need to do so.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/hold for testing
