### PR TITLE
ztp: OCPBUGS-239: run SR-IOV daemons on workers

### DIFF
--- a/ztp/source-crs/SriovOperatorConfig.yaml
+++ b/ztp/source-crs/SriovOperatorConfig.yaml
@@ -7,7 +7,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   configDaemonNodeSelector:
-    "node-role.kubernetes.io/$mcp": ""
+    "node-role.kubernetes.io/worker": ""
   disableDrain: false
   # Injector and OperatorWebhook pods can be disabled (set to "false") below
   # to reduce the number of management pods. It is recommended to start with the 


### PR DESCRIPTION
ZTP DU workflow provisions SriovOperatorConfig resource.
For SNOs, the SriovOperatorConfig resource includes
configDaemonNodeSelector set to "master".
If at a later time SNO is expanded with one or more workers,
SRIOV operator would not create sriov-device-plugin and
sriov-network-config-daemon pods on the worker node(s).
Any attempt to change the configDaemonNodeSelector will
result in sriov-device-plugin and
sriov-network-config-daemon pods restart and possible
network connectivity loss.

This commit sets configDaemonNodeSelector to "worker"
unconditionally. This fits all the deployment types known so far
(both SNO and 3NC nodes have the "worker" label, and therefore will
be selected, and on the standard clusters we only want to deploy
the daemons on workers)
/cc @lack @serngawy @imiller0 