### PR TITLE
ztp: Remove `run-level: "1"` annotation from the SR-IOV Namespace source CR

### DIFF
--- a/ztp/source-crs/SriovSubscriptionNS.yaml
+++ b/ztp/source-crs/SriovSubscriptionNS.yaml
@@ -5,5 +5,3 @@ metadata:
   annotations:
     workload.openshift.io/allowed: management
     ran.openshift.io/ztp-deploy-wave: "2"
-  labels:
-    openshift.io/run-level: "1"


### PR DESCRIPTION
The `openshift.io/run-level: "1"` label was replaced by a privileged SCC in the openshift/sriov-network-operator [commit](https://github.com/openshift/sriov-network-operator/commit/119c20587f169446481b27ce543766034f319f58). This change was introduced in OCP 4.5.

This PR contains the commit which removes the `openshift.io/run-level: "1"` label from `ztp/source-crs/SriovSubscriptionNS.yaml`.

A manual validation exercise was performed to verify this change. The exercise comprised of the following steps:
1. Build new ztp-site-generator image containing the changes in this commit (https://quay.io/repository/sakhoury/ztp-site-generator)
2. Update hub cluster (`ran-vcl02`) with new ztp-site-generator image
3. Deploy a spoke cluster (`cnfocto1`) with SriovNetwork policies
4. Verify that the `SriovNetwork` resource were successfully created with the associated `NetworkAttachmentDefinition` objects.
5. Deploy two pods on the same `SriovNetwork` and test that they can reach each other (via ping).

The result of step 5 above is available here: [output.txt](https://github.com/openshift-kni/cnf-features-deploy/files/9162464/output.txt)

Signed-off-by: Sharat Akhoury <sakhoury@redhat.com>

/cc @imiller0 @lack 