### PR TITLE
ztp: OCPBUGS-217: run PTP daemons on worker nodes only - Revert

### DIFF
--- a/ztp/source-crs/PtpOperatorConfig.yaml
+++ b/ztp/source-crs/PtpOperatorConfig.yaml
@@ -7,4 +7,4 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   daemonNodeSelector:
-    node-role.kubernetes.io/worker: ""
+    node-role.kubernetes.io/$mcp: ""

--- a/ztp/source-crs/PtpOperatorConfigForEvent.yaml
+++ b/ztp/source-crs/PtpOperatorConfigForEvent.yaml
@@ -7,7 +7,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   daemonNodeSelector:
-    node-role.kubernetes.io/worker: ""
+    node-role.kubernetes.io/$mcp: ""
   ptpEventConfig:
     enableEventPublisher: true
     transportHost: "amqp://amq-router.amq-router.svc.cluster.local"


### PR DESCRIPTION
Reverts openshift-kni/cnf-features-deploy#1213
The reason for creating the original PR was to make the PTP
daemon selector suitable for deployments besides SNO. This PR is
being reverted because the change to the source CRs would cause a
potentially disruptive update to the customer's cluster upon upgrade.
A better way to tackle the original problem would be updating
the reference PolicyGenTemplate.
/cc @imiller0