### PR TITLE
cnf-tests: sriov-network-operator bump 4.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ replace (
 
 // Test deps
 replace (
-	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20220822150116-4a80ee96015c // release-4.12
+	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20221115135951-db0df0e0ccc4 // release-4.12
 	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c //release-4.11
 	github.com/openshift-kni/numaresources-operator => github.com/openshift-kni/numaresources-operator v0.4.10-3.2022042201
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10

--- a/go.sum
+++ b/go.sum
@@ -1213,8 +1213,8 @@ github.com/openshift/ptp-operator v0.0.0-20221020063004-f41bc4e431fb/go.mod h1:N
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912/go.mod h1:0OXNy7VoqFexkxKqyQbHJLPwn1MFp1/CxRJAgKHM+/o=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b h1:NlOsWwZI4tYu6XbqG1/9jtg2I20+zs+8vy7d4X7ieZs=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b/go.mod h1:ESuS9sfrzo0EpEHaHNEvjo1oThseBnGU5s+RT1psTRA=
-github.com/openshift/sriov-network-operator v0.0.0-20220822150116-4a80ee96015c h1:caMf54aWe/AaMlZiAORg3DFPZ1DyBVynsjf/vmmgT8c=
-github.com/openshift/sriov-network-operator v0.0.0-20220822150116-4a80ee96015c/go.mod h1:sSLMDmMv2QqnxrmBA7jVv8PxefqxkZPFxFNDwZedtqc=
+github.com/openshift/sriov-network-operator v0.0.0-20221115135951-db0df0e0ccc4 h1:6wRJvnhd9eKmjFdZRU54dtwRDTMX8Jm6oe5r2dV/mTU=
+github.com/openshift/sriov-network-operator v0.0.0-20221115135951-db0df0e0ccc4/go.mod h1:bcJm2FRKNOgAEh1QDZg7p4+QWYVw6RILXyHNXKV0oEo=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/groupversion_info.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the sriovnetwork v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=sriovnetwork.openshift.io
+// +kubebuilder:object:generate=true
+// +groupName=sriovnetwork.openshift.io
 package v1
 
 import (

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/helper.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/helper.go
@@ -29,6 +29,13 @@ const (
 	POOLCONFIGFINALIZERNAME = "poolconfig.finalizers.sriovnetwork.openshift.io"
 	ESwithModeLegacy        = "legacy"
 	ESwithModeSwitchDev     = "switchdev"
+
+	SriovCniStateEnable  = "enable"
+	SriovCniStateDisable = "disable"
+	SriovCniStateAuto    = "auto"
+	SriovCniStateOff     = "off"
+	SriovCniStateOn      = "on"
+	SriovCniIpamEmpty    = "\"ipam\":{}"
 )
 
 const invalidVfIndex = -1
@@ -59,7 +66,7 @@ func (e NetFilterType) String() string {
 	}
 }
 
-func InitNicIDMap(client *kubernetes.Clientset, namespace string) error {
+func InitNicIDMap(client kubernetes.Interface, namespace string) error {
 	cm, err := client.CoreV1().ConfigMaps(namespace).Get(
 		context.Background(),
 		SupportedNicIDConfigmap,
@@ -479,12 +486,12 @@ func (cr *SriovIBNetwork) RenderNetAttDef() (*uns.Unstructured, error) {
 
 	data.Data["StateConfigured"] = true
 	switch cr.Spec.LinkState {
-	case "enable":
-		data.Data["SriovCniState"] = "enable"
-	case "disable":
-		data.Data["SriovCniState"] = "disable"
-	case "auto":
-		data.Data["SriovCniState"] = "auto"
+	case SriovCniStateEnable:
+		data.Data["SriovCniState"] = SriovCniStateEnable
+	case SriovCniStateDisable:
+		data.Data["SriovCniState"] = SriovCniStateDisable
+	case SriovCniStateAuto:
+		data.Data["SriovCniState"] = SriovCniStateAuto
 	default:
 		data.Data["StateConfigured"] = false
 	}
@@ -499,7 +506,7 @@ func (cr *SriovIBNetwork) RenderNetAttDef() (*uns.Unstructured, error) {
 	if cr.Spec.IPAM != "" {
 		data.Data["SriovCniIpam"] = "\"ipam\":" + strings.Join(strings.Fields(cr.Spec.IPAM), "")
 	} else {
-		data.Data["SriovCniIpam"] = "\"ipam\":{}"
+		data.Data["SriovCniIpam"] = SriovCniIpamEmpty
 	}
 
 	// metaplugins for the infiniband cni
@@ -575,32 +582,32 @@ func (cr *SriovNetwork) RenderNetAttDef() (*uns.Unstructured, error) {
 
 	data.Data["SpoofChkConfigured"] = true
 	switch cr.Spec.SpoofChk {
-	case "off":
-		data.Data["SriovCniSpoofChk"] = "off"
-	case "on":
-		data.Data["SriovCniSpoofChk"] = "on"
+	case SriovCniStateOff:
+		data.Data["SriovCniSpoofChk"] = SriovCniStateOff
+	case SriovCniStateOn:
+		data.Data["SriovCniSpoofChk"] = SriovCniStateOn
 	default:
 		data.Data["SpoofChkConfigured"] = false
 	}
 
 	data.Data["TrustConfigured"] = true
 	switch cr.Spec.Trust {
-	case "on":
-		data.Data["SriovCniTrust"] = "on"
-	case "off":
-		data.Data["SriovCniTrust"] = "off"
+	case SriovCniStateOn:
+		data.Data["SriovCniTrust"] = SriovCniStateOn
+	case SriovCniStateOff:
+		data.Data["SriovCniTrust"] = SriovCniStateOff
 	default:
 		data.Data["TrustConfigured"] = false
 	}
 
 	data.Data["StateConfigured"] = true
 	switch cr.Spec.LinkState {
-	case "enable":
-		data.Data["SriovCniState"] = "enable"
-	case "disable":
-		data.Data["SriovCniState"] = "disable"
-	case "auto":
-		data.Data["SriovCniState"] = "auto"
+	case SriovCniStateEnable:
+		data.Data["SriovCniState"] = SriovCniStateEnable
+	case SriovCniStateDisable:
+		data.Data["SriovCniState"] = SriovCniStateDisable
+	case SriovCniStateAuto:
+		data.Data["SriovCniState"] = SriovCniStateAuto
 	default:
 		data.Data["StateConfigured"] = false
 	}
@@ -624,7 +631,7 @@ func (cr *SriovNetwork) RenderNetAttDef() (*uns.Unstructured, error) {
 	if cr.Spec.IPAM != "" {
 		data.Data["SriovCniIpam"] = "\"ipam\":" + strings.Join(strings.Fields(cr.Spec.IPAM), "")
 	} else {
-		data.Data["SriovCniIpam"] = "\"ipam\":{}"
+		data.Data["SriovCniIpam"] = SriovCniIpamEmpty
 	}
 
 	data.Data["MetaPluginsConfigured"] = false

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/scheme/register.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/scheme/register.go
@@ -21,14 +21,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/clean/clean.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/clean/clean.go
@@ -26,9 +26,7 @@ func All() error {
 			return fmt.Errorf("failed to restore node drain state %v", err)
 		}
 	}
-	if !namespaces.Exists(namespaces.Test, clients) {
-		return nil
-	}
+
 	err := namespaces.DeleteAndWait(clients, namespaces.Test, 5*time.Minute)
 	if err != nil {
 		return fmt.Errorf("failed to delete sriov tests namespace %v", err)

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/namespaces/namespaces.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/namespaces/namespaces.go
@@ -20,6 +20,13 @@ import (
 // Test is the namespace to be use for testing
 const Test = "sriov-conformance-testing"
 
+var inhibitSecurityAdmissionLabels = map[string]string{
+	"pod-security.kubernetes.io/audit":               "privileged",
+	"pod-security.kubernetes.io/enforce":             "privileged",
+	"pod-security.kubernetes.io/warn":                "privileged",
+	"security.openshift.io/scc.podSecurityLabelSync": "false",
+}
+
 // WaitForDeletion waits until the namespace will be removed from the cluster
 func WaitForDeletion(cs *testclient.ClientSet, nsName string, timeout time.Duration) error {
 	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
@@ -36,7 +43,8 @@ func WaitForDeletion(cs *testclient.ClientSet, nsName string, timeout time.Durat
 func Create(namespace string, cs *testclient.ClientSet) error {
 	_, err := cs.Namespaces().Create(context.Background(), &k8sv1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name:   namespace,
+			Labels: inhibitSecurityAdmissionLabels,
 		}}, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
@@ -45,12 +53,17 @@ func Create(namespace string, cs *testclient.ClientSet) error {
 	return err
 }
 
-// DeleteAndWait deletes a namespace and waits until delete
+// DeleteAndWait deletes a namespace and waits until it is deleted
 func DeleteAndWait(cs *testclient.ClientSet, namespace string, timeout time.Duration) error {
 	err := cs.Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
-	if err != nil {
-		return err
+	if k8serrors.IsNotFound(err) {
+		return nil
 	}
+
+	if err != nil {
+		return fmt.Errorf("failed to delete namespace [%s]: %w", namespace, err)
+	}
+
 	return WaitForDeletion(cs, namespace, timeout)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -248,7 +248,7 @@ github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/client/clientset/version
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1
-# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20220822150116-4a80ee96015c
+# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20221115135951-db0df0e0ccc4
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
 github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/scheme
@@ -1372,7 +1372,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a
 # sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.0
 # sigs.k8s.io/json => sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2
-# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20220822150116-4a80ee96015c
+# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20221115135951-db0df0e0ccc4
 # github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c
 # github.com/openshift-kni/numaresources-operator => github.com/openshift-kni/numaresources-operator v0.4.10-3.2022042201
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b


### PR DESCRIPTION
SR-IOV Network Operator dependency bumped with commands:

```
go mod edit -replace\
github.com/k8snetworkplumbingwg/sriov-network-operator=\
github.com/openshift/sriov-network-operator@release-4.12
go mod tidy
go mod vendor
```

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>