### PR TITLE
Bug 2098156: ptp offset metrics for master count should be one

### DIFF
--- a/cnf-tests/testsuites/e2esuite/ptp/ptp.go
+++ b/cnf-tests/testsuites/e2esuite/ptp/ptp.go
@@ -405,7 +405,7 @@ func compareOffsetTime(timeDiff string) bool {
 			timeStampList = append(timeStampList, offsetFromMaster)
 		}
 	}
-	Expect(len(timeStampList)).To(BeNumerically("==", 2))
+	Expect(len(timeStampList)).To(BeNumerically("==", 1))
 	return true
 }
 


### PR DESCRIPTION
Recent change to check for master offset narrows down to find only one metrics for master offset.
The fix will check count of master offset to one
signed-off-by: Aneesh Puttur <aneeshputtur@gmail.com>