### PR TITLE
Bug 2026130: fix creation of empty policy objects

### DIFF
--- a/ztp/policygenerator/policyGen/policyBuilder.go
+++ b/ztp/policygenerator/policyGen/policyBuilder.go
@@ -328,12 +328,18 @@ func (pbuilder *PolicyBuilder) splitYamls(yamls []byte) ([][]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		resBytes, err := yaml.Marshal(resIntf)
 
-		if err != nil {
-			return nil, err
+		// Check that resIntf is not nil in order to mitigate appending an empty
+		// object as a result of redundant trailing seperator(s) "---""
+		if resIntf != nil {
+			resBytes, err := yaml.Marshal(resIntf)
+
+			if err != nil {
+				return nil, err
+			}
+
+			resources = append(resources, resBytes)
 		}
-		resources = append(resources, resBytes)
 	}
 	return resources, nil
 }

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericCRWithTrailingSeparators.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericCRWithTrailingSeparators.yaml
@@ -1,0 +1,18 @@
+---
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: JustForTest
+metadata:
+  name: test123
+  namespace: generic-ns
+  labels:
+    label-key: label-value
+  annotations:
+    annot-key: annot-value
+spec:
+  foo: bar
+
+---
+
+---


### PR DESCRIPTION
When a source CR for policyGen contains a trailing "---" separator, the generated policy contains an empty object. ACM complains that this object does not have a "kind" attribute and the policy never goes compliant.

This commit checks that the decoded YAML objects are not null prior to appending them for further processing.

Signed-off-by: Sharat Akhoury sakhoury@redhat.com
/cc @imiller0 @lack 
