### PR TITLE
ztp: OCPBUGS-3389: SiteConfig does not support modifying install conf…

### DIFF
--- a/ztp/ran-crd/site-config-crd.yaml
+++ b/ztp/ran-crd/site-config-crd.yaml
@@ -112,6 +112,14 @@ spec:
                         enum:
                           - OVNKubernetes
                           - OpenShiftSDN
+                      installConfigOverrides:
+                        description: |
+                          InstallConfigOverrides allows to pass install config parameters to be added as 
+                          annotation in the AgentClusterInstall CR. The values provided at InstallConfigOverrides 
+                          must be in json format. For example: "{\"controlPlane\":{\"hyperthreading\":\"Disabled\"}}".
+                          This will transform installConfigOverrides and networkType as annotation for AgentClusterInstall as below:
+                          agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType":"OVNKubernetes"},"controlPlane":{"hyperthreading":"Disabled"}}'.                         
+                        type: string
                       clusterImageSetNameRef:
                         description: |
                           Reference to the cluster image set. This is the OCP release that will be used to

--- a/ztp/siteconfig-generator/siteConfig/siteConfig.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig.go
@@ -166,6 +166,7 @@ type Clusters struct {
 	ServiceNetwork         []string          `yaml:"serviceNetwork"`
 	ClusterLabels          map[string]string `yaml:"clusterLabels"`
 	NetworkType            string            `yaml:"networkType"`
+	InstallConfigOverrides string            `yaml:"installConfigOverrides,omitempty"`
 	ClusterNetwork         []ClusterNetwork  `yaml:"clusterNetwork"`
 	IgnitionConfigOverride string            `yaml:"ignitionConfigOverride"`
 	DiskEncryption         DiskEncryption    `yaml:"diskEncryption"`

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
@@ -75,11 +75,12 @@ func (scbuilder *SiteConfigBuilder) validateSiteConfig(siteConfigTemp SiteConfig
 		if clusters[siteConfigTemp.Metadata.Name+"/"+cluster.ClusterName] {
 			return errors.New("Error: Repeated Cluster Name " + siteConfigTemp.Metadata.Name + "/" + cluster.ClusterName)
 		}
-		if cluster.NetworkType != "OpenShiftSDN" && cluster.NetworkType != "OVNKubernetes" {
-			return errors.New("Error: networkType must be either OpenShiftSDN or OVNKubernetes " + siteConfigTemp.Metadata.Name + "/" + cluster.ClusterName)
-		}
 
-		siteConfigTemp.Spec.Clusters[id].NetworkType = "{\"networking\":{\"networkType\":\"" + cluster.NetworkType + "\"}}"
+		var err error
+		siteConfigTemp.Spec.Clusters[id].NetworkType, err = agentClusterInstallAnnotation(cluster.NetworkType, cluster.InstallConfigOverrides)
+		if err != nil {
+			return errors.New("Error: " + err.Error())
+		}
 
 		if siteConfigTemp.Spec.ClusterImageSetNameRef == "" && siteConfigTemp.Spec.Clusters[id].ClusterImageSetNameRef == "" {
 			return errors.New("Error: Site and cluster clusterImageSetNameRef cannot be empty " + siteConfigTemp.Metadata.Name + "/" + cluster.ClusterName)

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
@@ -13,7 +13,7 @@ apiVersion: extensions.hive.openshift.io/v1beta1
 kind: AgentClusterInstall
 metadata:
     annotations:
-        agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType":"OVNKubernetes"}}'
+        agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType":"OVNKubernetes"},"controlPlane":{"hyperthreading":"Disabled"}}'
         argocd.argoproj.io/sync-wave: "1"
         ran.openshift.io/ztp-gitops-generated: '{}'
     name: cluster1


### PR DESCRIPTION
Introduces a new field named installConfigOverrides in the Siteconfig, which allows to pass the install config parameters to be set at annotations in AgentClusterInstall CR.Unit tests have been adapted to validate the changes

Signed-off-by: Sabbir Hasan <sahasan@redhat.com>

/cc @imiller0 @serngawy @browsell 