### PR TITLE
Bug 2044339 ztp: update ClusterVersion source CR

### DIFF
--- a/ztp/source-crs/ClusterVersion.yaml
+++ b/ztp/source-crs/ClusterVersion.yaml
@@ -5,8 +5,9 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "100"
 spec:
+  # The default channel is stable-<version>
   channel: $channel
-  desiredUpdate:
-    force: false
-    version: $version
-  upstream: https://api.openshift.com/api/upgrades_info/v1/graph # default upstream.
+  # The default upstream path is https://api.openshift.com/api/upgrades_info/v1/graph
+  upstream: $upstream
+  # desiredUpdate:
+  #   version: $version


### PR DESCRIPTION
- remove desiredUpdate.force as the default value in CVO is false
- comment out desiredUpdate.version to allow to update the CV with
  channel or(and) upstream only
- change the upstream value
