### PR TITLE
Bug 2094046: cnf-tests: verify minimal CPUs requirement for cyclictest test

### DIFF
--- a/cnf-tests/pod-utils/cyclictest-runner/main.go
+++ b/cnf-tests/pod-utils/cyclictest-runner/main.go
@@ -31,9 +31,22 @@ func main() {
 	}
 
 	mainThreadCPUs := selfCPUs.ToSlice()[0]
+	klog.Info("cyclictest main thread cpu: %d", mainThreadCPUs)
+
 	siblings, err := node.GetCPUSiblings(mainThreadCPUs)
 	if err != nil {
 		klog.Fatalf("failed to get main thread CPU siblings: %v", err)
+	}
+	klog.Info("cyclictest main thread's cpu siblings: %v", siblings)
+
+	// siblings > 1 means Hyper-threading enabled
+	if len(siblings) > 1 && selfCPUs.Size() == 2 {
+		// one CPU should be used to run cyclictest's main thread.
+		// the second is the sibling of the first one, which should be excluded from the list of the tested CPUs,
+		// because it might cause to false spikes (noisy-neighbor issue).
+		// the third one is the actual CPU to be tested, but due to SMT alignment restriction we need its sibling too.
+		// four in total.
+		klog.Fatalf("when hyper-threading enabled cyclictest pod requires at least 4 CPUs")
 	}
 
 	cpusForLatencyTest := selfCPUs.Difference(cpuset.NewCPUSet(siblings...))


### PR DESCRIPTION
We should handle the amount of minimal CPUs for cyclictest test more carefully. When HT disabled cyclictest needs 2 CPUs.

But when HT enabled oslat needs at least 4 CPUs:
One CPU should be used to run cyclictest's main thread. The second is the sibling of the first one, which should be excluded from the list of the tested CPUs, Because it might cause to false spikes (noisy-neighbor issue). The third one is the actual CPU to be tested, but due to SMT alignment restriction we need its sibling too. Four in total.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>