### PR TITLE
ztp: Enable workload partitioning on SNO worker

### DIFF
--- a/ztp/siteconfig-generator-kustomize-plugin/kustomization.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/kustomization.yaml
@@ -5,3 +5,4 @@ generators:
 - testSiteConfig/site1-sno-du.yaml
 - testSiteConfig/site2-sno-du.yaml
 - testSiteConfig/site2-standard-du.yaml
+- testSiteConfig/site1-sno-expansion.yaml

--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-expansion.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-expansion.yaml
@@ -1,0 +1,193 @@
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "site-sno-du-exp"
+  namespace: "site-sno-du-exp"
+spec:
+  baseDomain: "example.com"
+  pullSecretRef:
+    name: "pullSecretName"
+  clusterImageSetNameRef: "openshift-v4.8.0"
+  sshPublicKey: "ssh-rsa "
+  sshPrivateKeySecretRef:
+    name: "sshPrvKey"
+  clusters:
+  - clusterName: "site-sno-du-expaneded"
+    clusterType: sno
+    biosConfigRef:
+      filePath: "testSiteConfig/testHW.profile"
+    networkType: OVNKubernetes
+    extraManifestPath: testSiteConfig/testUserExtraManifest
+    clusterLabels:
+      group-du-sno: ""
+      common: true
+      sites : "site-sno-du-expanded"
+    clusterNetwork:
+      - cidr: 10.128.0.0/14
+        hostPrefix: 23
+    machineNetwork:
+      - cidr: 10.16.231.0/24
+    serviceNetwork:
+      - 172.30.0.0/16
+    manifestsConfig:
+      ntpServer: "pool.ntp.org"
+    additionalNTPSources:
+      - NTP.server1
+      - 10.16.231.22
+    ignitionConfigOverride: "igen"
+    diskEncryption:
+      type: "nbde"
+      tang:
+        - url: "http://10.0.0.1:7500"
+          thumbprint: "1234567890"
+    nodes:
+      - hostName: "node1"
+        role: master
+        bmcAddress: "idrac-virtualmedia+https://10.16.231.87/redfish/v1/Systems/System.Embedded.1"
+        bmcCredentialsName:
+          name: "name of bmcCredentials secret"
+        bootMACAddress: "00:00:00:01:20:30"
+        bootMode: "UEFI"
+        rootDeviceHints:
+          hctl: "1:2:0:0"
+        userData:
+          bootKey: value1
+        cpuset: "2-19,22-39"
+        installerArgs: '{"args": ["--append-karg", "nameserver=8.8.8.8", "-n"]}'
+        ignitionConfigOverride: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/containers/registries.conf", "overwrite": true, "contents": {"source": "data:text/plain;base64,aGVsbG8gZnJvbSB6dHAgcG9saWN5IGdlbmVyYXRvcg=="}}]}}'
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              macAddress: "00:00:00:01:20:30"
+            - name: eth0
+              macAddress: "02:00:00:80:12:14"
+            - name: eth1
+              macAddress: "02:00:00:80:12:15"
+          config:
+            interfaces:
+              - name: eno1
+                macAddress: "00:00:00:01:20:30"
+                type: ethernet
+                ipv4:
+                  enabled: true
+                  dhcp: false
+                  address:
+                  - ip: 10.16.231.3
+                    prefix-length: 24
+                  - ip: 10.16.231.28
+                    prefix-length: 24
+                  - ip: 10.16.231.31
+                    prefix-length: 24
+                ipv6:
+                  enabled: true
+                  dhcp: false
+                  address:
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:601"
+                    prefix-length: 64
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:602"
+                    prefix-length: 64
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:603"
+                    prefix-length: 64
+              - name: bond99
+                type: bond
+                state: up
+                ipv6:
+                  address:
+                  - ip: "2620:52:0:1302::100"
+                  prefix-length: 64
+                  enabled: true
+                  link-aggregation:
+                    mode: balance-rr
+                    options:
+                      miimon: '140'
+                    slaves:
+                    - eth0
+                    - eth1
+            dns-resolver:
+              config:
+                server:
+                  - 10.19.42.41
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-address: 10.16.231.254
+                  next-hop-interface: eno1
+                  table-id: 254
+        diskPartition:
+          - device: /dev/sda
+            partitions:
+              - mount_point: /var/my/path
+                size: 102500
+                start: 344844
+      - hostName: "node2"
+        role: worker
+        bmcAddress: "idrac-virtualmedia+https://10.16.231.87/redfish/v1/Systems/System.Embedded.1"
+        bmcCredentialsName:
+          name: "name of bmcCredentials secret"
+        bootMACAddress: "00:00:00:01:20:30"
+        bootMode: "UEFI"
+        rootDeviceHints:
+          hctl: "1:2:0:0"
+        userData:
+          bootKey: value1
+        cpuset: "2-19,22-39"
+        installerArgs: '{"args": ["--append-karg", "nameserver=8.8.8.8", "-n"]}'
+        ignitionConfigOverride: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/containers/registries.conf", "overwrite": true, "contents": {"source": "data:text/plain;base64,aGVsbG8gZnJvbSB6dHAgcG9saWN5IGdlbmVyYXRvcg=="}}]}}'
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              macAddress: "00:00:00:01:20:30"
+            - name: eth0
+              macAddress: "02:00:00:80:12:14"
+            - name: eth1
+              macAddress: "02:00:00:80:12:15"
+          config:
+            interfaces:
+              - name: eno1
+                macAddress: "00:00:00:01:20:30"
+                type: ethernet
+                ipv4:
+                  enabled: true
+                  dhcp: false
+                  address:
+                  - ip: 10.16.231.3
+                    prefix-length: 24
+                  - ip: 10.16.231.28
+                    prefix-length: 24
+                  - ip: 10.16.231.31
+                    prefix-length: 24
+                ipv6:
+                  enabled: true
+                  dhcp: false
+                  address:
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:601"
+                    prefix-length: 64
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:602"
+                    prefix-length: 64
+                  - ip: "2620:52:0:10e7:e42:a1ff:fe8a:603"
+                    prefix-length: 64
+              - name: bond99
+                type: bond
+                state: up
+                ipv6:
+                  address:
+                  - ip: "2620:52:0:1302::100"
+                  prefix-length: 64
+                  enabled: true
+                  link-aggregation:
+                    mode: balance-rr
+                    options:
+                      miimon: '140'
+                    slaves:
+                    - eth0
+                    - eth1
+            dns-resolver:
+              config:
+                server:
+                  - 10.19.42.41
+            routes:
+              config:
+                - destination: 0.0.0.0/0
+                  next-hop-address: 10.16.231.254
+                  next-hop-interface: eno1
+                  table-id: 254

--- a/ztp/siteconfig-generator/siteConfig/siteConfig.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig.go
@@ -210,7 +210,7 @@ func (rv *Clusters) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("Number of masters (counted %d) must be exactly 1 or 3", rv.NumMasters)
 	}
 	// Autodetect ClusterType based on the node counts
-	if rv.NumMasters == 1 && rv.NumWorkers == 0 {
+	if rv.NumMasters == 1 {
 		rv.ClusterType = SNO
 	} else {
 		rv.ClusterType = Standard

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
@@ -320,7 +320,7 @@ func populateSpec(filePath string, instantiatedCR map[string]interface{}) error 
 	return nil
 }
 
-func (scbuilder *SiteConfigBuilder) getWorkloadManifest(cpuSet string) (string, interface{}, error) {
+func (scbuilder *SiteConfigBuilder) getWorkloadManifest(cpuSet string, role string) (string, interface{}, error) {
 	filePath := scbuilder.scBuilderExtraManifestPath + "/" + workloadPath
 	crio, err := ReadExtraManifestResourceFile(filePath + "/" + workloadCrioFile)
 	if err != nil {
@@ -336,15 +336,21 @@ func (scbuilder *SiteConfigBuilder) getWorkloadManifest(cpuSet string) (string, 
 	kubeletStr := string(kubelet)
 	kubeletStr = strings.Replace(kubeletStr, cpuset, cpuSet, -1)
 	kubeletStr = base64.StdEncoding.EncodeToString([]byte(kubeletStr))
-	worklod, err := ReadExtraManifestResourceFile(filePath + "/" + workloadFile)
+	workload, err := ReadExtraManifestResourceFile(filePath + "/" + workloadFile)
 	if err != nil {
 		return "", nil, err
 	}
-	workloadStr := string(worklod)
+	workloadStr := string(workload)
 	workloadStr = strings.Replace(workloadStr, "$crio", crioStr, -1)
 	workloadStr = strings.Replace(workloadStr, "$k8s", kubeletStr, -1)
+	workloadStr = strings.Replace(workloadStr, "$mcp", role, -1)
 
-	return workloadFile, reflect.ValueOf(workloadStr).Interface(), nil
+	workloadFileParts := append(strings.Split(workloadFile, "-"), "")
+	copy(workloadFileParts[2:], workloadFileParts[1:])
+	workloadFileParts[1] = role
+	workloadFileForRole := strings.Join(workloadFileParts, "-")
+
+	return workloadFileForRole, reflect.ValueOf(workloadStr).Interface(), nil
 }
 
 func (scbuilder *SiteConfigBuilder) getExtraManifest(dataMap map[string]interface{}, clusterSpec Clusters) (map[string]interface{}, error) {
@@ -403,21 +409,24 @@ func (scbuilder *SiteConfigBuilder) getExtraManifest(dataMap map[string]interfac
 	}
 
 	// Adding workload partitions MC only for SNO clusters.
-	if clusterSpec.ClusterType == SNO && len(clusterSpec.Nodes) > 0 {
-		cpuSet := clusterSpec.Nodes[0].Cpuset
-		if cpuSet != "" {
-			k, v, err := scbuilder.getWorkloadManifest(cpuSet)
-			if err != nil {
-				errStr := fmt.Sprintf("Error could not read WorkloadManifest %s %s\n", clusterSpec.ClusterName, err)
-				return dataMap, errors.New(errStr)
-			} else {
-				data, err := addZTPAnnotationToManifest(v.(string))
+	if clusterSpec.ClusterType == SNO {
+		for node := range clusterSpec.Nodes {
+			cpuSet := clusterSpec.Nodes[node].Cpuset
+			role := clusterSpec.Nodes[node].Role
+			if cpuSet != "" {
+				k, v, err := scbuilder.getWorkloadManifest(cpuSet, role)
 				if err != nil {
-					return dataMap, err
+					errStr := fmt.Sprintf("Error could not read WorkloadManifest %s %s\n", clusterSpec.ClusterName, err)
+					return dataMap, errors.New(errStr)
+				} else {
+					data, err := addZTPAnnotationToManifest(v.(string))
+					if err != nil {
+						return dataMap, err
+					}
+					dataMap[k] = data
+					// Exclude the workload manifest
+					doNotMerge[k] = true
 				}
-				dataMap[k] = data
-				// Exclude the workload manifest
-				doNotMerge[k] = true
 			}
 		}
 	}

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -266,7 +266,7 @@ func Test_siteConfigBuildExtraManifest(t *testing.T) {
 
 		if mapSourceCR["kind"] == "ConfigMap" {
 			dataMap := mapSourceCR["data"].(map[string]interface{})
-			assert.NotEqual(t, dataMap["03-workload-partitioning.yaml"], nil)
+			assert.NotEqual(t, dataMap["03-master-workload-partitioning.yaml"], nil)
 			break
 		}
 	}

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
@@ -150,7 +150,7 @@ spec:
 ---
 apiVersion: v1
 data:
-    03-workload-partitioning.yaml: |
+    03-master-workload-partitioning.yaml: |
         apiVersion: machineconfiguration.openshift.io/v1
         kind: MachineConfig
         metadata:

--- a/ztp/source-crs/extra-manifest/workload/03-workload-partitioning.yaml
+++ b/ztp/source-crs/extra-manifest/workload/03-workload-partitioning.yaml
@@ -2,8 +2,8 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: master
-  name: 02-master-workload-partitioning
+    machineconfiguration.openshift.io/role: $mcp
+  name: 02-$mcp-workload-partitioning
 spec:
   config:
     ignition:


### PR DESCRIPTION
SNO expansion scenario occurs when initially a SNO
is deployed into production, and at a later date the
cluster size is increased by the addition of a worker node.
The resulting cluster will contain two nodes:
1. Original SNO serving as the control plane for itself and the additional node
2. One additional node without any control plane components (controlled by the SNO).
The additional worker is running the same type of workload as the original SNO,
so all the DU related configurations and optimizations apply to the worker
node as well. This includes workload partitioning.

This commit allows generation of workload partitioning
manifests on the additional worker node described above.

Signed-off-by: Vitaly <vgrinber@redhat.com>

/cc @lack @serngawy 