### PR TITLE
ztp: OCPBUGS-239: set SR-IOV node selector

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -56,7 +56,14 @@ spec:
           phc2sysOpts: "-a -r -n 24"
     - fileName: SriovOperatorConfig.yaml
       policyName: "config-policy"
+      # For existing clusters with node selector set as "master", 
+      # change the complianceType to "mustonlyhave".
+      # After complying with the policy, the complianceType can 
+      # be reverted to "musthave"
+      complianceType: musthave
       spec:
+        configDaemonNodeSelector:
+          node-role.kubernetes.io/worker: ""
         disableDrain: true
     - fileName: StorageLV.yaml
       policyName: "config-policy"


### PR DESCRIPTION
This commit provides reference for overriding SR-IOV configDaemonNodeSelector to "worker" instead of the default "master" predefined in the source-crs. The change is recommended on SNOs for forward compatibility with possible SNO expansion. When the default setting is left intact, then in case of an SNO expansion with one or more workers, SR-IOV operator would not create daemon containers on the worker node(s). Any attempt to change the configDaemonNodeSelector will result in daemon restart and possible downtime.

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>
/assign @imiller0 
/cc @serngawy 