### PR TITLE
Bug 2044400: enable siteConfig generator to accept both relative and absolute manifest paths

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/filesHandler.go
+++ b/ztp/siteconfig-generator/siteConfig/filesHandler.go
@@ -6,6 +6,13 @@ import (
 	"path/filepath"
 )
 
+func resolveFilePath(filePath string, basedir string) string {
+	if _, errAbsPath := os.Stat(filePath); errAbsPath == nil {
+		return filePath
+	}
+	return basedir + "/" + filePath
+}
+
 func GetFiles(path string) ([]os.FileInfo, error) {
 	fileInfo, err := os.Stat(path)
 
@@ -34,7 +41,8 @@ func ReadExtraManifestResourceFile(filePath string) ([]byte, error) {
 		return nil, err
 	}
 	dir = filepath.Dir(ex)
-	ret, err = ReadFile(dir + "/" + filePath)
+
+	ret, err = ReadFile(resolveFilePath(filePath, dir))
 
 	// added fail safe for test runs as `os.Executable()` will fail for tests
 	if err != nil {
@@ -43,7 +51,8 @@ func ReadExtraManifestResourceFile(filePath string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		ret, err = ReadFile(dir + "/" + filePath)
+
+		ret, err = ReadFile(resolveFilePath(filePath, dir))
 	}
 	return ret, err
 }
@@ -55,13 +64,19 @@ func GetExtraManifestResourceFiles(manifestsPath string) ([]os.FileInfo, error) 
 	}
 
 	dir := filepath.Dir(ex)
-	files, err := GetFiles(dir + "/" + manifestsPath)
+
+	var files []os.FileInfo
+
+	files, err = GetFiles(resolveFilePath(manifestsPath, dir))
+
 	if err != nil {
 		dir, err = os.Getwd()
+
 		if err != nil {
 			return nil, err
 		}
-		files, err = GetFiles(dir + "/" + manifestsPath)
+
+		files, err = GetFiles(resolveFilePath(manifestsPath, dir))
 	}
 	return files, err
 }

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -197,6 +198,34 @@ func Test_siteConfigDifferentClusterVersions(t *testing.T) {
 	_, err = scBuilder.Build(sc)
 	// expect cluster's clusterImageSetNameRef to be set to the specific release defined in the cluster
 	assert.Equal(t, sc.Spec.Clusters[0].ClusterImageSetNameRef, "openshift-4.9")
+}
+
+func Test_siteConfigBuildExtraManifestPaths(t *testing.T) {
+
+	sc := SiteConfig{}
+	err := yaml.Unmarshal([]byte(siteConfigTest), &sc)
+	assert.NoError(t, err)
+
+	relativeManifestPath := "../../source-crs/extra-manifest"
+	absoluteManifestPath, err := filepath.Abs(relativeManifestPath)
+	assert.Equal(t, err, nil)
+
+	// Test 1: Test with relative manifest path
+
+	scBuilder, _ := NewSiteConfigBuilder()
+	scBuilder.SetLocalExtraManifestPath(relativeManifestPath)
+	// Setting the networkType to its default value
+	sc.Spec.Clusters[0].NetworkType = "OVNKubernetes"
+	_, err = scBuilder.Build(sc)
+	assert.NoError(t, err)
+
+	// Test 2: Test with absolute manifest path
+
+	scBuilder, _ = NewSiteConfigBuilder()
+	scBuilder.SetLocalExtraManifestPath(absoluteManifestPath)
+	sc.Spec.Clusters[0].NetworkType = "OVNKubernetes"
+	_, err = scBuilder.Build(sc)
+	assert.NoError(t, err)
 }
 
 func Test_siteConfigBuildExtraManifest(t *testing.T) {


### PR DESCRIPTION
The siteConfig generator currently only accepts a relative path for the manifest path argument.

This commit enables both relative and absolute paths to be accepted by first checking if the path provided is an absolute path, if not, it defaults to the relative path.

Signed-off-by: Sharat Akhoury sakhoury@redhat.com
/cc @imiller0 @lack