### PR TITLE
ztp: Bug 2070349:The source CR for PTP Operator Config misaligned

### DIFF
--- a/ztp/source-crs/PtpOperatorConfigForEvent.yaml
+++ b/ztp/source-crs/PtpOperatorConfigForEvent.yaml
@@ -7,7 +7,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   daemonNodeSelector:
-  node-role.kubernetes.io/$mcp: ""
+    node-role.kubernetes.io/$mcp: ""
   ptpEventConfig:
     enableEventPublisher: true
     transportHost: "amqp://amq-router.amq-router.svc.cluster.local"


### PR DESCRIPTION
The PR fixes source CR for PTP Operator Config for fast event notification has the node-role field misaligned
by two spaces.
Signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>