### PR TITLE
ztp: OCPBUGS-217: set PTP daemonsetNodeSelector

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -43,6 +43,21 @@ spec:
           logs:
             type: "fluentd"
             fluentd: {}
+    # The setting below overrides the default "worker" selector predefined in
+    # the source-crs. The change is recommended on SNOs configured with PTP 
+    # event notification for forward compatibility with possible SNO expansion.
+    # When the default setting is left intact, then in case of an SNO 
+    # expansion with one or more workers, PTP operator
+    # would not create linuxptp-daemon containers on the worker node(s). Any
+    # attempt to change the daemonsetNodeSelector will result in ptp daemon
+    # restart and time synchronization loss.
+    # After complying with the policy, complianceType can be set to a safer "musthave"
+    # - fileName: PtpOperatorConfigForEvent.yaml
+    #   policyName: "config-policy"
+    #   complianceType: mustonlyhave
+    #   spec:
+    #     daemonNodeSelector:
+    #       node-role.kubernetes.io/worker: ""
     - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
       policyName: "config-policy"
       metadata:


### PR DESCRIPTION
This commit provides reference for overriding PTP daemonsetNodeSelector to "worker" instead of the default "master" predefined in the source-crs. The change is recommended on SNOs configured with PTP event notification for forward compatibility with possible SNO expansion. When the default setting is left intact, then in case of an SNO expansion with one or more workers, PTP operator
would not create linuxptp-daemon containers on the worker node(s). Any attempt to change the daemonsetNodeSelector will result in ptp daemon restart and time synchronization loss.

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>
/assign @imiller0 
/cc @serngawy 