### PR TITLE
Bug 2058630: ztp: Add proxy definition for AgentClusterInstall

### DIFF
--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/resources/cluster-crs.yaml
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/resources/cluster-crs.yaml
@@ -25,6 +25,7 @@ spec:
     serviceNetwork: siteconfig.Spec.Clusters.ServiceNetwork
   provisionRequirements:
     controlPlaneAgents: siteconfig.Spec.Clusters.NumMasters
+  proxy: siteconfig.Spec.Clusters.ProxySettings
   sshPublicKey: siteconfig.Spec.SshPublicKey
   manifestsConfigMapRef:
     name: siteconfig.Spec.Clusters.ClusterName


### PR DESCRIPTION
Backport fix to include proxy settings in AgentClusterInstall. BZ
2057721.

Signed-off-by: Ian Miller <imiller@redhat.com>