### PR TITLE
OCPBUGS-467: ztp: Validate policy evaluation intervals

### DIFF
--- a/ztp/policygenerator/policyGen/policyBuilder.go
+++ b/ztp/policygenerator/policyGen/policyBuilder.go
@@ -102,11 +102,23 @@ func (pbuilder *PolicyBuilder) Build(policyGenTemp utils.PolicyGenTemplate) (map
 					acmPolicy.Spec.PolicyTemplates[0].ObjDef.Spec.RemediationAction = remediationActionVal
 
 					// set to default EvaluationInterval or user set from PGT
+					if err := validateInterval(policyGenTemp.Spec.EvaluationInterval.Compliant); err != nil {
+						return policies, errors.New("Spec: evaluationInterval.compliant '" + err.Error() + "'")
+					}
+					if err := validateInterval(policyGenTemp.Spec.EvaluationInterval.NonCompliant); err != nil {
+						return policies, errors.New("Spec: evaluationInterval.noncompliant '" + err.Error() + "'")
+					}
 					acmPolicy.Spec.PolicyTemplates[0].ObjDef.Spec.EvaluationInterval = policyGenTemp.Spec.EvaluationInterval
 					if sFile.EvaluationInterval.Compliant != utils.UnsetStringValue {
+						if err := validateInterval(sFile.EvaluationInterval.Compliant); err != nil {
+							return policies, errors.New(sFile.FileName + ": evaluationInterval.compliant '" + err.Error() + "'")
+						}
 						acmPolicy.Spec.PolicyTemplates[0].ObjDef.Spec.EvaluationInterval.Compliant = sFile.EvaluationInterval.Compliant
 					}
 					if sFile.EvaluationInterval.NonCompliant != utils.UnsetStringValue {
+						if err := validateInterval(sFile.EvaluationInterval.NonCompliant); err != nil {
+							return policies, errors.New(sFile.FileName + ": evaluationInterval.noncompliant '" + err.Error() + "'")
+						}
 						acmPolicy.Spec.PolicyTemplates[0].ObjDef.Spec.EvaluationInterval.NonCompliant = sFile.EvaluationInterval.NonCompliant
 					}
 
@@ -134,6 +146,9 @@ func (pbuilder *PolicyBuilder) Build(policyGenTemp utils.PolicyGenTemplate) (map
 
 					var policyTemplate = policies[output].(utils.AcmPolicy).Spec.PolicyTemplates[0]
 					if sFile.EvaluationInterval.Compliant != utils.UnsetStringValue {
+						if err := validateInterval(sFile.EvaluationInterval.Compliant); err != nil {
+							return policies, errors.New(sFile.FileName + ": evaluationInterval.compliant '" + err.Error() + "'")
+						}
 						if sFile.EvaluationInterval.Compliant != policyTemplate.ObjDef.Spec.EvaluationInterval.Compliant &&
 							policyTemplate.ObjDef.Spec.EvaluationInterval.Compliant != policyGenTemp.Spec.EvaluationInterval.Compliant {
 							return policies, errors.New("Compliant EvaluationInterval '" + sFile.EvaluationInterval.Compliant + "' conflict with '" +
@@ -142,6 +157,9 @@ func (pbuilder *PolicyBuilder) Build(policyGenTemp utils.PolicyGenTemplate) (map
 						acmPolicy.Spec.PolicyTemplates[0].ObjDef.Spec.EvaluationInterval.Compliant = sFile.EvaluationInterval.Compliant
 					}
 					if sFile.EvaluationInterval.NonCompliant != utils.UnsetStringValue {
+						if err := validateInterval(sFile.EvaluationInterval.NonCompliant); err != nil {
+							return policies, errors.New(sFile.FileName + ": evaluationInterval.noncompliant '" + err.Error() + "'")
+						}
 						if sFile.EvaluationInterval.NonCompliant != policyTemplate.ObjDef.Spec.EvaluationInterval.NonCompliant &&
 							policyTemplate.ObjDef.Spec.EvaluationInterval.NonCompliant != policyGenTemp.Spec.EvaluationInterval.NonCompliant {
 							return policies, errors.New("NonCompliant EvaluationInterval '" + sFile.EvaluationInterval.NonCompliant + "' conflict with '" +

--- a/ztp/policygenerator/policyGen/policyHelper.go
+++ b/ztp/policygenerator/policyGen/policyHelper.go
@@ -3,6 +3,7 @@ package policyGen
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	utils "github.com/openshift-kni/cnf-features-deploy/ztp/policygenerator/utils"
 )
@@ -174,4 +175,12 @@ func waveDisplay(wave string) string {
 		return "unset"
 	}
 	return wave
+}
+
+func validateInterval(interval string) error {
+	if interval == utils.DisableEvaluationInterval {
+		return nil
+	}
+	_, err := time.ParseDuration(interval)
+	return err
 }

--- a/ztp/policygenerator/utils/utils.go
+++ b/ztp/policygenerator/utils/utils.go
@@ -11,6 +11,7 @@ const UnsetStringValue = "__unset_value__"
 const ZtpDeployWaveAnnotation = "ran.openshift.io/ztp-deploy-wave"
 const DefaultCompliantEvaluationInterval = "10m"
 const DefaultNonCompliantEvaluationInterval = "10s"
+const DisableEvaluationInterval = "never"
 
 // ComplianceType of "mustonlyhave" uses significant CPU to enforce. Default to
 // "musthave" so that we realize the CPU reductions unless explicitly told otherwise


### PR DESCRIPTION
This update adds a validation routine to prevent users entering an invalid
time duration string in PGT.

Signed-off-by: tliu2021 <tali@redhat.com>