### PR TITLE
cnf-tests: Skip test if multinetpolicy CRD is not present

### DIFF
--- a/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go
@@ -64,6 +64,16 @@ var _ = Describe("[sriov] [multinetworkpolicy] MultiNetworkPolicy integration", 
 	sctpEnabled := false
 	sriovEnabled := false
 
+	BeforeEach(func() {
+		// Tests can be triggered by setting `FEATURE=sriov` and can fail because the
+		// feature is not enabled.
+		crdPresent, err := np.IsMultiEnabled()
+		Expect(err).ToNot(HaveOccurred())
+		if !crdPresent {
+			Fail("feature [multinetworkpolicy] not enabled on cluster. run FEATURES=multinetworkpolicy make feature-deploy to enable it.")
+		}
+	})
+
 	execute.BeforeAll(func() {
 		sriovEnabled = networks.IsSriovOperatorInstalled()
 		if !sriovEnabled {

--- a/cnf-tests/testsuites/pkg/networkpolicy/multinetworkpolicy.go
+++ b/cnf-tests/testsuites/pkg/networkpolicy/multinetworkpolicy.go
@@ -2,13 +2,32 @@ package networkpolicy
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/onsi/gomega"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	multinetpolicyv1 "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
 	client "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/client"
 )
+
+func IsMultiEnabled() (bool, error) {
+	crd := &apiext.CustomResourceDefinition{}
+	err := client.Client.Get(context.TODO(), runtimeclient.ObjectKey{Name: "multi-networkpolicies.k8s.cni.cncf.io"}, crd)
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, fmt.Errorf("can't get CRD `multi-networkpolicies.k8s.cni.cncf.io` on cluster: %w", err)
+	}
+
+	return true, nil
+}
 
 type MultiNetworkPolicyOpt func(*multinetpolicyv1.MultiNetworkPolicy)
 

--- a/cnf-tests/testsuites/validationsuite/cluster/validation.go
+++ b/cnf-tests/testsuites/validationsuite/cluster/validation.go
@@ -25,6 +25,7 @@ import (
 	sriovtestclient "github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client"
 	testclient "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/client"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/namespaces"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/networkpolicy"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/networks"
 	utilNodes "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/nodes"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/utils"
@@ -503,9 +504,9 @@ var _ = Describe("validation", func() {
 
 	Context("[multineworkpolicy]", func() {
 		It("should have MultiNetworkPolicy CRD available in the cluster", func() {
-			crd := &apiext.CustomResourceDefinition{}
-			err := testclient.Client.Get(context.TODO(), goclient.ObjectKey{Name: "multi-networkpolicies.k8s.cni.cncf.io"}, crd)
+			crdPresent, err := networkpolicy.IsMultiEnabled()
 			Expect(err).ToNot(HaveOccurred())
+			Expect(crdPresent).To(BeTrue())
 		})
 
 		It("should have the daemonset in running state", func() {


### PR DESCRIPTION
Running tests with `FEATURE=sriov` triggers tests in multinetworkpolicy_sriov.go, even if the multinet policy feature is not enable. A guard on the feature present is therefore needed.

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>