### PR TITLE
fix `[sriov] Bond CNI integration bond cni over sriov` test

### DIFF
--- a/cnf-tests/testsuites/e2esuite/bond/bond.go
+++ b/cnf-tests/testsuites/e2esuite/bond/bond.go
@@ -29,8 +29,7 @@ var _ = Describe("bondcni", func() {
 	})
 
 	AfterEach(func() {
-		err := namespaces.CleanPods(namespaces.BondTestNamespace, apiclient)
-		Expect(err).ToNot(HaveOccurred())
+		namespaces.CleanPods(namespaces.BondTestNamespace, apiclient)
 	})
 
 	Context("bond over macvlan", func() {

--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -163,7 +163,8 @@ var _ = Describe("dpdk", func() {
 		var policyHasVhostnet bool
 		execute.BeforeAll(func() {
 			if !discovery.Enabled() {
-				networks.CleanSriov(sriovclient, namespaces.DpdkTest)
+				namespaces.CleanPods(namespaces.DpdkTest, sriovclient)
+				networks.CleanSriov(sriovclient)
 				networks.CreateSriovPolicyAndNetworkDPDKOnlyWithVhost(dpdkResourceName, workerCnfLabelSelector)
 			} else {
 				sriovNetworkNodePolicyList := &sriovv1.SriovNetworkNodePolicyList{}
@@ -184,8 +185,7 @@ var _ = Describe("dpdk", func() {
 		})
 
 		AfterEach(func() {
-			err := namespaces.CleanPods(namespaces.DpdkTest, client.Client)
-			Expect(err).ToNot(HaveOccurred())
+			namespaces.CleanPods(namespaces.DpdkTest, client.Client)
 		})
 
 		Context("Client should be able to forward packets", func() {
@@ -278,7 +278,8 @@ sleep INF
 	Context("VFS allocated for dpdk", func() {
 		execute.BeforeAll(func() {
 			if !discovery.Enabled() {
-				networks.CleanSriov(sriovclient, namespaces.DpdkTest)
+				namespaces.CleanPods(namespaces.DpdkTest, sriovclient)
+				networks.CleanSriov(sriovclient)
 				networks.CreateSriovPolicyAndNetworkDPDKOnly(dpdkResourceName, workerCnfLabelSelector)
 			}
 			var err error
@@ -436,7 +437,8 @@ sleep INF
 			}
 		})
 		execute.BeforeAll(func() {
-			networks.CleanSriov(sriovclient, namespaces.DpdkTest)
+			namespaces.CleanPods(namespaces.DpdkTest, sriovclient)
+			networks.CleanSriov(sriovclient)
 			createSriovPolicyAndNetworkShared()
 			var err error
 			dpdkWorkloadPod, err = pods.CreateDPDKWorkload(nodeSelector,
@@ -502,7 +504,8 @@ sleep INF
 				Skip("Split VF test disabled for discovery mode")
 			}
 
-			networks.CleanSriov(sriovclient, namespaces.DpdkTest)
+			namespaces.CleanPods(namespaces.DpdkTest, sriovclient)
+			networks.CleanSriov(sriovclient)
 		})
 
 		DescribeTable("Test connectivity using the requested nic", func(vendorID, deviceID string) {
@@ -557,7 +560,7 @@ sleep INF
 			if discovery.Enabled() {
 				Skip("Downward API test disabled for discovery mode")
 			}
-			networks.CleanSriov(sriovclient, namespaces.DpdkTest)
+			networks.CleanSriov(sriovclient)
 			createSriovPolicyAndNetworkShared()
 			var err error
 			dpdkWorkloadPod, err = pods.CreateDPDKWorkload(nodeSelector,
@@ -614,7 +617,8 @@ sleep INF
 			}
 
 			By("cleaning the sriov test configuration")
-			networks.CleanSriov(sriovclient, namespaces.DpdkTest)
+			namespaces.CleanPods(namespaces.DpdkTest, sriovclient)
+			networks.CleanSriov(sriovclient)
 		})
 	})
 })

--- a/cnf-tests/testsuites/e2esuite/s2i/s2i.go
+++ b/cnf-tests/testsuites/e2esuite/s2i/s2i.go
@@ -3,14 +3,15 @@ package s2i
 import (
 	"context"
 	"fmt"
-	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/performanceprofile"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/performanceprofile"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -166,7 +167,8 @@ var _ = Describe("s2i", func() {
 		err = performanceprofile.FindOrOverridePerformanceProfile(performanceProfileName, machineConfigPoolName)
 		Expect(err).ToNot(HaveOccurred())
 
-		networks.CleanSriov(sriovclient, namespaces.DpdkTest)
+		namespaces.CleanPods(namespaces.DpdkTest, sriovclient)
+		networks.CleanSriov(sriovclient)
 		networks.CreateSriovPolicyAndNetworkDPDKOnly(dpdkResourceName, workerCnfLabelSelector)
 
 		dpdkWorkloadPod, err = pods.CreateDPDKWorkload(nodeSelector,
@@ -226,7 +228,8 @@ var _ = Describe("s2i", func() {
 			}
 
 			By("cleaning the sriov test configuration")
-			networks.CleanSriov(sriovclient, namespaces.DpdkTest)
+			namespaces.CleanPods(namespaces.DpdkTest, sriovclient)
+			networks.CleanSriov(sriovclient)
 		})
 	})
 })

--- a/cnf-tests/testsuites/e2esuite/security/tuning.go
+++ b/cnf-tests/testsuites/e2esuite/security/tuning.go
@@ -32,8 +32,7 @@ var _ = Describe("tuningcni", func() {
 	})
 
 	AfterEach(func() {
-		err := namespaces.CleanPods(TestNamespace, apiclient)
-		Expect(err).ToNot(HaveOccurred())
+		namespaces.CleanPods(TestNamespace, apiclient)
 	})
 
 	Context("tuningcni over macvlan", func() {

--- a/cnf-tests/testsuites/e2esuite/security/tuning_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/security/tuning_sriov.go
@@ -40,8 +40,7 @@ var _ = Describe("[sriov] Tuning CNI integration", func() {
 	})
 
 	AfterEach(func() {
-		err := namespaces.CleanPods(SriovTestNamespace, apiclient)
-		Expect(err).ToNot(HaveOccurred())
+		namespaces.CleanPods(SriovTestNamespace, apiclient)
 	})
 
 	Context("tuning cni over sriov", func() {
@@ -52,7 +51,8 @@ var _ = Describe("[sriov] Tuning CNI integration", func() {
 		})
 
 		execute.BeforeAll(func() {
-			networks.CleanSriov(sriovclient, SriovTestNamespace)
+			namespaces.CleanPods(SriovTestNamespace, sriovclient)
+			networks.CleanSriov(sriovclient)
 			sysctls, err := networks.SysctlConfig(map[string]string{fmt.Sprintf(Sysctl, "IFNAME"): "1"})
 			Expect(err).ToNot(HaveOccurred())
 			networks.CreateSriovPolicyAndNetwork(sriovclient, namespaces.SRIOVOperator, "test-network", "testresource", fmt.Sprintf("{%s}", sysctls))

--- a/cnf-tests/testsuites/e2esuite/vrf/vrf.go
+++ b/cnf-tests/testsuites/e2esuite/vrf/vrf.go
@@ -71,8 +71,7 @@ var _ = Describe("[vrf]", func() {
 		vrfRed = addVRFNad(apiclient, "test-vrf-red", VRFRedName)
 	})
 	AfterEach(func() {
-		err := namespaces.CleanPods(TestNamespace, apiclient)
-		Expect(err).ToNot(HaveOccurred())
+		namespaces.CleanPods(TestNamespace, apiclient)
 	})
 
 	Context("", func() {

--- a/cnf-tests/testsuites/e2esuite/vrf/vrf_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/vrf/vrf_sriov.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/networks"
 	"time"
+
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/networks"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -92,10 +93,10 @@ var _ = Describe("[sriov] VRF integration", func() {
 
 	})
 	AfterEach(func() {
-		err := namespaces.CleanPods(sriovNamespaces.Test, apiclient)
-		Expect(err).ToNot(HaveOccurred())
+		namespaces.CleanPods(sriovNamespaces.Test, apiclient)
+
 		//TODO: We need to remove this block and add cleanup in to sriov-network-operator project
-		err = sriovClean.All()
+		err := sriovClean.All()
 		Expect(err).ToNot(HaveOccurred())
 		networks.WaitStable(sriovclient)
 	})

--- a/cnf-tests/testsuites/pkg/namespaces/namespaces.go
+++ b/cnf-tests/testsuites/pkg/namespaces/namespaces.go
@@ -2,14 +2,14 @@ package namespaces
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
 	gomega "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -90,10 +90,10 @@ func init() {
 }
 
 // WaitForDeletion waits until the namespace will be removed from the cluster
-func WaitForDeletion(cs *testclient.ClientSet, nsName string, timeout time.Duration) error {
+func WaitForDeletion(cs corev1client.NamespacesGetter, nsName string, timeout time.Duration) error {
 	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		_, err := cs.Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, nil
@@ -102,7 +102,7 @@ func WaitForDeletion(cs *testclient.ClientSet, nsName string, timeout time.Durat
 
 // Create creates a new namespace with the given name.
 // If the namespace exists, it returns.
-func Create(namespace string, cs *testclient.ClientSet) error {
+func Create(namespace string, cs corev1client.NamespacesGetter) error {
 	_, err := cs.Namespaces().Create(
 		context.Background(),
 		&k8sv1.Namespace{
@@ -134,7 +134,7 @@ func Clean(namespace string, prefix string, cs *testclient.ClientSet) error {
 			err = cs.NetworkPolicies(namespace).Delete(context.Background(), p.Name, metav1.DeleteOptions{
 				GracePeriodSeconds: pointer.Int64Ptr(0),
 			})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -149,7 +149,7 @@ func Clean(namespace string, prefix string, cs *testclient.ClientSet) error {
 			err = cs.Pods(namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{
 				GracePeriodSeconds: pointer.Int64Ptr(0),
 			})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !k8serrors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -177,26 +177,29 @@ func Clean(namespace string, prefix string, cs *testclient.ClientSet) error {
 }
 
 // Exists tells whether the given namespace exists
-func Exists(namespace string, cs *testclient.ClientSet) bool {
+func Exists(namespace string, cs corev1client.NamespacesGetter) bool {
 	_, err := cs.Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 	return err == nil || !k8serrors.IsNotFound(err)
 }
 
+type NamespacesAndPods interface {
+	Namespaces() corev1client.NamespaceInterface
+	Pods(namespace string) corev1client.PodInterface
+}
+
 // CleanPods deletes all pods in namespace
-func CleanPods(namespace string, cs *testclient.ClientSet) error {
+func CleanPods(namespace string, cs NamespacesAndPods) {
 	if !Exists(namespace, cs) {
-		return nil
+		return
 	}
 	err := cs.Pods(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{
 		GracePeriodSeconds: pointer.Int64Ptr(0),
 	}, metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("Failed to delete pods %v", err)
-	}
-	gomega.Eventually(func() int {
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	gomega.Eventually(func(g gomega.Gomega) int {
 		podsList, err := cs.Pods(namespace).List(context.Background(), metav1.ListOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		return len(podsList.Items)
 	}, 3*time.Minute, 10*time.Second).Should(gomega.BeZero())
-	return nil
 }

--- a/cnf-tests/testsuites/pkg/networks/sriov.go
+++ b/cnf-tests/testsuites/pkg/networks/sriov.go
@@ -44,11 +44,9 @@ func init() {
 	sriovclient = sriovtestclient.New("")
 }
 
-func CleanSriov(sriovclient *sriovtestclient.ClientSet, namespace string) {
-	// This clean only the policy and networks with the prefix of test
-	err := sriovnamespaces.CleanPods(namespace, sriovclient)
-	Expect(err).ToNot(HaveOccurred())
-	err = sriovnamespaces.CleanNetworks(namespaces.SRIOVOperator, sriovclient)
+// CleanSriov cleans SriovNetworks and SriovNetworkNodePolicies with the prefix of `test-`, that are in the `openshift-sriov-network-operator`
+func CleanSriov(sriovclient *sriovtestclient.ClientSet) {
+	err := sriovnamespaces.CleanNetworks(namespaces.SRIOVOperator, sriovclient)
 	Expect(err).ToNot(HaveOccurred())
 
 	if !discovery.Enabled() {


### PR DESCRIPTION
This PR should fix the following test error:

```
/remote-source/app/cnf-tests/testsuites/e2esuite/bond/bond_sriov.go:64
Unexpected error:
    <*errors.StatusError | 0xc0021d4c80>: {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "admission webhook \"network-resources-injector-config.k8s.io\" denied the request: could not find network attachment definition 'bond-testing/bond': could not get Network Attachment Definition bond-testing/bond: the server could not find the requested resource",
            Reason: "",
            Details: nil,
            Code: 400,
        },
    }
    admission webhook "network-resources-injector-config.k8s.io" denied the request: could not find network attachment definition 'bond-testing/bond': could not get Network Attachment Definition bond-testing/bond: the server could not find the requested resource
occurred
/remote-source/app/cnf-tests/testsuites/e2esuite/bond/bond_sriov.go:77
```

Alongside, I added two commits to improve the around `namespaces.CleanPods(...)` and `networks.CleanSriov(...)`.
