### PR TITLE
ztp: Enable kdump in the DU profile

### DIFF
--- a/ztp/source-crs/extra-manifest/06-kdump.yaml
+++ b/ztp/source-crs/extra-manifest/06-kdump.yaml
@@ -1,0 +1,16 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 06-kdump-enable-master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - enabled: true
+        name: kdump.service
+  kernelArguments:
+    - crashkernel=256M


### PR DESCRIPTION
To enable the Crash recovery kernel arming service, we need to add the
kernel command line argument 'crashkernel=256M' and enable the
'kdump.service' systemd service through a MachineConfig.

Addresses Bug 2062450