### PR TITLE
Bug 2062917: ztp: support adding configmap for image signature

### DIFF
--- a/ztp/policygenerator/policyGen/policyBuilder.go
+++ b/ztp/policygenerator/policyGen/policyBuilder.go
@@ -255,6 +255,15 @@ func (pbuilder *PolicyBuilder) getCustomResource(sourceFile utils.SourceFile, so
 		resourceMap["status"] = pbuilder.setValues(resourceMap["status"].(map[string]interface{}), sourceFile.Status)
 	}
 
+	if resourceMap["binaryData"] == nil && sourceFile.BinaryData != nil {
+		// If the user supplies a "binaryData" section but the source CR does not have
+		// one, this will ensure we pull in the user content
+		resourceMap["binaryData"] = make(map[string]interface{})
+	}
+	if resourceMap["binaryData"] != nil {
+		resourceMap["binaryData"] = pbuilder.setValues(resourceMap["binaryData"].(map[string]interface{}), sourceFile.BinaryData)
+	}
+
 	return resourceMap, nil
 }
 

--- a/ztp/policygenerator/policyGen/policyBuilderOverlay_test.go
+++ b/ztp/policygenerator/policyGen/policyBuilderOverlay_test.go
@@ -501,4 +501,55 @@ spec:
 	assert.Equal(t, statList[0], 1)
 	assert.Equal(t, statList[1], 2)
 	assert.Equal(t, statList[2], 3)
+
+	input = `
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "test1"
+  namespace: "test1"
+spec:
+  bindingRules:
+    justfortest: "true"
+  sourceFiles:
+    - fileName: GenericDataCR.yaml
+      policyName: "gen-policy1"
+      binaryData:
+        key1: value1
+`
+	policies, _ = buildTest(t, input)
+	assert.Contains(t, policies, "test1/test1-gen-policy1")
+
+	objects = extractCRsFromPolicies(t, policies)
+	assert.Equal(t, len(objects), 1)
+	objDef = objects[0].ObjectDefinition
+	assert.NotNil(t, objDef["data"])
+	assert.Equal(t, objDef["data"].(map[string]interface{})["justData"], true)
+	assert.NotNil(t, objDef["binaryData"])
+	assert.Equal(t, objDef["binaryData"].(map[string]interface{})["key1"], "value1")
+
+	input = `
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "test1"
+  namespace: "test1"
+spec:
+  bindingRules:
+    justfortest: "true"
+  sourceFiles:
+    - fileName: GenericCR.yaml
+      policyName: "gen-policy1"
+      binaryData:
+        xyz: xyz-value
+`
+	policies, _ = buildTest(t, input)
+	assert.Contains(t, policies, "test1/test1-gen-policy1")
+
+	objects = extractCRsFromPolicies(t, policies)
+	assert.Equal(t, len(objects), 1)
+	objDef = objects[0].ObjectDefinition
+	assert.NotNil(t, objDef["binaryData"])
+	data = objDef["binaryData"].(map[string]interface{})
+	assert.Equal(t, data["xyz"], "xyz-value")
 }

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericCR.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericCR.yaml
@@ -22,3 +22,5 @@ spec:
       key2: value2
       subSub:
         x: y
+binaryData:
+  abc: abc-value

--- a/ztp/policygenerator/utils/utils.go
+++ b/ztp/policygenerator/utils/utils.go
@@ -65,6 +65,7 @@ type SourceFile struct {
 	Spec              map[string]interface{} `yaml:"spec,omitempty"`
 	Data              map[string]interface{} `yaml:"data,omitempty"`
 	Status            map[string]interface{} `yaml:"status,omitempty"`
+	BinaryData        map[string]interface{} `yaml:"binaryData,omitempty"`
 }
 
 // Provide custom YAML unmarshal for SourceFile which provides default values

--- a/ztp/ran-crd/policy-gen-template-crd.yaml
+++ b/ztp/ran-crd/policy-gen-template-crd.yaml
@@ -173,12 +173,21 @@ spec:
                           sourcePolicies/{fileName} will be carried out to the
                           generated custom resource.
                         x-kubernetes-preserve-unknown-fields: true
-                        status:
+                      status:
                           type: object
                           description: |
                             (optional) status contains the values that will be set in
                             the source policy following the exact same path. If the
                             status is not defined, the defined status in the
+                            sourcePolicies/{fileName} will be carried out to the
+                            generated custom resource.
+                          x-kubernetes-preserve-unknown-fields: true
+                      binaryData:
+                          type: object
+                          description: |
+                            (optional) binaryData contains the values that will be set in
+                            the source policy following the exact same path. If the
+                            binaryData is not defined, the defined binaryData in the
                             sourcePolicies/{fileName} will be carried out to the
                             generated custom resource.
                           x-kubernetes-preserve-unknown-fields: true

--- a/ztp/source-crs/ImageSignature.yaml
+++ b/ztp/source-crs/ImageSignature.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-image-signature
+  namespace: openshift-config-managed
+  labels:
+    release.openshift.io/verification-signatures: ""
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "1"
+binaryData: {}


### PR DESCRIPTION
1. add configmap source-cr for image signature
2. support binaryData overlay in PGT

Signed-off-by: Angie Wang <angwang@redhat.com>