### PR TITLE
vendor: update MetalLB dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ replace (
 // Test deps
 replace (
 	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20211207043958-2bfa00ead503 // release-4.10
-	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20211215122912-b151615b54ba //release-4.10
+	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20220126083843-10d63d74c04c //release-4.10
 	github.com/openshift-kni/performance-addon-operators => github.com/openshift-kni/performance-addon-operators v0.0.0-20211108074240-1544d9d65408 // release-4.10
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10
 	github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc // release-4.9

--- a/go.sum
+++ b/go.sum
@@ -1093,8 +1093,8 @@ github.com/openshift/custom-resource-status v0.0.0-20210221154447-420d9ecf2a00/g
 github.com/openshift/library-go v0.0.0-20210706120254-6f1208ffd780/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
 github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a h1:3YvNi1U+SrL1gBfL7aDT0jHkwvk6+N/xPIqSKXYFRJo=
 github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a/go.mod h1:LC0tawtxYlQ94QiIMOZ68Q+B3xEO8Vq3FIn+srfm4mE=
-github.com/openshift/metallb-operator v0.0.0-20211215122912-b151615b54ba h1:KcFlBaGma7a5JwNPQqnMbPakJnlej2HEZNqyyHOlcTU=
-github.com/openshift/metallb-operator v0.0.0-20211215122912-b151615b54ba/go.mod h1:OklSBaSeVcigNS4wtnHABJJlpSype7HZ7xg1gWDffh4=
+github.com/openshift/metallb-operator v0.0.0-20220126083843-10d63d74c04c h1:hMDbYQu37c5f2NV1O1aGmgw0a7Oy3OGrVTnDuxHvFDg=
+github.com/openshift/metallb-operator v0.0.0-20220126083843-10d63d74c04c/go.mod h1:OklSBaSeVcigNS4wtnHABJJlpSype7HZ7xg1gWDffh4=
 github.com/openshift/ptp-operator v0.0.0-20211201021143-27df2443c98f h1:jTS15R8E8fFmLx27w1dNih+owFXM9uWUyV8lu0SJakE=
 github.com/openshift/ptp-operator v0.0.0-20211201021143-27df2443c98f/go.mod h1:ZZqGY2xKHSxu2Ov7F9X5OE8vPhwaGowoGkLxsWYUaBc=
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912/go.mod h1:0OXNy7VoqFexkxKqyQbHJLPwn1MFp1/CxRJAgKHM+/o=

--- a/vendor/github.com/metallb/metallb-operator/api/v1beta1/bgppeer_types.go
+++ b/vendor/github.com/metallb/metallb-operator/api/v1beta1/bgppeer_types.go
@@ -82,6 +82,9 @@ type BGPPeerSpec struct {
 	Password string `json:"password,omitempty" yaml:"password,omitempty"`
 
 	BFDProfile string `json:"bfdProfile,omitempty" yaml:"bfdprofile,omitempty"`
+
+	// EBGP peer is multi-hops away
+	EBGPMultiHop bool `json:"ebgpMultiHop,omitempty" yaml:"ebgp-multihop,omitempty"`
 	// Add future BGP configuration here
 }
 

--- a/vendor/github.com/metallb/metallb-operator/test/e2e/functional/tests/e2e.go
+++ b/vendor/github.com/metallb/metallb-operator/test/e2e/functional/tests/e2e.go
@@ -88,7 +88,7 @@ var _ = Describe("metallb", func() {
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: "app.kubernetes.io/component=controller"})
+					LabelSelector: "component=controller"})
 				Expect(err).ToNot(HaveOccurred())
 
 				deploy, err := testclient.Client.Deployments(metallb.Namespace).Get(context.Background(), consts.MetalLBDeploymentName, metav1.GetOptions{})
@@ -110,7 +110,7 @@ var _ = Describe("metallb", func() {
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: "app.kubernetes.io/component=speaker"})
+					LabelSelector: "component=speaker"})
 				Expect(err).ToNot(HaveOccurred())
 
 				daemonset, err := testclient.Client.DaemonSets(metallb.Namespace).Get(context.Background(), consts.MetalLBDaemonsetName, metav1.GetOptions{})

--- a/vendor/github.com/metallb/metallb-operator/test/e2e/metallb/metallb.go
+++ b/vendor/github.com/metallb/metallb-operator/test/e2e/metallb/metallb.go
@@ -51,13 +51,13 @@ func Delete(metallb *metallbv1beta1.MetalLB) {
 
 	Eventually(func() bool {
 		pods, _ := testclient.Client.Pods(metallb.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/component=%s", consts.MetalLBDeploymentName)})
+			LabelSelector: fmt.Sprintf("component=%s", consts.MetalLBDeploymentName)})
 		return len(pods.Items) == 0
 	}, DeployTimeout, Interval).Should(BeTrue())
 
 	Eventually(func() bool {
 		pods, _ := testclient.Client.Pods(metallb.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/component=%s", consts.MetalLBDaemonsetName)})
+			LabelSelector: fmt.Sprintf("component=%s", consts.MetalLBDaemonsetName)})
 		return len(pods.Items) == 0
 	}, DeployTimeout, Interval).Should(BeTrue())
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -180,7 +180,7 @@ github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/metallb/metallb-operator v0.0.0-20211202081249-1b0df396f552 => github.com/openshift/metallb-operator v0.0.0-20211215122912-b151615b54ba
+# github.com/metallb/metallb-operator v0.0.0-20211202081249-1b0df396f552 => github.com/openshift/metallb-operator v0.0.0-20220126083843-10d63d74c04c
 ## explicit
 github.com/metallb/metallb-operator/api/v1alpha1
 github.com/metallb/metallb-operator/api/v1beta1
@@ -982,7 +982,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a
 # sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.9.2
 # github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20211207043958-2bfa00ead503
-# github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20211215122912-b151615b54ba
+# github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20220126083843-10d63d74c04c
 # github.com/openshift-kni/performance-addon-operators => github.com/openshift-kni/performance-addon-operators v0.0.0-20211108074240-1544d9d65408
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b
 # github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc


### PR DESCRIPTION
The current metallb-operator commit id is not updated to main
causing CI failure.

This PR updates the MetalLB dependencies.