### PR TITLE
ztp: Bug 2021688: add mutex lock for ArgoCD apps

### DIFF
--- a/ztp/resource-generator/src/post-sync-entrypoint.sh
+++ b/ztp/resource-generator/src/post-sync-entrypoint.sh
@@ -4,3 +4,7 @@ source $(dirname "$0")/common.sh
 init $1
 
 python watcher.py $(./get-pre-sync-rv.sh $1) $RESOURCE_NAME debug
+
+unlock_message=$(oc delete configmap/openshift-ztp-lock)
+unlock_result=$?
+echo "ztp-hooks.postsync $(date -R) INFO [post-sync-entrypoint] Sync unlock: $unlock_message, result $unlock_result" >> /proc/1/fd/1

--- a/ztp/resource-generator/src/pre-sync-entrypoint.sh
+++ b/ztp/resource-generator/src/pre-sync-entrypoint.sh
@@ -3,6 +3,15 @@
 source $(dirname "$0")/common.sh
 init $1
 
+while true; do
+    if ! oc create configmap openshift-ztp-lock &> /dev/null; then
+        echo "ztp-hooks.presync $(date -R) INFO [pre-sync-entrypoint] Waiting to acquire sync lock" >> /proc/1/fd/1
+        sleep 60
+    else
+        break
+    fi
+done
+
 # Delete old resource version configmap if present
 if oc get configmap/rv &> /dev/null; then
     oc delete configmap/rv &> /dev/null


### PR DESCRIPTION
Adds mutex lock causing all concurrent ArgoCD apps
in a given namespace to execute serially.
This addresses an issue happenning when a concurrent
application deletes and re-creates the resource version
configmap, corrupting the ongoing application data.

The lock is realized with a configmap, created
in the pre-sync hook and deleted just before the post-sync
hook exits. All concurrent pre-sync hooks will block
until the configmap is deleted

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>