### PR TITLE
cnf-tests: Avoid clean SR-IOV resources

### DIFF
--- a/cnf-tests/testsuites/e2esuite/sctp/sctp_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/sctp/sctp_sriov.go
@@ -2,7 +2,6 @@ package sctp
 
 import (
 	"context"
-	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/networks"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -24,6 +23,7 @@ import (
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/discovery"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/execute"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/namespaces"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/networks"
 )
 
 const (
@@ -115,16 +115,6 @@ var _ = Describe("[sriov] SCTP integration", func() {
 				namespaces.Clean(TestNamespace, "testsctp-", client.Client)
 				if discoveryFailed {
 					Skip("Discovery failed, failed to find a valid node with SCTP and SRIOV enabled")
-				}
-			})
-			AfterEach(func() {
-				// TODO: This is ugly and works only because this is the only
-				// test in this context. To be removed and replaced with a clean on top
-				// of sriov tests generic / no policy
-				if !discovery.Enabled() {
-					err := sriovnamespaces.Clean(namespaces.SRIOVOperator, TestNamespace, sriovclient, false)
-					Expect(err).ToNot(HaveOccurred())
-					networks.WaitStable(sriovclient)
 				}
 			})
 

--- a/cnf-tests/testsuites/e2esuite/vrf/vrf_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/vrf/vrf_sriov.go
@@ -94,11 +94,6 @@ var _ = Describe("[sriov] VRF integration", func() {
 	})
 	AfterEach(func() {
 		namespaces.CleanPods(sriovNamespaces.Test, apiclient)
-
-		//TODO: We need to remove this block and add cleanup in to sriov-network-operator project
-		err := sriovClean.All()
-		Expect(err).ToNot(HaveOccurred())
-		networks.WaitStable(sriovclient)
 	})
 
 	Context("", func() {


### PR DESCRIPTION
Cleaning resources in `AfterEach(...)` ginkgo blocks inhibits
the k8sreporter to collect debug information in case of
failures.

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>