### PR TITLE
cnf-tests: allocate more dpdknic res in vhostnet

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -188,7 +188,7 @@ var _ = Describe("dpdk", func() {
 			if !discovery.Enabled() {
 				namespaces.CleanPods(namespaces.DpdkTest, sriovclient)
 				networks.CleanSriov(sriovclient)
-				createSriovPolicyAndNetworkShared()
+				createSriovPolicyAndNetworkDPDKOnlyWithVhost()
 			} else {
 				sriovNetworkNodePolicyList := &sriovv1.SriovNetworkNodePolicyList{}
 				err := client.Client.List(context.TODO(), sriovNetworkNodePolicyList)
@@ -299,7 +299,7 @@ sleep INF
 			if !discovery.Enabled() {
 				namespaces.CleanPods(namespaces.DpdkTest, sriovclient)
 				networks.CleanSriov(sriovclient)
-				createSriovPolicyAndNetworkShared()
+				createSriovPolicyAndNetworkDPDKOnly()
 			}
 			var err error
 			dpdkWorkloadPod, err = createDPDKWorkload(nodeSelector,


### PR DESCRIPTION
The regression has been introduced in

- https://github.com/openshift-kni/cnf-features-deploy/pull/1209

`vhostnet` and `VFS allocated for dpdk` suites require that the NIC is configured with 5 `dpdknic` resources.

`createSriovPolicyAndNetworkShared()` allocates 2 `dpdknic` and 3 `regularnic` (netdevice) resources.