### PR TITLE
ztp: OCPBUGS-239: run SR-IOV daemons on workers - Revert

### DIFF
--- a/ztp/source-crs/SriovOperatorConfig.yaml
+++ b/ztp/source-crs/SriovOperatorConfig.yaml
@@ -7,7 +7,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   configDaemonNodeSelector:
-    "node-role.kubernetes.io/worker": ""
+    "node-role.kubernetes.io/$mcp": ""
   disableDrain: false
   # Injector and OperatorWebhook pods can be disabled (set to "false") below
   # to reduce the number of management pods. It is recommended to start with the 


### PR DESCRIPTION
Reverts openshift-kni/cnf-features-deploy#1214
The reason for creating the original PR was to make the SR-IOV
daemon selector suitable for deployments besides SNO. This PR is
being reverted because the change to the source CRs would cause a
potentially disruptive update to the customer's cluster upon upgrade. 
A better way to tackle the original problem would be updating
the reference PolicyGenTemplate.
/cc @imiller0 