### PR TITLE
Bug 2064833: include non yaml files from sourceCRs in container

### DIFF
--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -39,8 +39,7 @@ WORKDIR $TEMP/ztp/resource-generator
 RUN ./tools/patchImageReference.sh ../gitops-subscriptions $IMAGE_REF
 RUN chown -R 1001:1001 $WD && \
     cp -R -L $TEMP/ztp/source-crs/extra-manifest $SITECONFIG_WD && \
-    cp -R -L $TEMP/ztp/source-crs/*.yaml $PGT_WD/source-crs && \
-    cp -r $TEMP/ztp/source-crs/validatorCRs $PGT_WD/source-crs && \
+    cp -R -L $TEMP/ztp/source-crs/ $PGT_WD/source-crs && \
     cp -r $TEMP/ztp/gitops-subscriptions/argocd $WD && \
     cp -r $SITECONFIG_WD/extra-manifest $WD  && \
     cp -r $PGT_WD/source-crs $WD


### PR DESCRIPTION
  ztp: include non yaml files from sourceCRs in container
   - Including recently added README.md

Signed-off-by: Nishant Parekh <nparekh@redhat.com>