### PR TITLE
Deploy the 4.12 version of optional operators

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -16,7 +16,7 @@ export GOFLAGS="${GOFLAGS:-"-mod=vendor"}"
 export PATH=$PATH:$GOPATH/bin
 
 export OCP_VERSION="${OCP_VERSION:-4.11}"
-export OPERATOR_VERSION="${OPERATOR_VERSION:-4.11}"
+export OPERATOR_VERSION="${OPERATOR_VERSION:-4.12}"
 export GATEKEEPER_VERSION="${GATEKEEPER_VERSION:-v0.2.0}"
 
 # the metallb-operator deployment and test namespace


### PR DESCRIPTION
We are now close to 4.12 release, we should be testing the 4.12 version of the operators. Plus, metallb 4.11 is not compatible with ocp 4.12 so we need to bump it.
