### PR TITLE
Remove PAO subscription from DU profile

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
@@ -26,17 +26,6 @@ spec:
       policyName: "subscriptions-policy"
     - fileName: PtpOperatorStatus.yaml
       policyName: "subscriptions-policy"
-    - fileName: PaoSubscription.yaml
-      policyName: "subscriptions-policy"
-      spec:
-      # Changing the channel value will upgrade/downgrade the operator installed version.
-        channel: "4.10"
-    - fileName: PaoSubscriptionNS.yaml
-      policyName: "subscriptions-policy"
-    - fileName: PaoSubscriptionOperGroup.yaml
-      policyName: "subscriptions-policy"
-    - fileName: PaoOperatorStatus.yaml
-      policyName: "subscriptions-policy"
     - fileName: ClusterLogNS.yaml
       policyName: "subscriptions-policy"
     - fileName: ClusterLogOperGroup.yaml

--- a/ztp/source-crs/PaoSubscription.yaml
+++ b/ztp/source-crs/PaoSubscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: performance-addon-operator
+  namespace: openshift-performance-addon-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  channel: "4.10"
+  name: performance-addon-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/ztp/source-crs/PaoSubscriptionCatalogSource.yaml
+++ b/ztp/source-crs/PaoSubscriptionCatalogSource.yaml
@@ -1,0 +1,17 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: performance-addon-operator
+  namespace: openshift-marketplace
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    ran.openshift.io/ztp-deploy-wave: "1"
+spec:
+  displayName: Openshift Performance Addon Operator
+  icon:
+    base64data: ""
+    mediatype: ""
+  #image: quay.io/openshift-kni/performance-addon-operator-index:4.9-snapshot
+  image: $imageUrl
+  publisher: Red Hat
+  sourceType: grpc

--- a/ztp/source-crs/PaoSubscriptionNS.yaml
+++ b/ztp/source-crs/PaoSubscriptionNS.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-performance-addon-operator
+  annotations:
+    workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "2"
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/ztp/source-crs/PaoSubscriptionOperGroup.yaml
+++ b/ztp/source-crs/PaoSubscriptionOperGroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: performance-addon-operator
+  namespace: openshift-performance-addon-operator
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"


### PR DESCRIPTION
The PAO subscription source-cr needs to remain available in the source-crs directory to support deployment of 4.10- clusters using the GitOps ZTP 4.11+ solution. However the subscription is removed from the reference PolicyGenTemplates so that future deployed clusters (running 4.11+) will not include PAO.