### PR TITLE
ztp: Adds LVM operator source crs for ZTP

### DIFF
--- a/ztp/source-crs/StorageLVMCluster.yaml
+++ b/ztp/source-crs/StorageLVMCluster.yaml
@@ -1,0 +1,18 @@
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: odf-lvmcluster
+  namespace: openshift-storage
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec: {}
+
+#example: creating a vg1 volume group leveraging all available disks on the node
+#         except the installation disk.
+#  storage:
+#    deviceClasses:
+#    - name: vg1
+#      thinPoolConfig:
+#        name: thin-pool-1
+#        sizePercent: 90
+#        overprovisionRatio: 10

--- a/ztp/source-crs/StorageLVMOSubscription.yaml
+++ b/ztp/source-crs/StorageLVMOSubscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: odf-lvm-operator
+  namespace: openshift-storage
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  channel: "stable-4.11"
+  name: odf-lvm-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/ztp/source-crs/StorageLVMOSubscriptionNS.yaml
+++ b/ztp/source-crs/StorageLVMOSubscriptionNS.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-storage
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"

--- a/ztp/source-crs/StorageLVMOSubscriptionOperGroup.yaml
+++ b/ztp/source-crs/StorageLVMOSubscriptionOperGroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: odf-lvm-operator-operatorgroup
+  namespace: openshift-storage
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  targetNamespaces:
+  - openshift-storage


### PR DESCRIPTION
Adds all the required manifests to install and configure the LVM Operator. Basically the subscription, operatorgroup and namespace (install) and the lvmcluster (configuration).

Signed-off-by: Alberto Losada <alosadag@redhat.com>

cc/ @imiller0 

