### PR TITLE
ztp: secure boot doc for ZTP 

### DIFF
--- a/ztp/gitops-subscriptions/argocd/SecureBoot.md
+++ b/ztp/gitops-subscriptions/argocd/SecureBoot.md
@@ -1,0 +1,115 @@
+# Enable and Verify for Secure Boot for SNO
+
+## Enabling Secure Boot 
+
+ - Configure `SiteConfig` with `UEFIScureBoot` for `bootMode`. E.g part of yaml below 
+   ```yaml
+    nodes:
+    - hostName: "myhost"
+      bootMode: "UEFISecureBoot"
+   ```
+
+- This value should now be available in the Hub (cluster w/ ACM) cluster's appropriate BareMetalHost (bmh) CR. e.g part of the yaml below 
+  ```yaml
+  spec:
+    bootMode: UEFISecureBoot
+  ```
+
+## Verifying Secure Boot
+
+1. log into the node
+
+    - With `oc`
+      ```shell
+      oc debug node/myhost.rh.com
+      
+      # don't forget to link the logs 
+      sh-4.4#  chroot /host
+      ```
+  
+    - **With `ssh` command** 
+       ```shell
+       ssh -i key core@myhost.rh.com # key: private key associated with the node
+       ```
+  
+2. Once logged into the node there are a couple of ways to verify. 
+
+    - **With `journalctl`**
+      ```shell
+      sh-4.4# journalctl -g secureboot
+      -- Logs begin at Wed 2022-03-23 17:14:14 UTC, end at Fri 2022-03-25 16:46:26 UTC. --
+      Mar 23 17:14:14 localhost kernel: secureboot: Secure boot enabled
+      -- Reboot --
+      Mar 23 17:20:00 localhost kernel: secureboot: Secure boot enabled
+      -- Reboot --
+      Mar 23 17:54:41 localhost kernel: secureboot: Secure boot enabled
+      -- Reboot --
+      Mar 23 18:04:16 localhost kernel: secureboot: Secure boot enabled
+      ```
+
+    - **With `mokutil`**
+      ```shell
+      mokutil --sb-state
+      SecureBoot enabled
+      ```
+
+**Debugging mokutil**
+
+If you're not using the latest set of source-crs and are running the real-time kernel, `mokutil` may return the following error message:
+
+```shell
+mokutil --sb-state
+EFI variables are not supported on this system
+```
+
+There are multiple ways to enable kernel access to the EFI variables that are required by `mokutil`: 
+
+- Update to the latest set of source-cr
+
+- Append `PerformanceProfile.yaml`'s  `additionalKernelArgs` from PGT
+
+  ```yaml
+  spec:
+    additionalKernelArgs:
+      - ...
+      - "efi=runtime"
+  ```
+- Use SiteConfig's `sno-extra-manifest` feature.
+
+  1. Create MachineConfig CR `99-efi-runtime-path-kargs.yaml`
+
+   ```yaml
+   apiVersion: machineconfiguration.openshift.io/v1
+   kind: MachineConfig
+   metadata:
+     labels:
+       machineconfiguration.openshift.io/role: master
+     name: 99-efi-runtime-path-kargs
+   spec:
+     kernelArguments:
+     - "efi=runtime"
+  ```
+  2. Include the `MC` with your `SiteConfig` as part of extra manifest. E.g part of the CR below
+  
+     ```yaml
+     clusters:
+     - clusterName: "myhost"
+       extraManifestPath: myhost/sno-extra-manifest/
+     ```
+
+     File dir may look like below 
+
+     ```shell
+     ➜ tree .
+       └── install
+       ├── myhost
+       │   ├── myhost.yaml
+       │   ├── secret.yaml
+       │   └── sno-extra-manifest
+       │       └── 99-efi-runtime-path-kargs.yaml
+       └── kustomization.yaml
+
+     ```
+
+##More info on Secure Boot
+- [Blog](https://cloud.redhat.com/blog/validating-secure-boot-functionality-in-a-sno-for-openshift-4.9)

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
@@ -46,6 +46,7 @@ spec:
         bmcCredentialsName:
           name: "example-node1-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:11"
+        # Use UEFISecureBoot to enable secure boot for this node
         bootMode: "UEFI"
         rootDeviceHints:
           hctl: '0:1:0'

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -45,6 +45,7 @@ spec:
         bmcCredentialsName:
           name: "example-node1-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:11"
+        # Use UEFISecureBoot to enable secure boot
         bootMode: "UEFI"
         rootDeviceHints:
           hctl: '0:1:0'

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
@@ -46,6 +46,7 @@ spec:
         bmcCredentialsName:
           name: "example-node1-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:11"
+        # Use UEFISecureBoot to enable secure boot for this node
         bootMode: "UEFI"
         rootDeviceHints:
           hctl: '0:1:0'

--- a/ztp/ran-crd/site-config-crd.yaml
+++ b/ztp/ran-crd/site-config-crd.yaml
@@ -274,7 +274,7 @@ spec:
                               type: string
                               pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
                             bootMode:
-                              description: Select the method of initializing the hardware during boot. Defaults to UEFI.
+                              description: Select the method of initializing the hardware during boot. Defaults to UEFI. Use UEFISecureBoot to enable secureboot
                               type: string
                               default: UEFI
                               enum:

--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -8,6 +8,7 @@ spec:
   additionalKernelArgs:
   - "idle=poll"
   - "rcupdate.rcu_normal_after_boot=0"
+  - "efi=runtime"
   cpu:
     isolated: $isolated
     reserved: $reserved


### PR DESCRIPTION
Upstream doc secure boot. Includes instruction on how to use mokutil 
CNF-[4157](https://issues.redhat.com/browse/CNF-4157)
CNF-[3096](https://issues.redhat.com/browse/CNF-3096)