### PR TITLE
rename Bare Metal Event Relay feature

### DIFF
--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/common-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/common-ranGen.yaml
@@ -34,11 +34,15 @@ spec:
       policyName: "storage-sub-policy"
     - fileName: ReduceMonitoringFootprint.yaml
       policyName: "mon-offload-policy"
-    - fileName: HardwareEventSubscription.yaml
-      policyName: "hw-events-sub-policy"
-    - fileName: HardwareEventSubscriptionNS.yaml
-      policyName: "hw-events-sub-policy"
-    - fileName: HardwareEventSubscriptionOperGroup.yaml
-      policyName: "hw-events-sub-policy"
-    - fileName: HardwareEvent.yaml
-      policyName: "hw-events-policy"
+    - fileName: AmqSubscriptionNS.yaml
+      policyName: "amq-sub-policy"
+    - fileName: AmqSubscriptionOperGroup.yaml
+      policyName: "amq-sub-policy"
+    - fileName: AmqSubscription.yaml
+      policyName: "amq-sub-policy"
+    - fileName: BareMetalEventRelaySubscriptionNS.yaml
+      policyName: "bare-metal-events-sub-policy"
+    - fileName: BareMetalEventRelaySubscriptionOperGroup.yaml
+      policyName: "bare-metal-events-sub-policy"
+    - fileName: BareMetalEventRelaySubscription.yaml
+      policyName: "bare-metal-events-sub-policy"

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/site-du-sno-1-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/site-du-sno-1-ranGen.yaml
@@ -97,3 +97,11 @@ spec:
         storage:
           pvc:
             claim: "image-registry-pvc"
+    - fileName: AmqInstance.yaml
+      policyName: "config-amq-policy"
+    - fileName: HardwareEvent.yaml
+      policyName: "config-bare-metal-events-policy"
+      spec:
+        nodeSelector: {}
+        transportHost: "amqp://amq-router.amq-router.svc.cluster.local" 
+        logLevel: "debug"

--- a/ztp/source-crs/BareMetalEventRelaySubscription.yaml
+++ b/ztp/source-crs/BareMetalEventRelaySubscription.yaml
@@ -1,13 +1,13 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: baremetal-hardware-event-proxy-operator-subscription
-  namespace: openshift-hw-events
+  name: bare-metal-event-relay-subscription
+  namespace: openshift-bare-metal-events
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   channel: "stable"
-  name: baremetal-hardware-event-proxy-operator
+  name: bare-metal-event-relay
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual

--- a/ztp/source-crs/BareMetalEventRelaySubscriptionNS.yaml
+++ b/ztp/source-crs/BareMetalEventRelaySubscriptionNS.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-hw-events
+  name: openshift-bare-metal-events
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
   labels:

--- a/ztp/source-crs/BareMetalEventRelaySubscriptionOperGroup.yaml
+++ b/ztp/source-crs/BareMetalEventRelaySubscriptionOperGroup.yaml
@@ -1,10 +1,10 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: baremetal-hardware-event-proxy-operator-group
-  namespace: openshift-hw-events
+  name: bare-metal-event-relay-group
+  namespace: openshift-bare-metal-events
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
   targetNamespaces:
-  - openshift-hw-events
+  - openshift-bare-metal-events

--- a/ztp/source-crs/HardwareEvent.yaml
+++ b/ztp/source-crs/HardwareEvent.yaml
@@ -1,8 +1,8 @@
 apiVersion: event.redhat-cne.org/v1alpha1
 kind: HardwareEvent
 metadata:
-  name: openshift-hw-events
-  namespace: openshift-hw-events
+  name: openshift-bare-metal-events
+  namespace: openshift-bare-metal-events
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:


### PR DESCRIPTION
The baremetal-hardware-event-proxy-operator is renamed to bare-metal-event-relay. This PR implements this change in ztp.
Amq Interconnect is required for Bare Metal Event Relay to work, therefore add amq deployment in the examples.


Signed-off-by: Jack Ding <jacding@redhat.com>