### PR TITLE
[release-4.9] ztp: Add mechanism to patch inner container references at build

### DIFF
--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -16,6 +16,7 @@ RUN go build -mod=vendor -o /PolicyGenerator
 
 # Container image
 FROM quay.io/redhat_emp1/ztp-base:latest
+ARG IMAGE_REF
 USER root
 ENV WD=/usr/src/hook
 RUN mkdir $WD
@@ -27,6 +28,8 @@ RUN tar -xvf $TAR_NAME ztp  && \
     rm $TAR_NAME && \
     chown -R 1001:1001 $WD
 COPY --from=builder  /PolicyGenerator $WD/ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator
+WORKDIR $WD/ztp/resource-generator
+RUN ./tools/patchImageReference.sh ../gitops-subscriptions $IMAGE_REF
 WORKDIR $WD/ztp/resource-generator/src
 USER 1001
 

--- a/ztp/resource-generator/Makefile
+++ b/ztp/resource-generator/Makefile
@@ -12,6 +12,7 @@
 # Type 1
 HOOK ?= quay.io/redhat_emp1/ztp-site-generator
 BASE ?= quay.io/redhat_emp1/ztp-base
+IMAGE_REF ?=
 
 TAR_NAME ?= temp.tar.gz
 ##@ General
@@ -45,6 +46,6 @@ base:  ## Build base image containing the CLI tools and python.
 	podman push ztp-base:latest ${BASE}
 build: ## Build the ZTP site generator image
 	tar cvzf ${TAR_NAME} --exclude *.gz ../../* && \
-	podman build --build-arg TAR_NAME=${TAR_NAME} -t ztp-site-generator:latest -f Containerfile; \
+	podman build --build-arg TAR_NAME=${TAR_NAME} --build-arg=IMAGE_REF='$(IMAGE_REF)' -t ztp-site-generator:latest -f Containerfile; \
 	rm ${TAR_NAME} && \
 	podman push ztp-site-generator:latest ${HOOK}

--- a/ztp/resource-generator/README.md
+++ b/ztp/resource-generator/README.md
@@ -17,3 +17,15 @@ FROM localhost/ztp-site-generator:latest
 COPY myInstallManifest.yaml /usr/src/hook/ztp/source-crs/extra-manifest/
 COPY mySourceCR.yaml /usr/src/hook/ztp/source-crs/
 ```
+
+## Custom builds
+The argocd deployment files refer to the upstream container images by
+default. But downstream builds (or other special-purpose builds) need
+to override that internal reference.  Setting the IMAGE_REF build
+argument will patch any internal references to that argument's value
+verbatim.
+
+Example:
+```
+make build IMAGE_REF=quay.io/personal/ztp-site-generator:latest
+```

--- a/ztp/resource-generator/tools/patchImageReference.sh
+++ b/ztp/resource-generator/tools/patchImageReference.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# This script finds and replaces all references to our upstream container with whatever is provided on the commandline.
+#
+# This can be uaed for personal builds or downstream builds to ensure the contents of the container always point at the right container image
+set -e
+
+BASEDIR=$1
+REPLACEMENT_IMAGE=$2
+UPSTREAM_IMAGE="quay.io/redhat_emp1/ztp-site-generator:latest"
+
+if [[ $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage:"
+    echo "  $(basename $0) basedir quay.io/repo/container:tag"
+    exit 1
+fi
+
+if [[ ! -d $BASEDIR ]]; then
+    echo "FATAL: $BASEDIR is not a directory" >&2
+    exit 2
+fi
+
+if [[ -z $REPLACEMENT_IMAGE || $UPSTREAM_IMAGE == $REPLACEMENT_IMAGE ]]; then
+    echo "Not replacing $UPSTREAM_IMAGE"
+    exit 0
+fi
+
+echo "Replacing $UPSTREAM_IMAGE with $REPLACEMENT_IMAGE..." >&2
+
+for file in $(grep -Rl $UPSTREAM_IMAGE $BASEDIR); do
+    echo "  Editing $file" >&2
+    sed -i "s,$UPSTREAM_IMAGE,$REPLACEMENT_IMAGE,g" $file
+done
+
+echo "Done" >&2
+exit 0


### PR DESCRIPTION
The argocd deployment files refer to the upstream container images by
default. But downstream builds (or other special-purpose builds) need to
have a facility to override that internal reference. This is that
facility. Setting the IMAGE_REF build argument will patch any internal
references to that argument's value verbatim.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

Manual cherry-pick of #1000
