### PR TITLE
infra: Disable SRO tests on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #TODO add default features here
-export FEATURES?=sctp performance xt_u32 vrf container-mount-namespace sro metallb gatekeeper
+export FEATURES?=sctp performance xt_u32 vrf container-mount-namespace metallb gatekeeper
 export SKIP_TESTS?=
 IMAGE_BUILD_CMD ?= "docker"
 


### PR DESCRIPTION
This commit will remove the SRO from the list of features we test on the CI
This is needed because there is no update method for the driverToolkit image
inside the CI cluster.
The outcome is that everytime there is a new kernel version for RHCOS the SRO lanes
start failing

There is an open RFE to the testplatform team to implement the auto rebuild.
We will be able to reintroduce this lane after that feature is implemented

Signed-off-by: Sebastian Sch <sebassch@gmail.com>