### PR TITLE
ztp: update disk partitioning docs to include use of rootDeviceHint

### DIFF
--- a/ztp/gitops-subscriptions/argocd/ImageRegistry.md
+++ b/ztp/gitops-subscriptions/argocd/ImageRegistry.md
@@ -1,24 +1,42 @@
 Installation
 -
-1. Use SiteConfig to generate MachineConfig for disk partitioning. Make sure to modify values in the mc appropriately as it is dependent on the underlying disk.
+1. Use SiteConfig to generate MachineConfig for disk partitioning. Make sure to modify values in the mc appropriately as it is dependent on the underlying disk.   
+
+   It is important use persistent naming for device, especially if you have more than one disk as names like `/dev/sda` and `/dev/sdb` may switch at every reboot. You can use `rootDeviceHints` to choose the bootable device and then use same the device for further partitioning, in this case, for Image registry. More info on persistent naming [here](https://wiki.archlinux.org/title/persistent_block_device_naming#Persistent_naming_methods).
+
+   wwn is used below. 
+
+
 ```yaml
 nodes:
-  - diskPartition:
-    - device: /dev/sda
+  - rootDeviceHints:
+      wwn: "0x62cea7f05c98c2002708a0a22ff480ea"
+    diskPartition:
+    - device: /dev/disk/by-id/wwn-0x62cea7f05c98c2002708a0a22ff480ea # depends on the hardware. can also serial num or device name. recommend using wwn. match with the rootDeviceHint above
       partitions:
        - mount_point: /var/imageregistry
-         size: 102500
-         start: 344844
+         size: 102500 # min value 100gig for image registry
+         start: 344844 # 25000 min value, otherwise root partition is too small. Recommended startMiB (Disk - sizeMiB - some buffer), if startMiB + sizeMiB  exceeds disk size, installation will fail
 ```
    
-3. Use PGT, to apply the following to create the pv and pvc and patch imageregistry config as part of normal day-2 operation
+3. Use PGT, to apply the following to create the pv and pvc and patch imageregistry config as part of normal day-2 operation. Select the appropriate PGT for each source-cr and refer to `wave` doc for more help. Below is as example if you would like to test it at the site level.
    ```yaml
    sourceFiles:
+      # storage class
+      - fileName: StorageClass.yaml
+        policyName: "sc-for-image-registry"
+        metadata:
+          name: image-registry-sc
+          annotations:
+            ran.openshift.io/ztp-deploy-wave: "100" # remove this when moved to the right PGT (site/group/common)
+     # persistent volume claim
      - fileName: StoragePVC.yaml
        policyName: "pvc-for-image-registry"
        metadata:
          name: image-registry-pvc
          namespace: openshift-image-registry
+         annotations:
+            ran.openshift.io/ztp-deploy-wave: "100"  # remove this when moved to the right PGT (site/group/common)
        spec:
          accessModes:
            - ReadWriteMany
@@ -27,10 +45,20 @@ nodes:
              storage: 100Gi
          storageClassName: image-registry-sc
          volumeMode: Filesystem
-     - fileName: ImageRegistryPV.yaml
-       policyName: "pv-for-image-registry"
+      # persistent volume
+     - fileName: ImageRegistryPV.yaml # this is assuming that mount_point is set to `/var/imageregistry` in SiteConfig
+                                      # using StorageClass `image-registry-sc` (see the first sc-file)
+       policyName: "pv-for-image-registry" 
+       metadata:
+         annotations:
+           ran.openshift.io/ztp-deploy-wave: "100"  # remove this when moved to the right PGT (site/group/common)
+      # configure registry to point to the pvc created above
      - fileName: ImageRegistryConfig.yaml
        policyName: "config-for-image-registry"
+       complianceType: musthave # do not use `mustlyonlyhave` as it will cause deployment failure of registry pod.
+       metadata:
+         annotations:
+           ran.openshift.io/ztp-deploy-wave: "100"  # remove this when moved to the right PGT (site/group/common)
        spec:
          storage:
            pvc:
@@ -41,6 +69,7 @@ Verify/Debug
 -
 - Check the CRD `Config` of group `imageregistry.operator.openshift.io`'s instance `cluster` is not reporting any error
 - Within a few minutes after the installation process is complete you should see the pvc filling up.
+- Check "registry*" pod is up correctly under `openshift-image-registry` namespace
 - From inside the node:
   - Successful login to the registry with podman:
      ```

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -107,3 +107,32 @@ spec:
               group.ice-ptp=0:f:10:*:ice-ptp.*
               [service]
               service.stalld=start,enable
+#    --- sources needed for image registry (check ImageRegistry.md for more details)----
+#    - fileName: StorageClass.yaml
+#      policyName: "config-policy"
+#      metadata:
+#        name: image-registry-sc
+#    - fileName: StoragePVC.yaml
+#      policyName: "config-policy"
+#      metadata:
+#        name: image-registry-pvc
+#        namespace: openshift-image-registry
+#      spec:
+#        accessModes:
+#          - ReadWriteMany
+#        resources:
+#          requests:
+#            storage: 100Gi
+#        storageClassName: image-registry-sc
+#        volumeMode: Filesystem
+#    - fileName: ImageRegistryPV.yaml  # this is assuming that mount_point is set to `/var/imageregistry` in SiteConfig
+                                       # using StorageClass `image-registry-sc` (see the first sc-file)
+#      policyName: "config-policy"
+#    - fileName: ImageRegistryConfig.yaml
+#      policyName: "config-policy"
+#      spec:
+#        storage:
+#          pvc:
+#            claim: "image-registry-pvc"
+#     ---- sources needed for image registry ends here ----
+

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -48,7 +48,14 @@ spec:
         # Use UEFISecureBoot to enable secure boot
         bootMode: "UEFI"
         rootDeviceHints:
-          hctl: '0:1:0'
+          wwn: "0x11111000000asd123"
+        # example of diskPartition below is used for image registry (check ImageRegistry.md for more details), but it's not limited to this use case
+#        diskPartition:
+#          - device: /dev/disk/by-id/wwn-0x11111000000asd123 # match rootDeviceHints
+#            partitions:
+#              - mount_point: /var/imageregistry
+#                size: 102500
+#                start: 344844
         cpuset: "0-1,52-53"
         nodeNetwork:
           interfaces:


### PR DESCRIPTION
update docs for disk partitioning to include use of rootDeviceHints and other warnings. also add the source crs file entries  in examples files

/cc @lack 