### PR TITLE
cnf-tests: Filter tests by features suites

### DIFF
--- a/cnf-tests/TESTLIST.md
+++ b/cnf-tests/TESTLIST.md
@@ -96,7 +96,7 @@ The cnf tests instrument each different feature required by CNF. Following, a de
 | [sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ingress DENY all traffic to a pod | Verifies that an Ingress rules can deny any incoming traffic | 
 | [sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ingress DENY all traffic to and within a namespace | Verifies that an Ingress rules can deny all traffic in a namespace | 
 | [sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific UDP port from any pod | Verifies rules can be applied to specific UDP ports | 
-| [sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol SCTP [sctp] | Verifies rules can be applied to SCTP transport protocol | 
+| [sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol SCTP | Verifies rules can be applied to SCTP transport protocol | 
 | [sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol TCP | Verifies rules can be applied to TCP transport protocol | 
 | [sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol TCP+UDP | Verifies rules can be applied to multiple transport protocols | 
 | [sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol UDP | Verifies rules can be applied to UDP transport protocol | 
@@ -147,7 +147,6 @@ The cnf tests instrument each different feature required by CNF. Following, a de
 | [sctp] Test Connectivity Connectivity between client and server connect a client pod to a server pod via Service ClusterIP Default namespace | Pod to pod connectivity via service ClusterIP, default namespace | 
 | [sctp] Test Connectivity Connectivity between client and server connect a client pod to a server pod via Service Node Port Custom namespace | Pod to pod connectivity via service nodeport, custom namespace | 
 | [sctp] Test Connectivity Connectivity between client and server connect a client pod to a server pod via Service Node Port Default namespace | Pod to pod connectivity via service nodeport, default namespace | 
-| [sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol SCTP [sctp] | Verifies rules can be applied to SCTP transport protocol | 
 
 ## Performance
 

--- a/cnf-tests/docgen/e2e.json
+++ b/cnf-tests/docgen/e2e.json
@@ -170,7 +170,7 @@
     "[sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ingress DENY all traffic to a pod": "Verifies that an Ingress rules can deny any incoming traffic",
     "[sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ingress DENY all traffic to and within a namespace": "Verifies that an Ingress rules can deny all traffic in a namespace",
     "[sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific UDP port from any pod": "Verifies rules can be applied to specific UDP ports",
-    "[sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol SCTP [sctp]": "Verifies rules can be applied to SCTP transport protocol",
+    "[sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol SCTP": "Verifies rules can be applied to SCTP transport protocol",
     "[sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol TCP": "Verifies rules can be applied to TCP transport protocol",
     "[sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol TCP+UDP": "Verifies rules can be applied to multiple transport protocols",
     "[sriov] [multinetworkpolicy] MultiNetworkPolicy integration Ports/Protocol Allow access only to a specific port/protocol UDP": "Verifies rules can be applied to UDP transport protocol",

--- a/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go
@@ -612,7 +612,7 @@ var _ = Describe("[sriov] [multinetworkpolicy] MultiNetworkPolicy integration", 
 			}
 		})
 
-		It("Allow access only to a specific port/protocol SCTP [sctp]", func() {
+		It("Allow access only to a specific port/protocol SCTP", func() {
 
 			if !sctpEnabled {
 				Skip("SCTP not enabled on test nodes")

--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -31,7 +31,7 @@ elif [ "$FEATURES" == "" ]; then
 	echo "No FEATURES provided"
   exit 1
 else
-  FOCUS="-ginkgo.focus="$(echo "$FEATURES" | tr ' ' '|')
+  FOCUS="-ginkgo.focus="\\[$(echo "$FEATURES" | sed -e 's/ /\\]\|\\[/g')\\]
   if [ "$FOCUS_TESTS" != "" ]; then
     FOCUS="-ginkgo.focus="$(echo "$FOCUS_TESTS" | tr ' ' '|')
   fi


### PR DESCRIPTION
Adding brackets to focus on tests by feature. If FEATURES var is used for ginkgo focus we should do the filtering by suites ([feature]). Without the brackets we may run tests that have a feature name in their description while they belong to a feature suite that we don't want to currently test.