### PR TITLE
ztp: fix broken systemd unit file path used for disk paritioning

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
@@ -201,7 +201,7 @@ data:
                               startMiB: 344844
                           wipeTable: false
                     filesystems:
-                        - device: /dev/disk/by-partlabel/var/imageregistry
+                        - device: /dev/disk/by-partlabel/var-imageregistry
                           format: xfs
                           path: /var/imageregistry
                 systemd:
@@ -211,7 +211,7 @@ data:
                             Before=local-fs.target
                             [Mount]
                             Where=/var/imageregistry
-                            What=/dev/disk/by-partlabel/var/imageregistry
+                            What=/dev/disk/by-partlabel/var-imageregistry
                             [Install]
                             WantedBy=local-fs.target
                           enabled: true

--- a/ztp/source-crs/extra-manifest/image-registry-partition-mc.yaml.tmpl
+++ b/ztp/source-crs/extra-manifest/image-registry-partition-mc.yaml.tmpl
@@ -28,7 +28,7 @@ spec:
       {{- range .DiskPartition }}
       {{- range .Partitions }}
         - path: {{ .MountPoint }}
-          device: /dev/disk/by-partlabel{{ .MountPoint }}
+          device: /dev/disk/by-partlabel/{{ .Label }}
           format: {{ .FileSystemFormat }}
       {{- end }}
       {{- end }}
@@ -43,7 +43,7 @@ spec:
             Before=local-fs.target
             [Mount]
             Where={{ .MountPoint }}
-            What=/dev/disk/by-partlabel{{ .MountPoint }}
+            What=/dev/disk/by-partlabel/{{ .Label }}
             [Install]
             WantedBy=local-fs.target
       {{- end }}


### PR DESCRIPTION
systemd unit file's path was broken, causing SNO installation failure. 

/cc @lack 