### PR TITLE
ztp: Prevent changing immutable objects on sno expansion

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfig.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig.go
@@ -209,9 +209,11 @@ func (rv *Clusters) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if rv.NumMasters != 1 && rv.NumMasters != 3 {
 		return fmt.Errorf("Number of masters (counted %d) must be exactly 1 or 3", rv.NumMasters)
 	}
-	// Autodetect ClusterType based on the node counts
+	// Autodetect ClusterType based on the node counts and fix number of workers to 0 for sno.
+	// The latter prevents AgentClusterInstall from being mutated upon SNO expansion
 	if rv.NumMasters == 1 {
 		rv.ClusterType = SNO
+		rv.NumWorkers = 0
 	} else {
 		rv.ClusterType = Standard
 	}


### PR DESCRIPTION
This change allows deploying additional SNO workers with ZTP.
When adding a worker to an existing SNO, user
adds an additional node to the existing SiteConfig.
The Generator is processing the modified siteconfig
and adds an additional line in AgentClusterInstall:
workerAgents: 1
However, agentclusterinstall is immutable.There is an
admission webhook that declines the change,
and the sync fails:
Attempted to change AgentClusterInstall.Spec which is
immutable after install started, except for ClusterMetadata
fields. Unsupported change: ProvisionRequirements.WorkerAgents: (0 => 1)

/cc @lack @serngawy 