### PR TITLE
Bug 2052124: add updateStrategy to DefaultCatsrc.yaml

### DIFF
--- a/ztp/source-crs/DefaultCatsrc.yaml
+++ b/ztp/source-crs/DefaultCatsrc.yaml
@@ -11,3 +11,6 @@ spec:
     image: $imageUrl
     publisher: Red Hat
     sourceType: grpc
+    updateStrategy:
+        registryPoll:
+            interval: 1h


### PR DESCRIPTION
DefaultCatsrc.yaml in ztp source-crs has registry poll disabled, therefore an updated operator index image will not be picked up automatically, thus operator upgrade will not take place.

This commit adds an updateStrategy specification to the DefaultCatsrc.yaml with a registry polling interval of 1h.

The polling interval was determined through an extensive empirical investigation. The report is attached to the PR: [polling interval characterization.pdf](https://github.com/openshift-kni/cnf-features-deploy/files/8812345/polling.interval.characterization.pdf)

Signed-off-by: Sharat Akhoury <sakhoury@redhat.com>

/cc @lack @imiller0 @tliu2021 @Missxiaoguo @browsell 