### PR TITLE
ztp: Redo the ContainerFile for ztp-site-generator

### DIFF
--- a/ztp/gitops-subscriptions/argocd/README.md
+++ b/ztp/gitops-subscriptions/argocd/README.md
@@ -8,7 +8,7 @@ The GitOps ZTP infrastructure relies on the ztp-site-generator container to prov
 
 ## Obtaining pre-built image
 ```
-    $ podman pull quay.io/redhat_emp1/ztp-site-generator:latest
+    $ podman pull quay.io/openshift-kni/ztp-site-generator:4.10.0
 ```
 
 ### Preparation of ZTP GIT repository

--- a/ztp/gitops-subscriptions/argocd/deployment/argocd-openshift-gitops-patch.json
+++ b/ztp/gitops-subscriptions/argocd/deployment/argocd-openshift-gitops-patch.json
@@ -41,7 +41,7 @@
             }
           ],
           "terminationMessagePolicy": "File",
-          "image": "quay.io/redhat_emp1/ztp-site-generator:latest"
+          "image": "quay.io/openshift-kni/ztp-site-generator:4.10.0"
         }
       ],
       "volumeMounts": [

--- a/ztp/policygenerator-kustomize-plugin/Makefile
+++ b/ztp/policygenerator-kustomize-plugin/Makefile
@@ -17,19 +17,19 @@ build:
 	mkdir -p $(POLICYGEN_KUSTOMIZE_DIR)
 	cp -r $(SOURCE_CRS_DIR) $(POLICYGEN_KUSTOMIZE_DIR)/
 	cp $(POLICYGEN_DIR)/policygenerator $(POLICYGEN_KUSTOMIZE_DIR)/PolicyGenTemplate
+
+$(KUSTOMIZE_BIN):
 	@if [[ $(KUSTOMIZE) == $(KUSTOMIZE_BIN) ]] && [ ! -f $(KUSTOMIZE) ]; then \
 		echo "kustomize not installed getting kustomize v"$(KUSTOMIZE_VERSION) \
 		&& cd $(KUSTOMIZE_DIR) && curl -m 600 -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s $(KUSTOMIZE_VERSION); \
 	fi
 
-test: build
+test: build $(KUSTOMIZE)
 	$(KUSTOMIZE) build --enable-alpha-plugins ./
 
-gen-files: build
+gen-files: build $(KUSTOMIZE)
 	@mkdir -p out/
 	$(KUSTOMIZE) build --enable-alpha-plugins ./ -o out/
 
 clean:
-	rm $(POLICYGEN_KUSTOMIZE_DIR)/PolicyGenerator
-	rm -rf $(POLICYGEN_KUSTOMIZE_DIR)/source-crs
-	rm -rf out/
+	rm -rf kustomize out

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -3,51 +3,41 @@ FROM openshift/origin-release:golang-1.16 as builder
 USER root
 ENV PKG_ROOT=cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_ROOT
-ENV PGT_ROOT=$PKG_PATH/ztp/policygenerator
-ENV SC_ROOT=$PKG_PATH/ztp/siteconfig-generator
+ENV PGT_ROOT=$PKG_PATH/ztp/policygenerator-kustomize-plugin
+ENV SC_ROOT=$PKG_PATH/ztp/siteconfig-generator-kustomize-plugin
 RUN mkdir -p $PKG_PATH
 WORKDIR $PKG_PATH/
-ARG TAR_NAME
-COPY --chown=1001 $TAR_NAME  $PKG_PATH/
-RUN (tar -xf $TAR_NAME) && rm $TAR_NAME
-WORKDIR $PKG_PATH/$PKG_ROOT
-RUN go mod tidy && go mod vendor
+COPY . .
 WORKDIR $PGT_ROOT
-RUN go build -mod=vendor -o /PolicyGenTemplate
+RUN make build
 WORKDIR $SC_ROOT
-RUN go build -mod=vendor -o /SiteConfig
+RUN make build
 
 # Container image
 FROM ubi8-minimal
 ARG IMAGE_REF
 USER root
-ENV WD=/home/ztp
-ENV TEMP=/tmp/ztp-temp
-ENV PGT_WD=/kustomize/plugin/ran.openshift.io/v1/policygentemplate
-ENV SITECONFIG_WD=/kustomize/plugin/ran.openshift.io/v1/siteconfig
+ENV BUILDER_ZTP=/go/src/cnf-features-deploy/ztp
+ENV ZTP_HOME=/home/ztp
+# Install utilities needed by the entrypoint scripts
 RUN microdnf install tar
-RUN mkdir -p $WD
-RUN mkdir -p $TEMP
-RUN mkdir -p $PGT_WD
-RUN mkdir -p $SITECONFIG_WD
-RUN mkdir -p $PGT_WD/source-crs
-WORKDIR $WD
-
-ARG TAR_NAME
-ADD --chown=1001 $TAR_NAME $TEMP
-WORKDIR $TEMP/ztp/resource-generator
-RUN ./tools/patchImageReference.sh ../gitops-subscriptions $IMAGE_REF
-RUN chown -R 1001:1001 $WD && \
-    cp -R -L $TEMP/ztp/source-crs/extra-manifest $SITECONFIG_WD && \
-    cp -R -L $TEMP/ztp/source-crs/*.yaml $PGT_WD/source-crs && \
-    cp -r $TEMP/ztp/source-crs/validatorCRs $PGT_WD/source-crs && \
-    cp -r $TEMP/ztp/gitops-subscriptions/argocd $WD && \
-    cp -r $SITECONFIG_WD/extra-manifest $WD  && \
-    cp -r $PGT_WD/source-crs $WD
-
-COPY --from=builder  /PolicyGenTemplate $PGT_WD
-COPY --from=builder  /SiteConfig $SITECONFIG_WD
-COPY --chown=1001 exportkustomize.sh /
-COPY entrypoints/* /usr/bin
+# Copy in the kustomize plugin directory structure
+COPY --from=builder $BUILDER_ZTP/policygenerator-kustomize-plugin/kustomize /kustomize
+COPY --from=builder $BUILDER_ZTP/siteconfig-generator-kustomize-plugin/kustomize /kustomize
+# Copy in the examples and source-cr files
+RUN mkdir -p $ZTP_HOME
+WORKDIR $ZTP_HOME
+COPY --from=builder $BUILDER_ZTP/source-crs source-crs
+COPY --from=builder $BUILDER_ZTP/source-crs/extra-manifest extra-manifest
+COPY --from=builder $BUILDER_ZTP/gitops-subscriptions/argocd argocd
+RUN chown -R 1001:1001 $ZTP_HOME
+# Copy in the entrypoint scripts
+COPY --from=builder $BUILDER_ZTP/resource-generator/entrypoints/* /usr/bin
+COPY --chown=1001 --from=builder $BUILDER_ZTP/resource-generator/exportkustomize.sh /
 USER 1001
 CMD entrypoints
+
+# Note: any edits made to this file need to be manually synchronized with the midstream build configuration:
+# - Clone with instructions from https://code.engineering.redhat.com/gerrit/admin/repos/ztp-site-generate
+# - Check out the appropriate branch, and edit distgit/containers/ztp-site-generate/Dockerfile.in
+# - Use gerrit to merge the change to midstream

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -1,5 +1,6 @@
 # Builder
-FROM openshift/origin-release:golang-1.16 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+ARG IMAGE_REF
 USER root
 ENV PKG_ROOT=cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_ROOT
@@ -8,6 +9,8 @@ ENV SC_ROOT=$PKG_PATH/ztp/siteconfig-generator-kustomize-plugin
 RUN mkdir -p $PKG_PATH
 WORKDIR $PKG_PATH/
 COPY . .
+WORKDIR $PKG_PATH/ztp/resource-generator
+RUN ./tools/patchImageReference.sh ../gitops-subscriptions $IMAGE_REF
 WORKDIR $PGT_ROOT
 RUN make build
 WORKDIR $SC_ROOT

--- a/ztp/resource-generator/Makefile
+++ b/ztp/resource-generator/Makefile
@@ -21,7 +21,7 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 build: ## Build the ZTP image
-	podman build -t ${IMAGE_NAME}:${VERSION} -f ztp/resource-generator/Containerfile ../..
+	podman build -t ${IMAGE_NAME}:${VERSION} --build-arg=IMAGE_REF='$(IMAGE_REF)' -f ztp/resource-generator/Containerfile ../..
 
 push: ## Push to registry ${REG_URL}
 	podman push ${IMAGE_NAME}:${VERSION} ${IMAGE_URL}:${VERSION}

--- a/ztp/resource-generator/Makefile
+++ b/ztp/resource-generator/Makefile
@@ -28,8 +28,8 @@ push: ## Push to registry ${REG_URL}
 
 export: ## Copy resources from container image to out/ directory
 	mkdir -p out
-	podman run --rm ${IMAGE_NAME}:${VERSION} extract /home/ztp --tar | tar x -C out
+	podman run --rm --log-driver=none ${IMAGE_NAME}:${VERSION} extract /home/ztp --tar | tar x -C out
 	mkdir -p out/kustomize
-	podman run --rm ${IMAGE_NAME}:${VERSION} extract /kustomize --tar | tar x -C out/kustomize
+	podman run --rm --log-driver=none ${IMAGE_NAME}:${VERSION} extract /kustomize --tar | tar x -C out/kustomize
 
 all: build export push

--- a/ztp/resource-generator/Makefile
+++ b/ztp/resource-generator/Makefile
@@ -3,7 +3,6 @@ IMAGE_NAME ?= ztp-site-generator
 IMAGE_URL ?= $(REG_URL)/$(IMAGE_NAME)
 IMAGE_REF ?=
 VERSION ?= latest
-TAR_NAME ?= temp.tar.gz
 
 .PHONY: help build push export all
 
@@ -21,21 +20,16 @@ TAR_NAME ?= temp.tar.gz
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
- ## Build the ztp image
-build:
-	tar cvzf ${TAR_NAME} --exclude *.gz ../../* && \
-	podman build --build-arg TAR_NAME=${TAR_NAME} --build-arg=IMAGE_REF='$(IMAGE_REF)' -t ${IMAGE_NAME}:${VERSION} -f Containerfile; \
-	rm ${TAR_NAME}
+build: ## Build the ZTP image
+	podman build -t ${IMAGE_NAME}:${VERSION} -f ztp/resource-generator/Containerfile ../..
 
- ## Push to registry $(REG_URL)
-push:
+push: ## Push to registry ${REG_URL}
 	podman push ${IMAGE_NAME}:${VERSION} ${IMAGE_URL}:${VERSION}
 
-## Copy resources from container image to out/ directory
-export:
+export: ## Copy resources from container image to out/ directory
 	mkdir -p out
-	podman run --rm --log-driver=none ${IMAGE_NAME}:${VERSION} extract /home/ztp --tar | tar x -C out
+	podman run --rm ${IMAGE_NAME}:${VERSION} extract /home/ztp --tar | tar x -C out
 	mkdir -p out/kustomize
-	podman run --rm --log-driver=none ${IMAGE_NAME}:${VERSION} extract /kustomize --tar | tar x -C out/kustomize
+	podman run --rm ${IMAGE_NAME}:${VERSION} extract /kustomize --tar | tar x -C out/kustomize
 
 all: build export push

--- a/ztp/resource-generator/README.md
+++ b/ztp/resource-generator/README.md
@@ -23,6 +23,10 @@ out/
 ## Push the container image to registry
 Run ``` $make push ``` in order to publish the image to the registry.
 
+## Automatic upstream container builds
+The Red Hat Prow infractructure automatically pushes the head of this
+master branch to quay.io/openshift-kni/ztp-site-generator:4.10.0
+
 ## Custom builds
 The argocd deployment files refer to the upstream container images by
 default. But downstream builds (or other special-purpose builds) need

--- a/ztp/resource-generator/entrypoints/extract
+++ b/ztp/resource-generator/entrypoints/extract
@@ -13,11 +13,12 @@ if [[ $1 == "-h" || $1 == "--help" || $1 == "help" ]]; then
     echo
     echo "    Important: With podman, add '--log-driver=none' to prevent podman from hanging with large data sent to stdout,"
     echo "               and '--rm' to avoid creating unneeded persistent container image"
+    echo "      podman run \$THIS_CONTAINER $(basename $0) /home/ztp --tar | tar -C ./out"
     echo
     echo "  $(basename $0) srcPath dstPath"
     echo "    Export the given directory structure to the destination path (should be mounted as a container volume)"
     echo "    Example:"
-    echo "      podman run --rm \$THIS_CONTAINER -v ./out:/out:Z $(basename $0) /home/ztp /out"
+    echo "      podman run \$THIS_CONTAINER -v ./out:/out:Z $(basename $0) /home/ztp /out"
     exit 1
 fi
 

--- a/ztp/resource-generator/entrypoints/extract
+++ b/ztp/resource-generator/entrypoints/extract
@@ -13,12 +13,11 @@ if [[ $1 == "-h" || $1 == "--help" || $1 == "help" ]]; then
     echo
     echo "    Important: With podman, add '--log-driver=none' to prevent podman from hanging with large data sent to stdout,"
     echo "               and '--rm' to avoid creating unneeded persistent container image"
-    echo "      podman run \$THIS_CONTAINER $(basename $0) /home/ztp --tar | tar -C ./out"
     echo
     echo "  $(basename $0) srcPath dstPath"
     echo "    Export the given directory structure to the destination path (should be mounted as a container volume)"
     echo "    Example:"
-    echo "      podman run \$THIS_CONTAINER -v ./out:/out:Z $(basename $0) /home/ztp /out"
+    echo "      podman run --rm \$THIS_CONTAINER -v ./out:/out:Z $(basename $0) /home/ztp /out"
     exit 1
 fi
 

--- a/ztp/resource-generator/tools/patchImageReference.sh
+++ b/ztp/resource-generator/tools/patchImageReference.sh
@@ -7,7 +7,7 @@ set -e
 
 BASEDIR=$1
 REPLACEMENT_IMAGE=$2
-UPSTREAM_IMAGE="quay.io/redhat_emp1/ztp-site-generator:latest"
+UPSTREAM_IMAGE="quay.io/openshift-kni/ztp-site-generator:4.10.0"
 
 if [[ $1 == "-h" || $1 == "--help" ]]; then
     echo "Usage:"

--- a/ztp/siteconfig-generator-kustomize-plugin/Makefile
+++ b/ztp/siteconfig-generator-kustomize-plugin/Makefile
@@ -17,20 +17,20 @@ build:
 	mkdir -p $(SITECONFIG_KUSTOMIZE_DIR)
 	cp -R -L $(EXTRAMANIFEST_DIR) $(SITECONFIG_KUSTOMIZE_DIR)/
 	cp $(SITECONFIG_DIR)/siteconfig-generator $(SITECONFIG_KUSTOMIZE_DIR)/SiteConfig
+
+$(KUSTOMIZE_BIN):
 	@if [[ $(KUSTOMIZE) == $(KUSTOMIZE_BIN) ]] && [ ! -f $(KUSTOMIZE) ]; then \
 		echo "kustomize not installed getting kustomize v"$(KUSTOMIZE_VERSION) \
 		&& cd $(KUSTOMIZE_DIR) && curl -m 600 -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s $(KUSTOMIZE_VERSION); \
 	fi
 
-test: build
+test: build $(KUSTOMIZE)
 	$(KUSTOMIZE) build --enable-alpha-plugins ./
 
-gen-files: build
+gen-files: build $(KUSTOMIZE)
 	@mkdir -p out/
 	$(KUSTOMIZE) build --enable-alpha-plugins ./ -o out/
 
 clean:
-	rm $(SITECONFIG_KUSTOMIZE_DIR)/SiteConfig
-	rm -rf $(SITECONFIG_KUSTOMIZE_DIR)/extra-manifest
-	rm -rf out/
+	rm -rf kustomize out
 


### PR DESCRIPTION
This removes the reliance on an external tarball so the Prow CI image
builder can build this for us.

It also simplifies the build process a lot, relying on the existing
makefiles in our source control to set up the kustomize plugin directory
structure rather than duplicating it, and removing a lot of extra
copying.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

ztp: fixed merge conflicts from cherry-pick

Signed-off-by: Nishant Parekh <nparekh@redhat.com>