### PR TITLE
[release-4.10] Bug 2064585: cnf-tests: remove mainaffinity option

### DIFF
--- a/cnf-tests/pod-utils/cyclictest-runner/main.go
+++ b/cnf-tests/pod-utils/cyclictest-runner/main.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/pod-utils/pkg/node"
 )
@@ -30,15 +29,6 @@ func main() {
 		klog.Fatalf("failed to get self allowed CPUs: %v", err)
 	}
 
-	mainThreadCPUs := selfCPUs.ToSlice()[0]
-	siblings, err := node.GetCPUSiblings(mainThreadCPUs)
-	if err != nil {
-		klog.Fatalf("failed to get main thread CPU siblings: %v", err)
-	}
-
-	cpusForLatencyTest := selfCPUs.Difference(cpuset.NewCPUSet(siblings...))
-	mainThreadCPUSet := cpuset.NewCPUSet(mainThreadCPUs)
-
 	err = node.PrintInformation()
 	if err != nil {
 		klog.Fatalf("failed to print node information: %v", err)
@@ -51,12 +41,11 @@ func main() {
 	cyclictestArgs := []string{
 		"--duration", *duration,
 		"--priority", *rtPriority,
-		"--threads", strconv.Itoa(cpusForLatencyTest.Size()),
-		"--affinity", cpusForLatencyTest.String(),
+		"--threads", strconv.Itoa(selfCPUs.Size()),
+		"--affinity", selfCPUs.String(),
 		"--histogram", *histogram,
 		"--interval", strconv.Itoa(*interval),
 		"--mlockall",
-		"--mainaffinity", mainThreadCPUSet.String(),
 		"--quiet",
 	}
 


### PR DESCRIPTION
The cyclictest binary which is called by the runner doesn't have the support for the mainaffinity flag in its current release.

Hence, we should remove the arg entirely

Signed-off-by: Talor Itzhak <titzhak@redhat.com>