### PR TITLE
ztp: OCPBUGS-3005: set step_threshold to 2.0

### DIFF
--- a/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-grandmaster.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-grandmaster.yaml
@@ -77,7 +77,7 @@ spec:
       pi_integral_scale 0.0
       pi_integral_exponent 0.4
       pi_integral_norm_max 0.3
-      step_threshold 0.0
+      step_threshold 2.0
       first_step_threshold 0.00002
       max_frequency 900000000
       clock_servo pi

--- a/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-slave.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/du-general/ptp/ptpconfig-slave.yaml
@@ -74,7 +74,7 @@ spec:
       pi_integral_scale 0.0
       pi_integral_exponent 0.4
       pi_integral_norm_max 0.3
-      step_threshold 0.0
+      step_threshold 2.0
       first_step_threshold 0.00002
       max_frequency 900000000
       clock_servo pi

--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-grandmaster.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-grandmaster.yaml
@@ -75,7 +75,7 @@ spec:
       pi_integral_scale 0.0
       pi_integral_exponent 0.4
       pi_integral_norm_max 0.3
-      step_threshold 0.0
+      step_threshold 2.0
       first_step_threshold 0.00002
       max_frequency 900000000
       clock_servo pi

--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-slave.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp/ptpconfig-slave.yaml
@@ -75,7 +75,7 @@ spec:
       pi_integral_scale 0.0
       pi_integral_exponent 0.4
       pi_integral_norm_max 0.3
-      step_threshold 0.0
+      step_threshold 2.0
       first_step_threshold 0.00002
       max_frequency 900000000
       clock_servo pi

--- a/ztp/policygenerator/testData/TestPtpConfig/sourcePolicies/TestPtpConfig.yaml
+++ b/ztp/policygenerator/testData/TestPtpConfig/sourcePolicies/TestPtpConfig.yaml
@@ -74,7 +74,7 @@ spec:
         pi_integral_scale 0.0
         pi_integral_exponent 0.4
         pi_integral_norm_max 0.3
-        step_threshold 0.0
+        step_threshold 2.0
         first_step_threshold 0.00002
         max_frequency 900000000
         clock_servo pi

--- a/ztp/source-crs/PtpConfigMaster.yaml
+++ b/ztp/source-crs/PtpConfigMaster.yaml
@@ -79,7 +79,7 @@ spec:
       pi_integral_scale 0.0
       pi_integral_exponent 0.4
       pi_integral_norm_max 0.3
-      step_threshold 0.0
+      step_threshold 2.0
       first_step_threshold 0.00002
       max_frequency 900000000
       clock_servo pi

--- a/ztp/source-crs/PtpConfigSlave.yaml
+++ b/ztp/source-crs/PtpConfigSlave.yaml
@@ -77,7 +77,7 @@ spec:
       pi_integral_scale 0.0
       pi_integral_exponent 0.4
       pi_integral_norm_max 0.3
-      step_threshold 0.0
+      step_threshold 2.0
       first_step_threshold 0.00002
       max_frequency 900000000
       clock_servo pi

--- a/ztp/source-crs/PtpConfigSlaveCvl.yaml
+++ b/ztp/source-crs/PtpConfigSlaveCvl.yaml
@@ -78,7 +78,7 @@ spec:
       pi_integral_scale 0.0
       pi_integral_exponent 0.4
       pi_integral_norm_max 0.3
-      step_threshold 0.0
+      step_threshold 2.0
       first_step_threshold 0.00002
       max_frequency 900000000
       clock_servo pi


### PR DESCRIPTION
This change is to allow faster reconciliation when a slave goes out of sync, for example from receiving invalid time from GM.

Closes-Bug: OCPBUGS-3005