### PR TITLE
cnf-tests: improve sriov nic selector

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -709,6 +709,11 @@ func findSriovDeviceForDPDK(sriovInfos *sriovcluster.EnabledNodes, nodeNames []s
 				if sriovInfos.IsSecureBootEnabled[nodeName] && iface.Vendor == networks.MlxVendorID {
 					continue
 				}
+
+				if networks.IsIntelDisabledNic(iface) {
+					continue
+				}
+
 				return nodeName, &iface, true
 			}
 		}

--- a/cnf-tests/testsuites/pkg/networks/sriov.go
+++ b/cnf-tests/testsuites/pkg/networks/sriov.go
@@ -125,6 +125,16 @@ func GetSupportedSriovNics() (map[string]string, error) {
 	return supportedNicsConfigMap.Data, nil
 }
 
+// if the sriov is not able in the kernel for intel nic the totalVF will be 0 so we skip the device
+// That is not the case for Mellanox devices that will report 0 until we configure the sriov interfaces
+// with the mstconfig package
+func IsIntelDisabledNic(iface sriovv1.InterfaceExt) bool {
+	if iface.Vendor == IntelVendorID && iface.TotalVfs == 0 {
+		return true
+	}
+	return false
+}
+
 func CreateSriovPolicyAndNetworkDPDKOnlyWithVhost(dpdkResourceName, workerCnfLabelSelector string) {
 	createSriovPolicyAndNetwork(dpdkResourceName, workerCnfLabelSelector, true)
 }

--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ replace (
 
 // Test deps
 replace (
-	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20221115135951-db0df0e0ccc4 // release-4.12
+	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20221118104808-b97559f25392 // release-4.12
 	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c //release-4.11
 	github.com/openshift-kni/numaresources-operator => github.com/openshift-kni/numaresources-operator v0.4.10-3.2022042201
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10

--- a/go.sum
+++ b/go.sum
@@ -1213,8 +1213,8 @@ github.com/openshift/ptp-operator v0.0.0-20221109224215-0229788f84f5/go.mod h1:z
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912/go.mod h1:0OXNy7VoqFexkxKqyQbHJLPwn1MFp1/CxRJAgKHM+/o=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b h1:NlOsWwZI4tYu6XbqG1/9jtg2I20+zs+8vy7d4X7ieZs=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b/go.mod h1:ESuS9sfrzo0EpEHaHNEvjo1oThseBnGU5s+RT1psTRA=
-github.com/openshift/sriov-network-operator v0.0.0-20221115135951-db0df0e0ccc4 h1:6wRJvnhd9eKmjFdZRU54dtwRDTMX8Jm6oe5r2dV/mTU=
-github.com/openshift/sriov-network-operator v0.0.0-20221115135951-db0df0e0ccc4/go.mod h1:bcJm2FRKNOgAEh1QDZg7p4+QWYVw6RILXyHNXKV0oEo=
+github.com/openshift/sriov-network-operator v0.0.0-20221118104808-b97559f25392 h1:NGss7tLZl1spgTboi/0JnqnVzYzLMC3EubZn3+UGq7c=
+github.com/openshift/sriov-network-operator v0.0.0-20221118104808-b97559f25392/go.mod h1:bcJm2FRKNOgAEh1QDZg7p4+QWYVw6RILXyHNXKV0oEo=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster/cluster.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster/cluster.go
@@ -104,6 +104,13 @@ func (n *EnabledNodes) FindOneSriovDevice(node string) (*sriovv1.InterfaceExt, e
 				continue
 			}
 
+			// if the sriov is not able in the kernel for intel nic the totalVF will be 0 so we skip the device
+			// That is not the case for Mellanox devices that will report 0 until we configure the sriov interfaces
+			// with the mstconfig package
+			if itf.Vendor == intelVendorID && itf.TotalVfs == 0 {
+				continue
+			}
+
 			return &itf, nil
 		}
 	}
@@ -126,6 +133,13 @@ func (n *EnabledNodes) FindSriovDevices(node string) ([]*sriovv1.InterfaceExt, e
 				continue
 			}
 
+			// if the sriov is not able in the kernel for intel nic the totalVF will be 0 so we skip the device
+			// That is not the case for Mellanox devices that will report 0 until we configure the sriov interfaces
+			// with the mstconfig package
+			if itf.Vendor == intelVendorID && itf.TotalVfs == 0 {
+				continue
+			}
+
 			devices = append(devices, &s.Status.Interfaces[i])
 		}
 	}
@@ -136,7 +150,7 @@ func (n *EnabledNodes) FindSriovDevices(node string) ([]*sriovv1.InterfaceExt, e
 func (n *EnabledNodes) FindOneVfioSriovDevice() (string, sriovv1.InterfaceExt) {
 	for _, node := range n.Nodes {
 		for _, nic := range n.States[node].Status.Interfaces {
-			if nic.Vendor == intelVendorID && sriovv1.IsSupportedModel(nic.Vendor, nic.DeviceID) {
+			if nic.Vendor == intelVendorID && sriovv1.IsSupportedModel(nic.Vendor, nic.DeviceID) && nic.TotalVfs != 0 {
 				return node, nic
 			}
 		}

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster/cluster.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster/cluster.go
@@ -104,7 +104,7 @@ func (n *EnabledNodes) FindOneSriovDevice(node string) (*sriovv1.InterfaceExt, e
 				continue
 			}
 
-			// if the sriov is not able in the kernel for intel nic the totalVF will be 0 so we skip the device
+			// if the sriov is not enable in the kernel for intel nic the totalVF will be 0 so we skip the device
 			// That is not the case for Mellanox devices that will report 0 until we configure the sriov interfaces
 			// with the mstconfig package
 			if itf.Vendor == intelVendorID && itf.TotalVfs == 0 {
@@ -133,7 +133,7 @@ func (n *EnabledNodes) FindSriovDevices(node string) ([]*sriovv1.InterfaceExt, e
 				continue
 			}
 
-			// if the sriov is not able in the kernel for intel nic the totalVF will be 0 so we skip the device
+			// if the sriov is not enable in the kernel for intel nic the totalVF will be 0 so we skip the device
 			// That is not the case for Mellanox devices that will report 0 until we configure the sriov interfaces
 			// with the mstconfig package
 			if itf.Vendor == intelVendorID && itf.TotalVfs == 0 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -248,7 +248,7 @@ github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/client/clientset/version
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1
-# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20221115135951-db0df0e0ccc4
+# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20221118104808-b97559f25392
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
 github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/scheme
@@ -1373,7 +1373,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a
 # sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.0
 # sigs.k8s.io/json => sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2
-# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20221115135951-db0df0e0ccc4
+# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20221118104808-b97559f25392
 # github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c
 # github.com/openshift-kni/numaresources-operator => github.com/openshift-kni/numaresources-operator v0.4.10-3.2022042201
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b


### PR DESCRIPTION
this commit add a check to be sure for intel nics that we enable sriov in the bios. if that is not the case the totalvf variabel will be 0 so we skip that nic

Signed-off-by: Sebastian Sch <sebassch@gmail.com>