### PR TITLE
ztp: OCPBUGS-217: run PTP daemons on worker nodes only

### DIFF
--- a/ztp/source-crs/PtpOperatorConfig.yaml
+++ b/ztp/source-crs/PtpOperatorConfig.yaml
@@ -7,4 +7,4 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   daemonNodeSelector:
-    node-role.kubernetes.io/$mcp: ""
+    node-role.kubernetes.io/worker: ""

--- a/ztp/source-crs/PtpOperatorConfigForEvent.yaml
+++ b/ztp/source-crs/PtpOperatorConfigForEvent.yaml
@@ -7,7 +7,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   daemonNodeSelector:
-    node-role.kubernetes.io/$mcp: ""
+    node-role.kubernetes.io/worker: ""
   ptpEventConfig:
     enableEventPublisher: true
     transportHost: "amqp://amq-router.amq-router.svc.cluster.local"


### PR DESCRIPTION
ZTP DU workflow provisions PtpOperatorConfig resource in case there
is a need for ptpEventConfig setting, and for standard clusters regardless
of ptp event needs.
For SNOs, the PtpOperatorConfig resource includes daemonsetNodeSelector
set to "master".
If at a later time SNO is expanded with one or more workers, PTP operator
would not create linuxptp-daemon containers on the worker node(s). Any
attempt to change the daemonsetNodeSelector will result in ptp daemon
restart and time synchronization loss.
This commit sets daemonNodeSelector to "worker" unconditionally. It fits
all the deployment types known so far (both SNO and 3NC nodes have the
"worker" label, and will be selected. For the standard clusters we only
want to deploy PTP on workers)
/cc @lack @serngawy @aneeshkp 