### PR TITLE
Bug 2060492: ztp: Update network_transport to L2

### DIFF
--- a/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-grandmaster.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-grandmaster.yaml
@@ -96,7 +96,7 @@ spec:
       # Default interface options
       #
       clock_type OC
-      network_transport UDPv4
+      network_transport L2
       delay_mechanism E2E
       time_stamping hardware
       tsproc_mode filter

--- a/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-slave.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-slave.yaml
@@ -93,7 +93,7 @@ spec:
       # Default interface options
       #
       clock_type OC
-      network_transport UDPv4
+      network_transport L2
       delay_mechanism E2E
       time_stamping hardware
       tsproc_mode filter

--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-grandmaster.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-grandmaster.yaml
@@ -94,7 +94,7 @@ spec:
       # Default interface options
       #
       clock_type OC
-      network_transport UDPv4
+      network_transport L2
       delay_mechanism E2E
       time_stamping hardware
       tsproc_mode filter

--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-slave.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-slave.yaml
@@ -94,7 +94,7 @@ spec:
       # Default interface options
       #
       clock_type OC
-      network_transport UDPv4
+      network_transport L2
       delay_mechanism E2E
       time_stamping hardware
       tsproc_mode filter

--- a/ztp/policygenerator/testData/TestPtpConfig/sourcePolicies/TestPtpConfig.yaml
+++ b/ztp/policygenerator/testData/TestPtpConfig/sourcePolicies/TestPtpConfig.yaml
@@ -93,7 +93,7 @@ spec:
         # Default interface options
         #
         clock_type OC
-        network_transport UDPv4
+        network_transport L2
         delay_mechanism E2E
         time_stamping hardware
         tsproc_mode filter

--- a/ztp/source-crs/PtpConfigMaster.yaml
+++ b/ztp/source-crs/PtpConfigMaster.yaml
@@ -98,7 +98,7 @@ spec:
       # Default interface options
       #
       clock_type OC
-      network_transport UDPv4
+      network_transport L2
       delay_mechanism E2E
       time_stamping hardware
       tsproc_mode filter

--- a/ztp/source-crs/PtpConfigSlave.yaml
+++ b/ztp/source-crs/PtpConfigSlave.yaml
@@ -96,7 +96,7 @@ spec:
       # Default interface options
       #
       clock_type OC
-      network_transport UDPv4
+      network_transport L2
       delay_mechanism E2E
       time_stamping hardware
       tsproc_mode filter

--- a/ztp/source-crs/PtpConfigSlaveCvl.yaml
+++ b/ztp/source-crs/PtpConfigSlaveCvl.yaml
@@ -97,7 +97,7 @@ spec:
       # Default interface options
       #
       clock_type OC
-      network_transport UDPv4
+      network_transport L2
       delay_mechanism E2E
       time_stamping hardware
       tsproc_mode filter


### PR DESCRIPTION
Currently, only L2 as network_transport is supported.
Example yamls currently set network_transport UDPv4, and then override
with -2 command-line option.
Update to set network_transport to L2 in yaml.