### PR TITLE
cnf-tests: update the documentation about image pull

### DIFF
--- a/cnf-tests/README.md
+++ b/cnf-tests/README.md
@@ -269,6 +269,7 @@ oc policy add-role-to-user system:image-puller system:serviceaccount:cnf-feature
 oc policy add-role-to-user system:image-puller system:serviceaccount:performance-addon-operators-testing:default --namespace=cnftests
 oc policy add-role-to-user system:image-puller system:serviceaccount:dpdk-testing:default --namespace=cnftests
 oc policy add-role-to-user system:image-puller system:serviceaccount:sriov-conformance-testing:default --namespace=cnftests
+oc policy add-role-to-user system:image-puller system:serviceaccount:openshift-sriov-network-operator:default --namespace=cnftests
 ```
 
 Retrieve the docker secret name and auth token:


### PR DESCRIPTION
We introduce a new container to validate the secure boot status on the nodes.

That pod runs in the openshift-sriov-network operator namespace so there is a need to allow pulling disconnected images from the cnftest namespace to the sriov one.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>