### PR TITLE
ztp: Update subscription channels to latest

### DIFF
--- a/ztp/source-crs/PaoSubscription.yaml
+++ b/ztp/source-crs/PaoSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "4.9"
+  channel: "4.10"
   name: performance-addon-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/ztp/source-crs/PtpSubscription.yaml
+++ b/ztp/source-crs/PtpSubscription.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "4.9"
+  channel: "stable"
   name: ptp-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/ztp/source-crs/SriovSubscription.yaml
+++ b/ztp/source-crs/SriovSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "4.9"
+  channel: "stable"
   name: sriov-network-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/ztp/source-crs/StorageSubscription.yaml
+++ b/ztp/source-crs/StorageSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "4.9"
+  channel: "stable"
   name: local-storage-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Update subscriptions to point to the latest channel. In most cases this
is the "stable" channel, however Performance Addon Operator does not
have "stable" and is pointed to 4.10.

Signed-off-by: Ian Miller <imiller@redhat.com>