### PR TITLE
ztp: bug 2065713: remove sync lock on sync fail

### DIFF
--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/post-sync.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/policygentemplates/post-sync.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: policies-sub
   generateName: post-sync-
   annotations:
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook: PostSync,SyncFail
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
   template:

--- a/ztp/gitops-subscriptions/argocd/resource-hook-example/siteconfig/post-sync.yaml
+++ b/ztp/gitops-subscriptions/argocd/resource-hook-example/siteconfig/post-sync.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: clusters-sub
   generateName: post-sync-
   annotations:
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook: PostSync,SyncFail
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
   template:


### PR DESCRIPTION
Adds an additional SyncFail annotation to the post-sync resource-hook
for cleaning up the sync lock mutex.
The hook run on the sync failure will process all the partially
synchronized resources and release the lock for the next attempt.

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>
/cc @imiller0 @serngawy 