### PR TITLE
cnf-tests: add mtu to nad builder

### DIFF
--- a/cnf-tests/testsuites/e2esuite/bond/bond.go
+++ b/cnf-tests/testsuites/e2esuite/bond/bond.go
@@ -46,7 +46,7 @@ var _ = Describe("bondcni", func() {
 				err = client.Client.Create(context.Background(), macVlanNad)
 				Expect(err).ToNot(HaveOccurred())
 
-				bondNad, err := networks.NewNetworkAttachmentDefinitionBuilder(namespaces.BondTestNamespace, bondNadName).WithBond(bondIfcName, "net2", "net1").WithStaticIpam(bondIP).Build()
+				bondNad, err := networks.NewNetworkAttachmentDefinitionBuilder(namespaces.BondTestNamespace, bondNadName).WithBond(bondIfcName, "net2", "net1", 1300).WithStaticIpam(bondIP).Build()
 				Expect(err).ToNot(HaveOccurred())
 				err = client.Client.Create(context.Background(), bondNad)
 				Expect(err).ToNot(HaveOccurred())

--- a/cnf-tests/testsuites/pkg/networks/network.go
+++ b/cnf-tests/testsuites/pkg/networks/network.go
@@ -38,7 +38,7 @@ func (b *NetworkAttachmentDefinitionBuilder) WithTuning(sysctls string) *Network
 	return b
 }
 
-func (b *NetworkAttachmentDefinitionBuilder) WithBond(bondName, link1, link2 string) *NetworkAttachmentDefinitionBuilder {
+func (b *NetworkAttachmentDefinitionBuilder) WithBond(bondName, link1, link2 string, mtu int) *NetworkAttachmentDefinitionBuilder {
 	bondConfig := `
 	    "type": "bond",
 		"ifname": "%s",
@@ -46,8 +46,9 @@ func (b *NetworkAttachmentDefinitionBuilder) WithBond(bondName, link1, link2 str
 		"failOverMac": 1,
 		"linksInContainer": true,
 		"miimon": "100",
+		"mtu": %d,
 		"links": [ {"name": "%s"}, {"name": "%s"} ]`
-	b.setConfig(fmt.Sprintf(bondConfig, bondName, link1, link2))
+	b.setConfig(fmt.Sprintf(bondConfig, bondName, mtu, link1, link2))
 	return b
 }
 


### PR DESCRIPTION
Adding an mtu parameter to the nad builder.
Note that mtu is a mandatory parameter, to avoid issues
with leaving the deafult value, which causes issues in
some test environments.