### PR TITLE
s2i: switch to generic platform dpdk

### DIFF
--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -43,7 +43,11 @@ RUN cd /usr/src/ && wget http://fast.dpdk.org/rel/dpdk-${DPDK_VER}.tar.xz && tar
     cd dpdk-stable-${DPDK_VER} && \
     meson build && \
     cd build  && \
-    meson configure -Denable_docs=false && \
+    meson configure -Denable_docs=false \
+                    -Dplatform=generic \
+                    -Dmax_ethports=32 \
+                    -Dmax_numa_nodes=8 \
+                    -Dtests=false && \
     ninja && \
     ninja install && \
     echo "/usr/local/lib64" > /etc/ld.so.conf.d/dpdk.conf && \


### PR DESCRIPTION
the following error:

```
 ERROR: This system does not support "VPCLMULQDQ".
          Please check that RTE_MACHINE is set correctly.
          EAL: FATAL: unsupported cpu type.
          EAL: unsupported cpu type.
          EAL: Error - exiting with code: 1
            Cause: Cannot init EAL: Operation not supported
```

switching to the general platform in dpdk

Signed-off-by: Sebastian Sch <sebassch@gmail.com>