### PR TITLE
Bug 2047871: ztp: Add mechanism to patch inner container references at build

### DIFF
--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -1,5 +1,6 @@
 # Builder
 FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+ARG IMAGE_REF
 USER root
 ENV PKG_ROOT=cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_ROOT
@@ -8,6 +9,8 @@ ENV SC_ROOT=$PKG_PATH/ztp/siteconfig-generator-kustomize-plugin
 RUN mkdir -p $PKG_PATH
 WORKDIR $PKG_PATH/
 COPY . .
+WORKDIR $PKG_PATH/ztp/resource-generator
+RUN ./tools/patchImageReference.sh ../gitops-subscriptions $IMAGE_REF
 WORKDIR $PGT_ROOT
 RUN make build
 WORKDIR $SC_ROOT

--- a/ztp/resource-generator/Makefile
+++ b/ztp/resource-generator/Makefile
@@ -1,6 +1,7 @@
 REG_URL ?= quay.io/openshift-kni
 IMAGE_NAME ?= ztp-site-generator
 IMAGE_URL ?= $(REG_URL)/$(IMAGE_NAME)
+IMAGE_REF ?=
 VERSION ?= latest
 
 .PHONY: help build export all
@@ -20,7 +21,7 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 build: ## Build the ZTP image
-	podman build -t ${IMAGE_NAME}:${VERSION} -f ztp/resource-generator/Containerfile ../..
+	podman build -t ${IMAGE_NAME}:${VERSION} --build-arg=IMAGE_REF='$(IMAGE_REF)' -f ztp/resource-generator/Containerfile ../..
 
 export: ## Copy resources from container image to out/ directory
 	mkdir -p out

--- a/ztp/resource-generator/README.md
+++ b/ztp/resource-generator/README.md
@@ -23,3 +23,15 @@ out/
 ## Automatic upstream container builds
 The Red Hat Prow infractructure automatically pushes the head of this
 master branch to quay.io/openshift-kni/ztp-site-generator:latest
+
+## Custom builds
+The argocd deployment files refer to the upstream container images by
+default. But downstream builds (or other special-purpose builds) need
+to override that internal reference.  Setting the IMAGE_REF build
+argument will patch any internal references to that argument's value
+verbatim.
+
+Example:
+```
+make build IMAGE_REF=quay.io/personal/ztp-site-generator:latest
+```

--- a/ztp/resource-generator/tools/patchImageReference.sh
+++ b/ztp/resource-generator/tools/patchImageReference.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# This script finds and replaces all references to our upstream container with whatever is provided on the commandline.
+#
+# This can be uaed for personal builds or downstream builds to ensure the contents of the container always point at the right container image
+set -e
+
+BASEDIR=$1
+REPLACEMENT_IMAGE=$2
+UPSTREAM_IMAGE="quay.io/openshift-kni/ztp-site-generator:latest"
+
+if [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage:"
+    echo "  $(basename $0) basedir quay.io/repo/container:tag"
+    exit 1
+fi
+
+if [[ ! -d $BASEDIR ]]; then
+    echo "FATAL: $BASEDIR is not a directory" >&2
+    exit 2
+fi
+
+if [[ -z $REPLACEMENT_IMAGE || $UPSTREAM_IMAGE == $REPLACEMENT_IMAGE ]]; then
+    echo "Not replacing $UPSTREAM_IMAGE"
+    exit 0
+fi
+
+echo "Replacing $UPSTREAM_IMAGE with $REPLACEMENT_IMAGE..." >&2
+
+for file in $(grep -Rl $UPSTREAM_IMAGE $BASEDIR); do
+    echo "  Editing $file" >&2
+    sed -i "s,$UPSTREAM_IMAGE,$REPLACEMENT_IMAGE,g" $file
+done
+
+echo "Done" >&2
+exit 0


### PR DESCRIPTION
The argocd deployment files refer to the upstream container images by
default. But downstream builds (or other special-purposw builds) need to
have a facility to override that internal reference. This is that
facility. Setting the IMAGE_REF build argument will patch any internal
references to that argument's value verbatim.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
