### PR TITLE
Bug 2064825: add sanity checks prior to instantiating CR

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
@@ -230,14 +230,27 @@ func (scbuilder *SiteConfigBuilder) instantiateCR(target string, originalTemplat
 
 	// Sanity-check the resulting metadata to ensure it's valid compared to the non-overridden original CR:
 	originalMetadata := originalCR["metadata"].(map[string]interface{})
-	overriddenMetadata := overriddenCR["metadata"].(map[string]interface{})
+
+	// Sanity-check the overridden metadata object to ensure that it's instantiated correctly
+	overriddenMetadata, ok := overriddenCR["metadata"].(map[string]interface{})
+	if !ok {
+		return override, fmt.Errorf("Overriden template metadata in %q is not specified!", overridePath)
+	}
+
 	for _, field := range []string{"name", "namespace"} {
 		if originalMetadata[field] != overriddenMetadata[field] {
 			return overriddenCR, fmt.Errorf("Overridden template metadata.%s %q does not match expected value %q", field, overriddenMetadata[field], originalMetadata[field])
 		}
 	}
 	originalAnnotations := originalMetadata["annotations"].(map[string]interface{})
-	overriddenAnnotations := overriddenMetadata["annotations"].(map[string]interface{})
+
+	// Sanity-check the overridden metadata annotations
+	overriddenAnnotations, ok := overriddenMetadata["annotations"].(map[string]interface{})
+	if !ok {
+		return override, fmt.Errorf("Overriden template metadata annotations in %q is not specified!", overridePath)
+	}
+
+	// Validate the the argocd annotation
 	argocdAnnotation := "argocd.argoproj.io/sync-wave"
 	if originalAnnotations[argocdAnnotation] != overriddenAnnotations[argocdAnnotation] {
 		return overriddenCR, fmt.Errorf("Overridden template metadata.annotations[%q] %q does not match expected value %q", argocdAnnotation, overriddenAnnotations[argocdAnnotation], originalAnnotations[argocdAnnotation])

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -502,6 +502,18 @@ func Test_CRTemplateOverride(t *testing.T) {
 		expectedSearchCollector: true,
 		expectedBmhInspection:   "disabled",
 	}, {
+		what:                  "Override KlusterletAddonConfig with missing metadata",
+		clusterCrTemplates:    map[string]string{"KlusterletAddonConfig": "testdata/KlusterletAddonConfigOverride-MissingMetadata.yaml"},
+		expectedErrorContains: "Overriden template metadata in",
+	}, {
+		what:                  "Override KlusterletAddonConfig with missing metadata.annotations",
+		clusterCrTemplates:    map[string]string{"KlusterletAddonConfig": "testdata/KlusterletAddonConfigOverride-MissingMetadataAnnotations.yaml"},
+		expectedErrorContains: "Overriden template metadata annotations in",
+	}, {
+		what:                  "Override KlusterletAddonConfig with missing metadata.annotations.argocd",
+		clusterCrTemplates:    map[string]string{"KlusterletAddonConfig": "testdata/KlusterletAddonConfigOverride-MissingArgocdAnnotation.yaml"},
+		expectedErrorContains: "does not match expected value",
+	}, {
 		what:                    "Override KlusterletAddonConfig at the cluster level",
 		clusterCrTemplates:      map[string]string{"KlusterletAddonConfig": "testdata/KlusterletAddonConfigOverride.yaml"},
 		expectedErrorContains:   "",

--- a/ztp/siteconfig-generator/siteConfig/testdata/KlusterletAddonConfigOverride-MissingArgocdAnnotation.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/KlusterletAddonConfigOverride-MissingArgocdAnnotation.yaml
@@ -1,0 +1,25 @@
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+  annotations:
+    foo: "bar"
+  name: "{{ .Cluster.ClusterName }}"
+  namespace: "{{ .Cluster.ClusterName }}"
+spec:
+  clusterName: "{{ .Cluster.ClusterName }}"
+  clusterNamespace: "{{ .Cluster.ClusterName }}"
+  clusterLabels:
+    cloud: auto-detect
+    vendor: auto-detect
+  applicationManager:
+    enabled: true 
+  certPolicyController:
+    enabled: true
+  iamPolicyController:
+    enabled: true
+  policyController:
+    enabled: true
+  searchCollector:
+    enabled: true
+
+

--- a/ztp/siteconfig-generator/siteConfig/testdata/KlusterletAddonConfigOverride-MissingMetadata.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/KlusterletAddonConfigOverride-MissingMetadata.yaml
@@ -1,0 +1,19 @@
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+spec:
+  clusterName: "{{ .Cluster.ClusterName }}"
+  clusterNamespace: "{{ .Cluster.ClusterName }}"
+  clusterLabels:
+    cloud: auto-detect
+    vendor: auto-detect
+  applicationManager:
+    enabled: true 
+  certPolicyController:
+    enabled: true
+  iamPolicyController:
+    enabled: true
+  policyController:
+    enabled: true
+  searchCollector:
+    enabled: true
+

--- a/ztp/siteconfig-generator/siteConfig/testdata/KlusterletAddonConfigOverride-MissingMetadataAnnotations.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/KlusterletAddonConfigOverride-MissingMetadataAnnotations.yaml
@@ -1,0 +1,21 @@
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+  name: "{{ .Cluster.ClusterName }}"
+  namespace: "{{ .Cluster.ClusterName }}"
+spec:
+  clusterName: "{{ .Cluster.ClusterName }}"
+  clusterNamespace: "{{ .Cluster.ClusterName }}"
+  clusterLabels:
+    cloud: auto-detect
+    vendor: auto-detect
+  applicationManager:
+    enabled: true 
+  certPolicyController:
+    enabled: true
+  iamPolicyController:
+    enabled: true
+  policyController:
+    enabled: true
+  searchCollector:
+    enabled: true


### PR DESCRIPTION
The clusters app panics when klusterletaddonconfig via siteconfig has missing attributes / components such as the argocd sync-wave annotation.

This commit adds sanity checks to verify the existence of these attributes prior to instantiating the CR to avoid the application from panicking. If there are missing attributes, an appropriate error is returned instead!

Signed-off-by: Sharat Akhoury [sakhoury@redhat.com](mailto:sakhoury@redhat.com)
/cc @imiller0 @lack