### PR TITLE
ztp: Adding SriovFec configuration 

### DIFF
--- a/ztp/source-crs/SriovFecClusterConfig.yaml
+++ b/ztp/source-crs/SriovFecClusterConfig.yaml
@@ -1,0 +1,21 @@
+apiVersion: sriovfec.intel.com/v2
+kind: SriovFecClusterConfig
+metadata:
+  name: config
+  namespace: vran-acceleration-operators 
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  drainSkip: $drainSkip # true if SNO, false by default
+  priority: 1
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  acceleratorSelector:
+    pciAddress: $pciAddress
+  physicalFunction:  
+    pfDriver: "pci-pf-stub"
+    vfDriver: "vfio-pci"
+    vfAmount: 16
+    bbDevConfig: $bbDevConfig
+#Recommended configuration for Intel ACC100 (Mount Bryce) FPGA here: https://github.com/smart-edge-open/openshift-operator/blob/main/spec/openshift-sriov-fec-operator.md#sample-cr-for-wireless-fec-acc100
+#Recommended configuration for Intel N3000 FPGA here: https://github.com/smart-edge-open/openshift-operator/blob/main/spec/openshift-sriov-fec-operator.md#sample-cr-for-wireless-fec-n3000


### PR DESCRIPTION
Including the Accelerators configuration. In the source-crs folders there are manifests to install the sriovFec operator but there is not configuration that can be applied and managed using ZTP.

Some telco 5G vRAN DU come with a FEC accelerator, mainly ACC100 which is the only supported one in OpenShift. Previously it was supported the N3000 as well.

The source-cr I am including contains:

* wave set to 10 as any other configuration manifest
* drainskip set to optional. It must be true if SNO
* bbDevConfig set to optional. This is the configuration that mainly differs between the FPGA managed by the CRD.

More information about configuration examples can be found here:

* [N3000](https://github.com/smart-edge-open/openshift-operator/blob/main/spec/openshift-sriov-fec-operator.md#sample-cr-for-wireless-fec-n3000)
* [ACC100](https://github.com/smart-edge-open/openshift-operator/blob/main/spec/openshift-sriov-fec-operator.md#sample-cr-for-wireless-fec-acc100)

:exclamation: Currently only ACC100 (Mount Bryce) is supported and used by the telcos.