### PR TITLE
Allow running cnf-tests in parallel 

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -22,6 +22,7 @@ export LATENCY_TEST_RUN=${LATENCY_TEST_RUN:-false}
 
 export IS_OPENSHIFT="${IS_OPENSHIFT:-true}"
 
+export SKIP_TEST_NAMESPACES_CREATION="${SKIP_TEST_NAMESPACES_CREATION:-false}"
 
 echo "Running local tests"
 
@@ -58,7 +59,8 @@ if [ "$TESTS_IN_CONTAINER" == "true" ]; then
   -e KUBECONFIG=/kubeconfig/kubeconfig \
   -e SCTPTEST_HAS_NON_CNF_WORKERS=$SCTPTEST_HAS_NON_CNF_WORKERS \
   -e TEST_SUITES=$TEST_SUITES \
-  -e IS_OPENSHIFT=$IS_OPENSHIFT"
+  -e IS_OPENSHIFT=$IS_OPENSHIFT \
+  -e SKIP_TEST_NAMESPACES_CREATION=$SKIP_TEST_NAMESPACES_CREATION"
 
   # add latency tests env variable to the cnf-tests container
   if [ "$LATENCY_TEST_RUN" == "true" ];then


### PR DESCRIPTION
Doing this to allow running more than one instance of the tests in parallel on the same cluster, per feature, under different namespaces.