### PR TITLE
cnf-tests: bond cni on macvlan test

### DIFF
--- a/cnf-tests/TESTLIST.md
+++ b/cnf-tests/TESTLIST.md
@@ -214,6 +214,7 @@ The cnf tests instrument each different feature required by CNF. Following, a de
 | Test Name | Description |
 | -- | ----------- |
 | [vrf]  Integration: NAD, IPAM: static, Interfaces: 1, Scheme: 2 Pods 2 VRFs OCP Primary network overlap {"IPStack":"ipv4"} | Verifies that it's possible to configure within the same node 1 VRF that overlaps pod's network + 2 non overlapping VRF on top of mac-vlan cni which is based on top of default route node's interface. Connectivity ICMP test. | 
+| bondcni bond over macvlan should be able to create pod with bond interface over macvlan interfaces | Verifies bond interface on top of macvlan interfaces is created correctly | 
 | fec Expose resource on the node should show resources under the node | Verifies that the sriov-fec operator is able to create and expose virtual functions from the acc100 accelerator card | 
 | gatekeeper constraints should apply constraints | Verifies that creating a gatekeeper constraint template and constraint will cause a pod to be rejected. | 
 | gatekeeper mutation should apply mutations by order | Verifies that gatekeeper mutations are applied by order | 

--- a/cnf-tests/docgen/e2e.json
+++ b/cnf-tests/docgen/e2e.json
@@ -92,6 +92,7 @@
     "[sriov] operator Generic SriovNetworkNodePolicy Virtual Functions should release the VFs once the pod deleted and same VFs can be used by the new created pods": "Verifies that an allocated VF is released when the pod that was using it is deleted.",
     "[sriov] operator No SriovNetworkNodePolicy SR-IOV network config daemon can be set by nodeselector Should schedule the config daemon on selected nodes": "Verifies that it's possible to configure",
     "[vrf]  Integration: NAD, IPAM: static, Interfaces: 1, Scheme: 2 Pods 2 VRFs OCP Primary network overlap {\"IPStack\":\"ipv4\"}": "Verifies that it's possible to configure within the same node 1 VRF that overlaps pod's network + 2 non overlapping VRF on top of mac-vlan cni which is based on top of default route node's interface. Connectivity ICMP test.",
+    "bondcni bond over macvlan should be able to create pod with bond interface over macvlan interfaces": "Verifies bond interface on top of macvlan interfaces is created correctly",
     "dpdk Downward API Volume is readable in container": "Verifies that the container downward API volumes are readable and match the Pod inforamtion details",
     "dpdk VFS allocated for dpdk Validate HugePages SeLinux access should allow to remove the hugepage file inside the pod": "Verifies that we are able to remove the hugepages files after the DPDK running",
     "dpdk VFS allocated for dpdk Validate HugePages should allocate the amount of hugepages requested": "Verifies that the number of hugepages requested by the pod are allocated.",

--- a/cnf-tests/testsuites/e2esuite/bond/bond.go
+++ b/cnf-tests/testsuites/e2esuite/bond/bond.go
@@ -1,0 +1,87 @@
+package bond
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	nadtypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	client "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/client"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/execute"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/namespaces"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/networks"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/pods"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	TestNamespace = "bond-testing"
+)
+
+var _ = Describe("bondcni", func() {
+	apiclient := client.New("")
+
+	execute.BeforeAll(func() {
+		err := namespaces.Create(TestNamespace, apiclient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := namespaces.CleanPods(TestNamespace, apiclient)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("bond over macvlan", func() {
+		It("should be able to create pod with bond interface over macvlan interfaces",
+			func() {
+				macvlanNadName := "macvlan-nad"
+				bondNadName := "bond-nad"
+				bondIfcName := "bondifc"
+				bondIP := "1.1.1.17"
+
+				macVlanNad, err := networks.NewNetworkAttachmentDefinitionBuilder(TestNamespace, macvlanNadName).WithMacVlan().Build()
+				Expect(err).ToNot(HaveOccurred())
+				err = client.Client.Create(context.Background(), macVlanNad)
+				Expect(err).ToNot(HaveOccurred())
+
+				bondNad, err := networks.NewNetworkAttachmentDefinitionBuilder(TestNamespace, bondNadName).WithBond(bondIfcName, "net2", "net1").WithStaticIpam(bondIP).Build()
+				Expect(err).ToNot(HaveOccurred())
+				err = client.Client.Create(context.Background(), bondNad)
+				Expect(err).ToNot(HaveOccurred())
+
+				podDefinition := pods.DefineWithNetworks(TestNamespace, []string{fmt.Sprintf("%s/%s, %s/%s, %s/%s@%s", TestNamespace, macvlanNadName, TestNamespace, macvlanNadName, TestNamespace, bondNadName, bondIfcName)})
+				pod, err := client.Client.Pods(TestNamespace).Create(context.Background(), podDefinition, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				err = pods.WaitForPhase(client.Client, pod, corev1.PodRunning, 1*time.Minute)
+				Expect(err).ToNot(HaveOccurred())
+
+				pod, err = client.Client.Pods(TestNamespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				networkStatusString, ok := pod.Annotations["k8s.v1.cni.cncf.io/network-status"]
+				Expect(ok).To(BeTrue())
+				Expect(networkStatusString).ToNot(BeNil())
+
+				networkStatuses := []nadtypes.NetworkStatus{}
+				err = json.Unmarshal([]byte(networkStatusString), &networkStatuses)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(networkStatuses)).To(Equal(4))
+				Expect(networkStatuses[3].Interface).To(Equal(bondIfcName))
+				Expect(networkStatuses[3].Name).To(Equal(fmt.Sprintf("%s/%s", TestNamespace, bondNadName)))
+
+				// TODO: This will not work due to BZ 2082360. Uncomment once fixed and changes are propagated.
+				// Expect(len(networkStatuses[3].Ips)).To(Equal(1))
+				// Expect(len(networkStatuses[3].Ips[0])).To(Equal(bondIP))
+
+				stdout, err := pods.ExecCommand(client.Client, *pod, []string{"ip", "addr", "show", bondIfcName})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(strings.Index(stdout.String(), "inet "+bondIP))
+			})
+	})
+})

--- a/cnf-tests/testsuites/e2esuite/test_suite_test.go
+++ b/cnf-tests/testsuites/e2esuite/test_suite_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
+	_ "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/bond"       // this is needed otherwise the bond test won't be executed
 	_ "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/dpdk"       // this is needed otherwise the dpdk test won't be executed
 	_ "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/fec"        // this is needed otherwise the fec test won't be executed
 	_ "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/gatekeeper" // this is needed otherwise the gatekeeper test won't be executed'
@@ -35,6 +36,7 @@ import (
 	perfUtils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 
 	sriovClean "github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/clean"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/bond"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/clean"
 	testclient "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/client"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/discovery"
@@ -151,6 +153,7 @@ var _ = AfterSuite(func() {
 		testutils.GatekeeperTestingNamespace,
 		namespaces.OVSQOSTest,
 		namespaces.SroTestNamespace,
+		bond.TestNamespace,
 	}
 
 	for _, n := range nn {


### PR DESCRIPTION
Adding test verifying that a pod with a bond interface
over two macvlan interfaces is created correctly

depends on: #1175 