### PR TITLE
Bug 2087208 - informDuValidator (multi-yaml) policy fails when overlay status in multi yaml file

### DIFF
--- a/ztp/policygenerator/policyGen/policyBuilder.go
+++ b/ztp/policygenerator/policyGen/policyBuilder.go
@@ -188,8 +188,8 @@ func (pbuilder *PolicyBuilder) getCustomResources(sFile utils.SourceFile, source
 		return resources, err
 	}
 	// Update multiple yamls structure in same file not allowed.
-	if len(yamls) > 1 && (len(sFile.Data) > 0 || len(sFile.Spec) > 0) {
-		return resources, errors.New("Update spec/data of multiple yamls structure in same file " + sFile.FileName +
+	if len(yamls) > 1 && (len(sFile.Data) > 0 || len(sFile.Spec) > 0 || len(sFile.Status) > 0) {
+		return resources, errors.New("Update spec/data/status of multiple yamls structure in same file " + sFile.FileName +
 			" not allowed. Instead separate them in multiple files")
 	} else if len(yamls) > 1 && len(sFile.Data) == 0 && len(sFile.Spec) == 0 {
 		// Append yaml structures without modify spec or data fields

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericMultiYaml.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericMultiYaml.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: JustForTest
+metadata:
+  name: test123
+  namespace: generic-ns
+status:
+  key1: value1
+  statusList:
+    - a
+    - b
+    - c
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: JustForTest
+metadata:
+  name: test123
+  namespace: generic-ns
+data:
+  justData: true
+


### PR DESCRIPTION


Signed-off-by: melserngawy <melserng@redhat.com>