### PR TITLE
[release-4.9] ztp: bug 2068098: Remove workload management annotation from AMQ namespace

### DIFF
--- a/ztp/source-crs/AmqSubscriptionNS.yaml
+++ b/ztp/source-crs/AmqSubscriptionNS.yaml
@@ -3,5 +3,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: amq-router
-  annotations:
-    workload.openshift.io/allowed: management


### PR DESCRIPTION
AMQ interconnect operators are not pinned to platform cores, and the AMQ namespace has an annotation to manage workload.
So removing workload management annotations from the namespace