### PR TITLE
Add netcat to cnftests image

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -64,7 +64,7 @@ RUN yum install -y numactl-devel make gcc && \
 FROM centos:7
 
 # python3 is needed for hwlatdetect
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs linuxptp iperf3 python3
+RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs linuxptp iperf3 python3 nc
 
 RUN mkdir -p /usr/local/etc/cnf
 

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -78,7 +78,7 @@ RUN yum install -y numactl-devel make gcc && \
 FROM openshift/origin-base
 
 # python3 is needed for hwlatdetect
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3 python3
+RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3 python3 nc
 
 RUN mkdir -p /usr/local/etc/cnf
 


### PR DESCRIPTION
`nc` comes in handy when implement tests for multi-networkpolicy, in order to check if
a host/port is reachable from specific pods.

I'm filing this PR because images should be already available on quay.io prior to filing the PR that uses them.