### PR TITLE
cnf-tests: tuning over bond test

### DIFF
--- a/cnf-tests/TESTLIST.md
+++ b/cnf-tests/TESTLIST.md
@@ -273,6 +273,7 @@ The cnf tests instrument each different feature required by CNF. Following, a de
 | sro Apply the special resource CR to build the OOT driver should have a oot driver imagestream built | Test the out of tree driver build by SRO | 
 | sro Apply the special resource CR to build the OOT driver should have the driver built inside the container | Test the drivers exist in the created driver container by SRO | 
 | sro Build source out of tree driver for SRO using Should have the source driver image as imageStream | Test a Source Container build as input for the SRO build recipe | 
+| tuningcni tuningcni over bond should be able to create pod with sysctls over bond | Verify a sysctl can be created over a bond interface | 
 | tuningcni tuningcni over macvlan pods with sysctl's over macvlan should be able to ping each other | Tuned macvlan pods should be able to ping | 
 | tuningcni tuningcni over macvlan should be able to create pod with sysctls over macvlan | Should be able to create pod with tuned macvlan interface | 
 | xt_u32 Negative - xt_u32 disabled Should NOT create an iptable rule | Negative test: when the xt_u32 module is not enabled, appling an iptables rule that utilize the module should fail. | 

--- a/cnf-tests/docgen/e2e.json
+++ b/cnf-tests/docgen/e2e.json
@@ -184,6 +184,7 @@
     "sro Apply the special resource CR to build the OOT driver should have a oot driver imagestream built": "Test the out of tree driver build by SRO",
     "sro Apply the special resource CR to build the OOT driver should have the driver built inside the container": "Test the drivers exist in the created driver container by SRO",
     "sro Build source out of tree driver for SRO using Should have the source driver image as imageStream": "Test a Source Container build as input for the SRO build recipe",
+    "tuningcni tuningcni over bond should be able to create pod with sysctls over bond": "Verify a sysctl can be created over a bond interface",
     "tuningcni tuningcni over macvlan pods with sysctl's over macvlan should be able to ping each other": "Tuned macvlan pods should be able to ping",
     "tuningcni tuningcni over macvlan should be able to create pod with sysctls over macvlan": "Should be able to create pod with tuned macvlan interface",
     "xt_u32 Negative - xt_u32 disabled Should NOT create an iptable rule": "Negative test: when the xt_u32 module is not enabled, appling an iptables rule that utilize the module should fail.",


### PR DESCRIPTION
Adding test veryfying that a bond interface can be applied, with a tuning-cni plugin updateing a sysctl of the bond interface
