### PR TITLE
infra: Bump go to 1.18

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -3,7 +3,7 @@ FROM quay.io/fedora/fedora:34-x86_64
 ENV GOPATH /go
 ENV GOBIN /go/bin
 ENV GOCACHE /go/.cache
-ENV GOVERSION=1.17.2
+ENV GOVERSION=1.18.7
 ENV PATH=$PATH:/root/.gimme/versions/go"$GOVERSION".linux.amd64/bin:$GOBIN
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/cnf-features-deploy
 
@@ -28,8 +28,11 @@ RUN mkdir ~/bin && \
     eval "$(gimme $GOVERSION)" && \
     cat $GIMME_ENV >> $HOME/.bashrc && \
     # get required golang tools and OC client
-    go get github.com/onsi/ginkgo/ginkgo@v1.16.5 && \
-    go get github.com/onsi/gomega/...@v1.17.0 && \
+    go mod init placeholder.com/m && \
+    go get github.com/onsi/ginkgo/ginkgo && \
+    go install github.com/onsi/ginkgo/ginkgo && \
+    go get github.com/onsi/gomega/... && \
+    go install github.com/onsi/gomega/... && \
     go get -u golang.org/x/lint/golint && \
     go install github.com/lack/mcmaker@v0.0.5 && \
     export latest_oc_client_version=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ 2>/dev/null | grep -o \"openshift-client-linux-4.*tar.gz\" | tr -d \") && \


### PR DESCRIPTION
Update to k8s 1.24 brings along go 1.18.

Signed-off-by: Ian Miller <imiller@redhat.com>