### PR TITLE
vendor: Bump mcmaker dependency to v0.0.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200626054723-37f83d1996bc
 	github.com/k8snetworkplumbingwg/sriov-network-operator v1.0.1-0.20211126031536-11faae79733e
 	github.com/kennygrant/sanitize v1.2.4
-	github.com/lack/mcmaker v0.0.5
+	github.com/lack/mcmaker v0.0.6
 	github.com/metallb/metallb-operator v0.0.0-20211202081249-1b0df396f552
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
@@ -82,6 +82,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/lack/yamltrim v0.0.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 // indirect

--- a/go.sum
+++ b/go.sum
@@ -888,8 +888,10 @@ github.com/kulti/thelper v0.4.0/go.mod h1:vMu2Cizjy/grP+jmsvOFDx1kYP6+PD1lqg4Yu5
 github.com/kunwardeep/paralleltest v1.0.2/go.mod h1:ZPqNm1fVHPllh5LPVujzbVz1JN2GhLxSfY+oqUsvG30=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/kyoh86/exportloopref v0.1.8/go.mod h1:1tUcJeiioIs7VWe5gcOObrux3lb66+sBqGZrRkMwPgg=
-github.com/lack/mcmaker v0.0.5 h1:CU3EIXUSW2LoBXq3AnHE+3cRxIu8dxuBaS34o5hGg6Q=
-github.com/lack/mcmaker v0.0.5/go.mod h1:LD6gD5KLXTRYiWKFFVhTFFV6KT5rcM4CcyuPRDGhyVw=
+github.com/lack/mcmaker v0.0.6 h1:YgegwKOfKyEw8iAtJU/GSRhN4H2lpHX+7sbyMoWYVwQ=
+github.com/lack/mcmaker v0.0.6/go.mod h1:eUVLoQ0YnNp7gXk0cBmIyz83lpARJ+EO3zn2RF7tfNU=
+github.com/lack/yamltrim v0.0.1 h1:l4h/zT4U7x0As8ZlPOaCgC0Ptl/qzKM/Sd0aUe/e4o0=
+github.com/lack/yamltrim v0.0.1/go.mod h1:S/ScLL7NdOtk+kRMsOdOHTKdsztBYbGgn9csP/mwYsI=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/ldez/gomoddirectives v0.2.1/go.mod h1:sGicqkRgBOg//JfpXwkB9Hj0X5RyJ7mlACM5B9f6Me4=

--- a/vendor/github.com/lack/yamltrim/README.md
+++ b/vendor/github.com/lack/yamltrim/README.md
@@ -1,0 +1,86 @@
+YamlTrim
+========
+
+A simple go library and utility to do better zero-trimming from complex yaml structures.
+
+Command Usage
+-------------
+
+Install the utility:
+```
+go install github.com/lack/yamltrim/cmd/yamltrim
+```
+
+Yamltrim filters stdin to stdout, applying the deep trimming facility of the library to the input yaml:
+```
+$ cat input.yaml
+top:
+  middle:
+    deep: ""
+  other:
+  - ""
+  - two
+$ yamltrim <input.yaml
+top:
+    other:
+          - two
+```
+
+Library Usage
+-------------
+
+Example utility:
+```
+package main
+
+import (
+	"fmt"
+
+	"github.com/lack/yamltrim"
+	"gopkg.in/yaml.v3"
+)
+
+func main() {
+	input := `
+top:
+  middle:
+    deep: ""
+  other:
+  - ""
+  - two
+`
+
+	var original interface{}
+	err := yaml.Unmarshal([]byte(input), &original)
+	if err != nil {
+		panic(err)
+	}
+
+	trimmed := yamltrim.YamlTrim(original)
+
+	origBytes, err := yaml.Marshal(original)
+	fmt.Printf("Original:\n----------\n%s\n", origBytes)
+
+	trimmedBytes, err := yaml.Marshal(trimmed)
+	fmt.Printf("Stripped:\n----------\n%s\n", trimmedBytes)
+}
+```
+
+Output:
+```
+Original:
+----------
+top:
+    middle:
+        deep: ""
+    other:
+      - ""
+      - two
+
+Stripped:
+----------
+top:
+    other:
+      - two
+
+```

--- a/vendor/github.com/lack/yamltrim/yamltrim.go
+++ b/vendor/github.com/lack/yamltrim/yamltrim.go
@@ -1,0 +1,77 @@
+package yamltrim
+
+import "log"
+
+// YamlTrim will deeply trim a given structure:
+// - For maps (only map[string]interface{} supported for now), recursively remove any entries whose values are zero, and return 'nil' if the final result is an empty map
+// - For slices (only []interface{} supported for now), recursively remove any entries that are zero, and return 'nil' if the final result is an empty slice
+// - For scalar types, return 'nil' for a zero value, else return the value
+func YamlTrim(src interface{}) interface{} {
+	switch t := src.(type) {
+	case map[string]interface{}:
+		// Recursrvely check the next level down
+		t = trimMap(t)
+		// only retain if the trimmed result has content
+		if len(t) > 0 {
+			return t
+		}
+		return nil
+	case []interface{}:
+		// Recursively check all items in the slice
+		t = trimSlice(t)
+		// only retain if the trimmed result has content
+		if len(t) > 0 {
+			return t
+		}
+		return nil
+	case string:
+		// omit empty strings
+		if len(t) == 0 {
+			return nil
+		}
+	case bool:
+		// omit false booleans
+		if !t {
+			return nil
+		}
+	case int:
+		// omit zeroes
+		if t == 0 {
+			return nil
+		}
+	case float64:
+		// omit zeroes
+		if t == 0.0 {
+			return nil
+		}
+	case nil:
+		// omit nil pointers
+		return nil
+	default:
+		// Report but retain everything else
+		log.Printf("Unknown type: %v (%T)\n", src, src)
+	}
+	return src
+}
+
+func trimSlice(src []interface{}) []interface{} {
+	var dst []interface{}
+	for _, v := range src {
+		t := YamlTrim(v)
+		if t != nil {
+			dst = append(dst, t)
+		}
+	}
+	return dst
+}
+
+func trimMap(src map[string]interface{}) map[string]interface{} {
+	dst := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		t := YamlTrim(v)
+		if t != nil {
+			dst[k] = t
+		}
+	}
+	return dst
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -225,10 +225,13 @@ github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/pod
 # github.com/kennygrant/sanitize v1.2.4
 ## explicit
 github.com/kennygrant/sanitize
-# github.com/lack/mcmaker v0.0.5
+# github.com/lack/mcmaker v0.0.6
 ## explicit; go 1.16
 github.com/lack/mcmaker
 github.com/lack/mcmaker/pkg
+# github.com/lack/yamltrim v0.0.1
+## explicit; go 1.17
+github.com/lack/yamltrim
 # github.com/mailru/easyjson v0.7.7
 ## explicit; go 1.12
 github.com/mailru/easyjson/buffer


### PR DESCRIPTION
This update to mcmaker splits out part of the shared functionality into
a new 'yamltrim' package that will soon be reused in ztp/policygenerator and
ztp/siteconfig-generator.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
