### PR TITLE
Bug 2050393: ztp: Add support for customer features

### DIFF
--- a/ztp/source-crs/ImageRegistryConfig.yaml
+++ b/ztp/source-crs/ImageRegistryConfig.yaml
@@ -1,0 +1,28 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: Config
+metadata:
+  name: cluster
+  annotations:
+    # The registry depends on backend storage being
+    # configured. StoragePVC defaults to wave 10, so this CR defaults
+    # to wave 11 to satisfy that dependency.
+    ran.openshift.io/ztp-deploy-wave: "11"
+spec:
+  logLevel: Normal
+  managementState: Managed
+  observedConfig: null
+  # These fields can be set by the user as desired
+  #operatorLogLevel: Normal
+  #proxy: {}
+  replicas: 1
+  requests:
+    read:
+      maxWaitInQueue: 0s
+    write:
+      maxWaitInQueue: 0s
+  rolloutStrategy: Recreate
+  # User needs to specify proper storage
+  storage: {}
+  #  pvc:
+  #    claim: ''
+  unsupportedConfigOverrides: null

--- a/ztp/source-crs/MachineConfigGeneric.yaml
+++ b/ztp/source-crs/MachineConfigGeneric.yaml
@@ -1,0 +1,13 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: generic
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    #storage:
+    #  files:
+    #    - contents: ""

--- a/ztp/source-crs/StoragePVC.yaml
+++ b/ztp/source-crs/StoragePVC.yaml
@@ -1,0 +1,15 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-storage
+  namespace: default
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+    volume.beta.kubernetes.io/storage-class: $storageclass
+# User should supply all required content
+spec: {}
+  #accessModes:
+  #  - ReadWriteOnce
+  #resources:
+  #  requests:
+  #    storage: 400Gi


### PR DESCRIPTION
A local registry is needed to cache container images and reduce the need
to pull images across a potentially slow link at system startup.

The Generic MachineConfig template is needed to support customer
specific tuning.

Signed-off-by: Ian Miller <imiller@redhat.com>