### PR TITLE
cnf-tests: intentionally ignore NROP setup errors 

### DIFF
--- a/cnf-tests/testsuites/pkg/features/features.go
+++ b/cnf-tests/testsuites/pkg/features/features.go
@@ -165,12 +165,14 @@ type NumaresourcesFixture struct {
 
 func (p *NumaresourcesFixture) Setup() error {
 	// note this intentionally does NOT set the infra we depends on the configsuite for this
-	return numaserialconf.SetupFixture()
-	// note we do NOT CHECK for error to have occurred - intentionally.
+	_ = numaserialconf.SetupFixture()
+	// note we ignore the error here.
+	// We do NOT CHECK for error to have occurred - intentionally.
 	// Among other things, this function gets few NUMA resources-specific objects.
 	// In case we do NOT have the NUMA resources CRDs deployed, the setup will fail.
 	// But we cannot know until we run the tests, so we handle this in the tests themselves.
 	// This will be improved in future releases of the numaresources operator.
+	return nil
 }
 
 func (p *NumaresourcesFixture) Cleanup() error {


### PR DESCRIPTION
Add missing blank import to make sure to register the types needed by the NUMAResources suite.

Fixes instances of this error:
```
/remote-source/app/cnf-tests/testsuites/e2esuite/test_suite_test.go:106
   Unexpected error:
      <*meta.NoKindMatchError | 0xc001c6c1c0>: {
          GroupKind: {
              Group: "topology.node.k8s.io",
              Kind: "NodeResourceTopology",
          },
          SearchedVersions: ["v1alpha1"],
      }
      no matches for kind "NodeResourceTopology" in version "topology.node.k8s.io/v1alpha1"
  occurred
  /remote-source/app/cnf-tests/testsuites/e2esuite/test_suite_test.go:109
```

Signed-off-by: Francesco Romani <fromani@redhat.com>