### PR TITLE
Bug 2097488 cnf-tests: bump `sriov-network-operator` commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ replace (
 
 // Test deps
 replace (
-	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20220519143048-dc0a8bda79f1 // release-4.11
+	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20220706125402-e281e75bc6fb // release-4.12
 	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c //release-4.11
 	github.com/openshift-kni/numaresources-operator => github.com/openshift-kni/numaresources-operator v0.4.10-3.2022042201
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10

--- a/go.sum
+++ b/go.sum
@@ -1208,8 +1208,8 @@ github.com/openshift/ptp-operator v0.0.0-20211201021143-27df2443c98f/go.mod h1:Z
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912/go.mod h1:0OXNy7VoqFexkxKqyQbHJLPwn1MFp1/CxRJAgKHM+/o=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b h1:NlOsWwZI4tYu6XbqG1/9jtg2I20+zs+8vy7d4X7ieZs=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b/go.mod h1:ESuS9sfrzo0EpEHaHNEvjo1oThseBnGU5s+RT1psTRA=
-github.com/openshift/sriov-network-operator v0.0.0-20220519143048-dc0a8bda79f1 h1:J17M+nXtdIs+mXhWl8f8lmG17qYE8n5LydIJSKme/zA=
-github.com/openshift/sriov-network-operator v0.0.0-20220519143048-dc0a8bda79f1/go.mod h1:r9dFsWYJynBEVPP20CcPbLpCqK+RZlQdmtW9SxKCzkY=
+github.com/openshift/sriov-network-operator v0.0.0-20220706125402-e281e75bc6fb h1:r4iMAdYPg4GgX1BB1cVbhr5zJU6wv6JHz/ME0FrTvf8=
+github.com/openshift/sriov-network-operator v0.0.0-20220706125402-e281e75bc6fb/go.mod h1:r9dFsWYJynBEVPP20CcPbLpCqK+RZlQdmtW9SxKCzkY=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go
@@ -815,7 +815,7 @@ var _ = Describe("[sriov] operator", func() {
 			It("Should be able to configure a metaplugin", func() {
 				ipam := `{"type": "host-local","ranges": [[{"subnet": "1.1.1.0/24"}]],"dataDir": "/run/my-orchestrator/container-ipam-state"}`
 				config := func(network *sriovv1.SriovNetwork) {
-					network.Spec.MetaPluginsConfig = `{ "type": "tuning", "sysctl": { "net.core.somaxconn": "500"}}`
+					network.Spec.MetaPluginsConfig = `{ "type": "tuning", "sysctl": { "net.ipv4.conf.IFNAME.accept_redirects": "1"}}`
 				}
 				err := network.CreateSriovNetwork(clients, sriovDevice, sriovNetworkName, namespaces.Test, operatorNamespace, resourceName, ipam, []network.SriovNetworkOptions{config}...)
 				Expect(err).ToNot(HaveOccurred())
@@ -825,10 +825,10 @@ var _ = Describe("[sriov] operator", func() {
 				}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				testPod := createTestPod(node, []string{sriovNetworkName})
-				stdout, _, err := pod.ExecCommand(clients, testPod, "more", "/proc/sys/net/core/somaxconn")
+				stdout, _, err := pod.ExecCommand(clients, testPod, "more", "/proc/sys/net/ipv4/conf/net1/accept_redirects")
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(strings.TrimSpace(stdout)).To(Equal("500"))
+				Expect(strings.TrimSpace(stdout)).To(Equal("1"))
 			})
 		})
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -232,7 +232,7 @@ github.com/json-iterator/go
 ## explicit; go 1.12
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1
-# github.com/k8snetworkplumbingwg/sriov-network-operator v1.0.1-0.20211126031536-11faae79733e => github.com/openshift/sriov-network-operator v0.0.0-20220519143048-dc0a8bda79f1
+# github.com/k8snetworkplumbingwg/sriov-network-operator v1.0.1-0.20211126031536-11faae79733e => github.com/openshift/sriov-network-operator v0.0.0-20220706125402-e281e75bc6fb
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
 github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/scheme
@@ -1243,7 +1243,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20210706120254-6f1208ffd780
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a
 # sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.0
-# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20220519143048-dc0a8bda79f1
+# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20220706125402-e281e75bc6fb
 # github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c
 # github.com/openshift-kni/numaresources-operator => github.com/openshift-kni/numaresources-operator v0.4.10-3.2022042201
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b


### PR DESCRIPTION
Dependency has been updated with commands:
```
go mod edit -replace \
  github.com/k8snetworkplumbingwg/sriov-network-operator=\
  github.com/openshift/sriov-network-operator@release-4.12
go mod tidy
go mod vendor
```

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>