### PR TITLE
ztp: fix sno expansion tuned include directive

### DIFF
--- a/ztp/gitops-subscriptions/argocd/SNOExpansion.md
+++ b/ztp/gitops-subscriptions/argocd/SNOExpansion.md
@@ -184,7 +184,7 @@ spec:
             data: |
               [main]
               summary=Configuration changes profile inherited from performance created tuned
-              include=openshift-node-performance-openshift-node-performance-profile
+              include=openshift-node-performance-openshift-worker-node-performance-profile
               [bootloader]
               cmdline_crash=nohz_full=4-47
               [sysctl]


### PR DESCRIPTION
This commit fixes a copy-paste error in the tuned patch manifest for sno expansion.

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>

/cc @imiller0 @serngawy 