### PR TITLE
features: dpdk build: Check for more states in post deploy script

### DIFF
--- a/feature-configs/deploy/s2i/post_deploy.sh
+++ b/feature-configs/deploy/s2i/post_deploy.sh
@@ -1,23 +1,14 @@
 #!/bin/sh
 
-start_build=false
 last_build=$(oc get build -n dpdk -o json | jq '.items[-1].metadata.name' | tr -d '"')
-if [ $last_build == "null" ]; then
-    exit 1
-else
+if [ $last_build != "null" ]; then
     build_status=$(oc get build -n dpdk $last_build -o json | jq '.status.phase' | tr -d '"')
     if [ $build_status == "Complete" ]; then
         exit 0
-    elif [ $build_status == "Running" ]; then
-        exit 1
-    elif [ $build_status == "Failed" ] || [ $build_status == "Error" ]; then
+    elif [ $build_status == "Failed" ] || [ $build_status == "Error" ] || [ $build_status == "Cancelled" ]; then
         oc delete build -n dpdk $last_build
-        start_build=true
+        oc start-build -n dpdk s2i-dpdk
     fi
 fi
 
-if $start_build; then
-    oc start-build -n dpdk s2i-dpdk
-    exit 1
-fi
-
+exit 1


### PR DESCRIPTION
We were missing few states. Exit with error if didn't match to Complete state.
