### PR TITLE
Bug 2051540: cnf-tests:cyclictest: remove smi option

### DIFF
--- a/cnf-tests/pod-utils/cyclictest-runner/main.go
+++ b/cnf-tests/pod-utils/cyclictest-runner/main.go
@@ -57,7 +57,6 @@ func main() {
 		"--interval", strconv.Itoa(*interval),
 		"--mlockall",
 		"--mainaffinity", mainThreadCPUSet.String(),
-		"--smi",
 		"--quiet",
 	}
 


### PR DESCRIPTION
cyclictest does not yet support the --smi option for newer processors (e.g. ice lake).

This will require an update to the rt-tests package to support newer processor models.
Until that is done, the change to add must be backed out, or this test won't work on ice lake processors.

A NOTE: this change is not temporary - it probaly would never be safe to add --smi option here, because of the way cyclictest is written, it is always going to fail on new processor models.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>