### PR TITLE
ztp: cleanup sourceCRs to be used for platform upgrade using PGT 

### DIFF
--- a/ztp/source-crs/ClusterVersion.yaml
+++ b/ztp/source-crs/ClusterVersion.yaml
@@ -7,10 +7,12 @@ metadata:
 spec:
   channel: stable-4.10
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph # default upstream.
-  desiredUpdate:
-    force: false
-    version: $version
-status:
-  history:
-    -  version: $version
-       state: "Completed"
+
+# add these changes using PGT overlay to generate the policy to perform and verify platform upgrade.
+#  desiredUpdate:
+#    force: false
+#    version: $version
+#status:
+#  history:
+#    -  version: $version
+#       state: "Completed"

--- a/ztp/source-crs/ClusterVersionUpgradeGraph.yaml
+++ b/ztp/source-crs/ClusterVersionUpgradeGraph.yaml
@@ -1,9 +1,0 @@
-apiVersion: config.openshift.io/v1
-kind: ClusterVersion
-metadata:
-  name: version
-  annotations:
-    ran.openshift.io/ztp-deploy-wave: "90"
-spec:
-  channel: stable-4.10
-  upstream: https://api.openshift.com/api/upgrades_info/v1/graph # default upstream.


### PR DESCRIPTION
 - remove ClusterVersionUpgradeGraph.yml from sourceCRs
 - remove spec.desiredUpdate and status sections to be added in using PGT overlays
Signed-off-by: Nishant Parekh <nparekh@redhat.com>