### PR TITLE
Bug 2059663: ztp: Suppress NMStateConfig when nodeNetwork empty

### DIFF
--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfig.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfig.go
@@ -181,6 +181,14 @@ func (rv *Nodes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return err
 }
 
+// Return true if the NodeNetwork content is empty or not defined
+func (node *Nodes) nodeNetworkIsEmpty() bool {
+	if len(node.NodeNetwork.Config) == 0 && len(node.NodeNetwork.Interfaces) == 0 {
+		return true
+	}
+	return false
+}
+
 // MachineNetwork
 type MachineNetwork struct {
 	Cidr string `yaml:"cidr"`

--- a/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/siteConfig/siteConfigBuilder_test.go
@@ -1,11 +1,14 @@
 package siteConfig
 
 import (
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/openshift-kni/cnf-features-deploy/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/utils"
 	"github.com/stretchr/testify/assert"
+
+	"gopkg.in/yaml.v3"
 )
 
 func fh() *utils.FilesHandler {
@@ -39,4 +42,116 @@ func Test_grtManifestFromTemplate(t *testing.T) {
 		assert.Equal(t, test.expectFn, fn)
 		assert.Equal(t, test.expectContent, content)
 	}
+}
+
+func getKind(builtCRs []interface{}, kind string) (map[string]interface{}, error) {
+	for _, cr := range builtCRs {
+		mapSourceCR := cr.(map[string]interface{})
+		if mapSourceCR["kind"] == kind {
+			return mapSourceCR, nil
+		}
+	}
+	return nil, errors.New("Error: Did not find " + kind + " in result")
+}
+
+func Test_nmstateConfig(t *testing.T) {
+	network := `
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "test-site"
+  namespace: "test-site"
+spec:
+  baseDomain: "example.com"
+  clusterImageSetNameRef: "openshift-v4.8.0"
+  sshPublicKey:
+  clusters:
+  - clusterName: "cluster1"
+    clusterLabels:
+      group-du-sno: ""
+      common: true
+      sites : "test-site"
+    nodes:
+      - hostName: "node1"
+        nodeNetwork:
+          interfaces:
+            - name: "eno1"
+              macAddress: E4:43:4B:F6:12:E0
+          config:
+            interfaces:
+            - name: eno1
+              type: ethernet
+              state: up
+`
+	sc := SiteConfig{}
+	err := yaml.Unmarshal([]byte(network), &sc)
+	assert.Equal(t, err, nil)
+
+	fh := fh()
+	fh.SetResourceBaseDir("../")
+	scBuilder, _ := NewSiteConfigBuilder(fh)
+	//scBuilder.SetLocalExtraManifestPath("../../source-crs/extra-manifest")
+	// Check good case, network creates NMStateConfig
+	result, err := scBuilder.Build(sc)
+	nmState, err := getKind(result["customResource/test-site/cluster1"], "NMStateConfig")
+	assert.NotNil(t, nmState, nil)
+
+	noNetwork := `
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "test-site"
+  namespace: "test-site"
+spec:
+  baseDomain: "example.com"
+  clusterImageSetNameRef: "openshift-v4.8.0"
+  sshPublicKey:
+  clusters:
+  - clusterName: "cluster1"
+    clusterLabels:
+      group-du-sno: ""
+      common: true
+      sites : "test-site"
+    nodes:
+      - hostName: "node1"
+`
+
+	// Set empty case, no network means no NMStateConfig
+	err = yaml.Unmarshal([]byte(noNetwork), &sc)
+	assert.Equal(t, err, nil)
+	scBuilder, _ = NewSiteConfigBuilder(fh)
+	result, err = scBuilder.Build(sc)
+	nmState, err = getKind(result["customResource/test-site/cluster1"], "NMStateConfig")
+	assert.Nil(t, nmState, nil)
+
+	emptyNetwork := `
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "test-site"
+  namespace: "test-site"
+spec:
+  baseDomain: "example.com"
+  clusterImageSetNameRef: "openshift-v4.8.0"
+  sshPublicKey:
+  clusters:
+  - clusterName: "cluster1"
+    clusterLabels:
+      group-du-sno: ""
+      common: true
+      sites : "test-site"
+    nodes:
+      - hostName: "node1"
+        nodeNetwork:
+          interfaces: []
+          config: {}
+`
+
+	// With empty config and interfaces
+	err = yaml.Unmarshal([]byte(emptyNetwork), &sc)
+	assert.Equal(t, err, nil)
+	scBuilder, _ = NewSiteConfigBuilder(fh)
+	result, err = scBuilder.Build(sc)
+	nmState, err = getKind(result["customResource/test-site/cluster1"], "NMStateConfig")
+	assert.Nil(t, nmState, nil)
 }


### PR DESCRIPTION
If the user does not supply any networking data in the nodeNetwork field
for a given node we should not generate the NMStateConfig CR. The
resultant NMStateConfig CR would be empty (no config/interfaces) and
causes the install to not complete (crash noted in infraenv). This patch
detects the empty nodeNetwork configuration in the user supplied
SiteConfig and suppresses the generation of NMStateConfig for that node.

Signed-off-by: Ian Miller <imiller@redhat.com>