### PR TITLE
Update dpdk testpmd dockerfile with centos8 stream and latest dpdk version

### DIFF
--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -1,12 +1,12 @@
-FROM quay.io/centos/centos:8
+FROM quay.io/centos/centos:stream8
 
 LABEL maintainer="Sebastian Scheinkman <sebassch@gmail.com>"
 LABEL io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"
 LABEL io.s2i.scripts-url="image:///usr/libexec/s2i"
 
 ENV BUILDER_VERSION 0.1
-ENV DPDK_VER 20.11.1
-ENV DPDK_DIR /usr/src/dpdk-stable-${DPDK_VER}
+ENV DPDK_VER 21.11
+ENV DPDK_DIR /usr/src/dpdk-${DPDK_VER}
 ENV RTE_TARGET=x86_64-native-linuxapp-gcc
 ENV RTE_SDK=${DPDK_DIR}
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig/
@@ -36,10 +36,10 @@ RUN yum install -y wget python3\
  yum install -y libibverbs-devel && \
  yum clean all
 
-RUN pip3 install meson ninja
+RUN pip3 install meson ninja pyelftools
 
 RUN cd /usr/src/ && wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz && tar -xpvf dpdk-${DPDK_VER}.tar.xz && rm dpdk-${DPDK_VER}.tar.xz && \
-    cd dpdk-stable-${DPDK_VER} && \
+    cd dpdk-${DPDK_VER} && \
     meson build && \
     cd build  && \
     meson configure -Denable_docs=false && \


### PR DESCRIPTION
CentOS 8 is EOL so needs to be replaced by CentOS 8 Stream
DPDK version is upgraded to latest 21.11 (which is not using the stable naming in the file)

Signed-off-by: Alberto Losada <alosadag@redhat.com>

cc/ @SchSeba 