### PR TITLE
cnf-tests: Add support for PSA on test namespaces

### DIFF
--- a/cnf-tests/testsuites/e2esuite/test_suite_test.go
+++ b/cnf-tests/testsuites/e2esuite/test_suite_test.go
@@ -51,7 +51,6 @@ import (
 	numaserialconf "github.com/openshift-kni/numaresources-operator/test/e2e/serial/config"
 	_ "github.com/openshift-kni/numaresources-operator/test/e2e/serial/tests"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -104,44 +103,19 @@ var _ = BeforeSuite(func() {
 	if !skipTestNSCreation {
 		Expect(testclient.Client).NotTo(BeNil())
 		// create test namespace
-		ns := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: testutils.NamespaceTesting,
-			},
-		}
-		_, err := testclient.Client.Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		err := namespaces.Create(testutils.NamespaceTesting, testclient.Client)
 		Expect(err).ToNot(HaveOccurred())
 
-		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: perfUtils.NamespaceTesting,
-			},
-		}
-		_, err = testclient.Client.Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		err = namespaces.Create(perfUtils.NamespaceTesting, testclient.Client)
 		Expect(err).ToNot(HaveOccurred())
 
-		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespaces.DpdkTest,
-			},
-		}
-		_, err = testclient.Client.Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		err = namespaces.Create(namespaces.DpdkTest, testclient.Client)
 		Expect(err).ToNot(HaveOccurred())
 
-		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: testutils.GatekeeperTestingNamespace,
-			},
-		}
-		_, err = testclient.Client.Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		err = namespaces.Create(testutils.GatekeeperTestingNamespace, testclient.Client)
 		Expect(err).ToNot(HaveOccurred())
 
-		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespaces.SroTestNamespace,
-			},
-		}
-		_, err = testclient.Client.Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		err = namespaces.Create(namespaces.SroTestNamespace, testclient.Client)
 		Expect(err).ToNot(HaveOccurred())
 	}
 

--- a/cnf-tests/testsuites/pkg/namespaces/namespaces.go
+++ b/cnf-tests/testsuites/pkg/namespaces/namespaces.go
@@ -49,6 +49,12 @@ var SCTPTest string
 
 var OVSQOSTest string
 
+var namespaceLabels = map[string]string{
+	"pod-security.kubernetes.io/audit":   "privileged",
+	"pod-security.kubernetes.io/enforce": "privileged",
+	"pod-security.kubernetes.io/warn":    "privileged",
+}
+
 func init() {
 	DpdkTest = os.Getenv("DPDK_TEST_NAMESPACE")
 	if DpdkTest == "" {
@@ -101,7 +107,8 @@ func Create(namespace string, cs *testclient.ClientSet) error {
 		context.Background(),
 		&k8sv1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
+				Name:   namespace,
+				Labels: namespaceLabels,
 			}},
 		metav1.CreateOptions{})
 


### PR DESCRIPTION
OCP >= 4.12 wants to have stricter podsecurity rules.
In our e2e tests we do a bunch of stuff, including running privileged pods. We just annotate the test namespace(s) to signal we need top privileges. Since e2e tests run in very controlled envs (CI mostly), and since test namespace should be gone anyway once the e2e tests are finished.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>