### PR TITLE
Bug 2061782: ztp: Add mechanism to patch inner container references at build 

### DIFF
--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -19,6 +19,7 @@ RUN go build -mod=vendor -o /SiteConfig
 
 # Container image
 FROM ubi8-minimal
+ARG IMAGE_REF
 USER root
 ENV WD=/home/ztp
 ENV TEMP=/tmp/ztp-temp
@@ -34,6 +35,8 @@ WORKDIR $WD
 
 ARG TAR_NAME
 ADD --chown=1001 $TAR_NAME $TEMP
+WORKDIR $TEMP/ztp/resource-generator
+RUN ./tools/patchImageReference.sh ../gitops-subscriptions $IMAGE_REF
 RUN chown -R 1001:1001 $WD && \
     cp -R -L $TEMP/ztp/source-crs/extra-manifest $SITECONFIG_WD && \
     cp -R -L $TEMP/ztp/source-crs/*.yaml $PGT_WD/source-crs && \

--- a/ztp/resource-generator/Makefile
+++ b/ztp/resource-generator/Makefile
@@ -1,6 +1,7 @@
 REG_URL ?= quay.io/redhat_emp1
 IMAGE_NAME ?= ztp-site-generator
 IMAGE_URL ?= $(REG_URL)/$(IMAGE_NAME)
+IMAGE_REF ?=
 VERSION ?= latest
 TAR_NAME ?= temp.tar.gz
 
@@ -23,7 +24,7 @@ help: ## Display this help.
  ## Build the ztp image
 build:
 	tar cvzf ${TAR_NAME} --exclude *.gz ../../* && \
-	podman build --build-arg TAR_NAME=${TAR_NAME} -t ${IMAGE_NAME}:${VERSION} -f Containerfile; \
+	podman build --build-arg TAR_NAME=${TAR_NAME} --build-arg=IMAGE_REF='$(IMAGE_REF)' -t ${IMAGE_NAME}:${VERSION} -f Containerfile; \
 	rm ${TAR_NAME}
 
  ## Push to registry $(REG_URL)

--- a/ztp/resource-generator/README.md
+++ b/ztp/resource-generator/README.md
@@ -22,3 +22,15 @@ out/
 
 ## Push the container image to registry
 Run ``` $make push ``` in order to publish the image to the registry.
+
+## Custom builds
+The argocd deployment files refer to the upstream container images by
+default. But downstream builds (or other special-purpose builds) need
+to override that internal reference.  Setting the IMAGE_REF build
+argument will patch any internal references to that argument's value
+verbatim.
+
+Example:
+```
+make build IMAGE_REF=quay.io/personal/ztp-site-generator:latest
+```

--- a/ztp/resource-generator/tools/patchImageReference.sh
+++ b/ztp/resource-generator/tools/patchImageReference.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# This script finds and replaces all references to our upstream container with whatever is provided on the commandline.
+#
+# This can be uaed for personal builds or downstream builds to ensure the contents of the container always point at the right container image
+set -e
+
+BASEDIR=$1
+REPLACEMENT_IMAGE=$2
+UPSTREAM_IMAGE="quay.io/redhat_emp1/ztp-site-generator:latest"
+
+if [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage:"
+    echo "  $(basename $0) basedir quay.io/repo/container:tag"
+    exit 1
+fi
+
+if [[ ! -d $BASEDIR ]]; then
+    echo "FATAL: $BASEDIR is not a directory" >&2
+    exit 2
+fi
+
+if [[ -z $REPLACEMENT_IMAGE || $UPSTREAM_IMAGE == $REPLACEMENT_IMAGE ]]; then
+    echo "Not replacing $UPSTREAM_IMAGE"
+    exit 0
+fi
+
+echo "Replacing $UPSTREAM_IMAGE with $REPLACEMENT_IMAGE..." >&2
+
+for file in $(grep -Rl $UPSTREAM_IMAGE $BASEDIR); do
+    echo "  Editing $file" >&2
+    sed -i "s,$UPSTREAM_IMAGE,$REPLACEMENT_IMAGE,g" $file
+done
+
+echo "Done" >&2
+exit 0


### PR DESCRIPTION
The argocd deployment files refer to the upstream container images by
default. But downstream builds (or other special-purpose builds) need to
have a facility to override that internal reference. This is that
facility. Setting the IMAGE_REF build argument will patch any internal
references to that argument's value verbatim.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

- Manual cherry-pick of #985 to release-4.10