### PR TITLE
OCPBUGS-1594: Fec tests: do not clean in discovery mode

### DIFF
--- a/cnf-tests/testsuites/e2esuite/fec/fec.go
+++ b/cnf-tests/testsuites/e2esuite/fec/fec.go
@@ -166,6 +166,11 @@ func getAcc100PciFromNode(nodeName string) (string, error) {
 }
 
 func Clean() {
+	// Given discovery skips, no need to clean
+	if discovery.Enabled() {
+		return
+	}
+
 	sriovFecCluster := &sriovfecv2.SriovFecClusterConfig{}
 	err := client.Client.Get(context.TODO(), runtimeClient.ObjectKey{Name: sriovFecClusterConfigName, Namespace: namespaces.IntelOperator}, sriovFecCluster)
 	if meta.IsNoMatchError(err) || errors.IsNotFound(err) {


### PR DESCRIPTION
Discovery mode skips the tests, so we should not try to delete any config in case discovery mode is enabled.
