### PR TITLE
Bug 2050391: ztp: delete wave annotation from the policy-wrapped CRs

### DIFF
--- a/ztp/policygenerator/README.md
+++ b/ztp/policygenerator/README.md
@@ -7,7 +7,7 @@ The full list of the CRs that ztp RAN solution provide to deploy ACM policies ar
 By default, the policies created have `remediationAction: inform`, so that other tooling(e.g.[Topology Aware Lifecycle Operator](https://github.com/openshift-kni/cluster-group-upgrades-operator#readme)) or direct user interaction can be used to opt-in to when these policies apply to individual clusters. This can be overridden by adding `remediationAction: enforce` to the PolicyGenTemplate spec.
 
 ### Policy waves
-To use the Topology Aware Lifecycle Operator roll out the policies, ZTP deploy waves are used to order how policies are applied to the spoke cluster.  All policies created by PolicyGen have a ztp deploy wave by default. The ztp deploy wave of each policy is set by using the `ran.openshift.io/ztp-deploy-wave` annotation which is based on the same wave annotation from each [source CR](https://github.com/openshift-kni/cnf-features-deploy/source-crs/README.md) included in the policy. The policies have lower values should be applied first. All CRs have the same wave should be applied in the same policy. For the CRs with different waves, which means they have dependency between each other, so they are supposed to be applied in the separate policies.
+To use the Topology Aware Lifecycle Operator roll out the policies, ZTP deploy waves are used to order how policies are applied to the spoke cluster.  All policies created by PolicyGen have a ztp deploy wave by default. The ztp deploy wave of each policy is set by using the `ran.openshift.io/ztp-deploy-wave` annotation which is based on the same wave annotation from each [source CR](../source-crs/README.md) included in the policy. The policies have lower values should be applied first. All CRs have the same wave should be applied in the same policy. For the CRs with different waves, which means they have dependency between each other, so they are supposed to be applied in the separate policies. It's also possible to override the default source CR wave via the PolicyGenTemplate so that the CR can be included the same policy and the wave overrides should be reflected in the policy level.
 
 ### Examples
 - Example 1: Consider the PolicyGenTemplate below to create ACM policies for both [ConsoleOperatorDisable.yaml](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/source-crs/ConsoleOperatorDisable.yaml) and [ClusterLogging.yaml](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/source-crs/ClusterLogging.yaml).
@@ -74,7 +74,6 @@ spec:
                 include.release.openshift.io/self-managed-high-availability: "false"
                 include.release.openshift.io/single-node-developer: "false"
                 release.openshift.io/create-only: "true"
-                ran.openshift.io/ztp-deploy-wave: "10"
               name: cluster
             spec:
               logLevel: Normal
@@ -116,8 +115,6 @@ spec:
             metadata:
               name: instance
               namespace: openshift-logging
-            annotations:
-              ran.openshift.io/ztp-deploy-wave: "10"
             spec:
               collection:
                 logs:

--- a/ztp/policygenerator/policyGen/policyBuilder_test.go
+++ b/ztp/policygenerator/policyGen/policyBuilder_test.go
@@ -763,6 +763,16 @@ spec:
 			} else {
 				assert.Equal(t, wave, expectedWave)
 			}
+
+			// verify the wave has been removed from the built CRs wrapped in the policy
+			objects := policy.Spec.PolicyTemplates[0].ObjDef.Spec.ObjectTemplates
+			for _, obj := range objects {
+				metadata, _ := obj.ObjectDefinition["metadata"].(map[string]interface{})
+				annotations, ok := metadata["annotations"].(map[string]interface{})
+				if ok {
+					assert.NotContains(t, annotations, utils.ZtpDeployWaveAnnotation)
+				}
+			}
 		}
 	}
 }

--- a/ztp/policygenerator/policyGen/policyHelper.go
+++ b/ztp/policygenerator/policyGen/policyHelper.go
@@ -159,6 +159,13 @@ func SetPolicyDeployWave(policyMeta utils.MetaData, resource generatedCR) error 
 				utils.ZtpDeployWaveAnnotation, resource.pgtSourceFile.FileName, waveDisplay(crWave), policyMeta.Name, waveDisplay(policyWave))
 		}
 	}
+
+	// delete wave from the built CR wrapped in the policy
+	delete(crAnnotations, utils.ZtpDeployWaveAnnotation)
+	if len(crAnnotations) == 0 {
+		delete(crMetadata, "annotations")
+	}
+
 	return nil
 }
 

--- a/ztp/source-crs/README.md
+++ b/ztp/source-crs/README.md
@@ -6,7 +6,7 @@ This folder contains a full list of CRs for ZTP RAN solution.
 * ./validatorCRs contains the validation CRs to be deployed via the ACM policies to validate some configuration
 
 ### Waves
-Each configuration CR has a default `ran.openshift.io/ztp-deploy-wave` annotation that represents the deployment order of the resources wrapped in the ACM inform policies.
+Each configuration CR has a default `ran.openshift.io/ztp-deploy-wave` annotation that represents the deployment order of the resources wrapped in the ACM inform policies generated via [PolicyGen](../policygenerator/README.md). The source CR wave annotation is used for determining and setting the policy wave annotation and it will be removed from the built CR included in the generated policy at runtime.
 
 In general, the common configuration CRs for all types of sites should be applied first(eg. CatalogSources, OperatorNamespaces, OperatorSubscriptions, etc), so they have the lowest waves. Then, the group configuration CRs for a set of similar clusters would be the next(eg. PTP configuration, PAO configuration, etc). The last is the configuration CRs for each individual site(eg. IP addresses, SRIOV configuration, etc).
 


### PR DESCRIPTION
Strip the wave annotation from the built CR after the wave is
assigned to the policy.

Signed-off-by: Angie Wang <angwang@redhat.com>