### PR TITLE
Bug 2072572: ztp: Update SNO example for single IP

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -65,12 +65,10 @@ spec:
                 ipv6:
                   enabled: true
                   address:
-                  # For SNO sites with static IP addresses, the node-specific, API and Ingress IPs should all be configured on the interface
+                  # For SNO sites with static IP addresses, the node-specific,
+                  # API and Ingress IPs should all be the same and configured on
+                  # the interface
                   - ip: 1111:2222:3333:4444::aaaa:1
-                    prefix-length: 64
-                  - ip: 1111:2222:3333:4444::1:1
-                    prefix-length: 64
-                  - ip: 1111:2222:3333:4444::1:2
                     prefix-length: 64
             dns-resolver:
               config:


### PR DESCRIPTION
SNO expects a single IP address for the node, API and ingress. This
single IP should be configured on the interface. Issues can occur during
installation if separate IPs are used (eg BZ 2053675). Updating the
reference SiteConfig to reflect this.

Signed-off-by: Ian Miller <imiller@redhat.com>