### PR TITLE
cnf-tests: add PSA labels to the default namespace

### DIFF
--- a/cnf-tests/testsuites/pkg/features/features.go
+++ b/cnf-tests/testsuites/pkg/features/features.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/fec"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/ptp"
-	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/sctp"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/security"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/sro"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/vrf"
@@ -110,7 +109,13 @@ type SCTPFixture struct {
 }
 
 func (p *SCTPFixture) Setup() error {
-	return nil
+	err := namespaces.Create(namespaces.SCTPTest, testclient.Client)
+	if err != nil {
+		return err
+	}
+
+	err = namespaces.AddPSALabelsToNamespace(namespaces.Default, testclient.Client)
+	return err
 }
 
 func (p *SCTPFixture) Cleanup() error {
@@ -119,7 +124,7 @@ func (p *SCTPFixture) Cleanup() error {
 		return fmt.Errorf("failed to clean 'default' namespace 'testsctp' prefix")
 	}
 
-	return namespaces.Delete(sctp.TestNamespace, testclient.Client)
+	return namespaces.Delete(namespaces.SCTPTest, testclient.Client)
 }
 
 type XTU32Fixture struct {

--- a/cnf-tests/testsuites/pkg/namespaces/namespaces.go
+++ b/cnf-tests/testsuites/pkg/namespaces/namespaces.go
@@ -131,6 +131,25 @@ func Create(namespace string, cs corev1client.NamespacesGetter) error {
 	return err
 }
 
+func AddPSALabelsToNamespace(namespace string, cs corev1client.NamespacesGetter) error {
+	ns, err := cs.Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if ns.Labels == nil {
+		ns.Labels = GetPSALabels()
+		return nil
+	}
+
+	for k, v := range GetPSALabels() {
+		ns.Labels[k] = v
+	}
+
+	_, err = cs.Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
+	return err
+}
+
 // Delete deletes a namespace with the given name, and waits for it's deletion.
 // If the namespace not found, it returns.
 func Delete(namespace string, cs *testclient.ClientSet) error {


### PR DESCRIPTION
This is needed because the sctp tests use the default namespace

Signed-off-by: Sebastian Sch <sebassch@gmail.com>