### PR TITLE
ztp: Fixup the policyTemplate.go for consistency

### DIFF
--- a/ztp/policygenerator/policyGen/policyTemplate.go
+++ b/ztp/policygenerator/policyGen/policyTemplate.go
@@ -20,7 +20,7 @@ spec:
             metadata:
                 name: policyGenTemplate.metadata.name-sourceFiles.policyName-config
             spec:
-                remediationAction: enforce
+                remediationAction: inform
                 severity: low
                 namespaceselector:
                     exclude:


### PR DESCRIPTION
In reality this is a no-op, since we always reset both
'remediationAction' fields in code when generating the policy:
https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/policygenerator/policyGen/policyBuilder.go#L101-L102

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/cc @imiller0 @serngawy
