### PR TITLE
[release-4.11] cnf-tests: Filter tests by features suites

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -31,7 +31,7 @@ elif [ "$FEATURES" == "" ]; then
 	echo "No FEATURES provided"
   exit 1
 else
-  FOCUS="-ginkgo.focus="$(echo "$FEATURES" | tr ' ' '|')
+  FOCUS="-ginkgo.focus="\\[$(echo "$FEATURES" | sed -e 's/ /\\]\|\\[/g')\\]
   if [ "$FOCUS_TESTS" != "" ]; then
     FOCUS="-ginkgo.focus="$(echo "$FOCUS_TESTS" | tr ' ' '|')
   fi


### PR DESCRIPTION
Adding brackets to focus on tests by feature. If FEATURES var is used for ginkgo focus we should do the filtering by suites ([feature]). Without the brackets we may run tests that have a feature name in their description while they belong to a feature suite that we don't want to currently test.