### PR TITLE
features: MetalLB: remove targetNamespaces

### DIFF
--- a/feature-configs/deploy/metallb/operator_operatorgroup.yaml
+++ b/feature-configs/deploy/metallb/operator_operatorgroup.yaml
@@ -3,6 +3,3 @@ kind: OperatorGroup
 metadata:
   name: metallb-operator
   namespace: metallb-system
-spec:
-  targetNamespaces:
-  - metallb-system


### PR DESCRIPTION
metallb-operator is now deployed in all Namespaces to support its conversion webhooks.