### PR TITLE
Bug 2073439: ztp: Disable podman logging when extracting container data

### DIFF
--- a/ztp/gitops-subscriptions/argocd/README.md
+++ b/ztp/gitops-subscriptions/argocd/README.md
@@ -17,7 +17,7 @@ Create a GIT repository for hosting site configuration data. The ZTP pipeline wi
 2. Export the argocd directory from the ztp-site-generator container image by executing the following commands:
 ```
     $ mkdir -p ./out
-    $ podman run --rm ztp-site-generator:latest extract /home/ztp --tar | tar x -C ./out
+    $ podman run --rm --log-driver=none ztp-site-generator:latest extract /home/ztp --tar | tar x -C ./out
 ```
 3. Check the out directory that created above. It contains the following sub directories
   - out/extra-manifest: contains the source CRs files that SiteConfig uses to generate extra manifest configMap.

--- a/ztp/resource-generator/Makefile
+++ b/ztp/resource-generator/Makefile
@@ -25,8 +25,8 @@ build: ## Build the ZTP image
 
 export: ## Copy resources from container image to out/ directory
 	mkdir -p out
-	podman run --rm ${IMAGE_NAME}:${VERSION} extract /home/ztp --tar | tar x -C out
+	podman run --rm --log-driver=none ${IMAGE_NAME}:${VERSION} extract /home/ztp --tar | tar x -C out
 	mkdir -p out/kustomize
-	podman run --rm ${IMAGE_NAME}:${VERSION} extract /kustomize --tar | tar x -C out/kustomize
+	podman run --rm --log-driver=none ${IMAGE_NAME}:${VERSION} extract /kustomize --tar | tar x -C out/kustomize
 
 all: build export

--- a/ztp/resource-generator/entrypoints/entrypoints
+++ b/ztp/resource-generator/entrypoints/entrypoints
@@ -27,7 +27,7 @@ template and example distribution
 
 You can export these templates and examples by running the following commands:
 
-    $ podman run --rm ztp-site-generator:latest extract /home/ztp --tar | tar x -C ./out
+    $ podman run --rm --log-driver=none ztp-site-generator:latest extract /home/ztp --tar | tar x -C ./out
 
 extract
 -------

--- a/ztp/resource-generator/entrypoints/extract
+++ b/ztp/resource-generator/entrypoints/extract
@@ -9,12 +9,15 @@ if [[ $1 == "-h" || $1 == "--help" || $1 == "help" ]]; then
     echo "  $(basename $0) srcPath --tar"
     echo "    Export the given directory structure to stdout as a tar stream (should be redirected)"
     echo "    Example:"
-    echo "      podman run \$THIS_CONTAINER $(basename $0) /home/ztp --tar | tar -C ./out"
+    echo "      podman run --rm --log-driver=none \$THIS_CONTAINER $(basename $0) /home/ztp --tar | tar -C ./out"
+    echo
+    echo "    Important: With podman, add '--log-driver=none' to prevent podman from hanging with large data sent to stdout,"
+    echo "               and '--rm' to avoid creating unneeded persistent container image"
     echo
     echo "  $(basename $0) srcPath dstPath"
     echo "    Export the given directory structure to the destination path (should be mounted as a container volume)"
     echo "    Example:"
-    echo "      podman run \$THIS_CONTAINER -v ./out:/out:Z $(basename $0) /home/ztp /out"
+    echo "      podman run --rm \$THIS_CONTAINER -v ./out:/out:Z $(basename $0) /home/ztp /out"
     exit 1
 fi
 


### PR DESCRIPTION
As described in https://github.com/containers/podman/issues/13779,
podman by default logs all of a container's stdout in order to retain
info to make 'podman logs' work. But this extra copy of stdout can be
overrun and cause hangs when shipping large amounts of data through
stdout (as in the case when piping out a tar stream).  Changing the
instructions and documentation to add '--log-driver=none' to the podman
commandline disables this extra unneeded logging and prevents hangs.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/cc @imiller0 @serngawy 