### PR TITLE
fix for ptp interfaces test failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -193,6 +193,7 @@ replace (
 	github.com/openshift/cluster-node-tuning-operator => github.com/openshift/cluster-node-tuning-operator v0.0.0-20221109154259-940cf4ab1d74 // release-4.13
 	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20221012165547-f859132ee700 // release-4.8
 	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a // release-4.8
+	github.com/test-network-function/l2discovery-lib => github.com/test-network-function/l2discovery-lib v0.0.5
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.0
 	sigs.k8s.io/json => sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2
 )

--- a/go.sum
+++ b/go.sum
@@ -1493,8 +1493,8 @@ github.com/test-network-function/graphsolver-lib v0.0.2/go.mod h1:X9HIBAST5obDb8
 github.com/test-network-function/l2discovery-exports v0.0.0-20220909220625-69bfab4b0fc1/go.mod h1:RczK2vQ2EHQiz/LtLW9Et8xFPngY8dC9ep2tPY+31UI=
 github.com/test-network-function/l2discovery-exports v0.0.1 h1:4/49T2Js92JyOAO8T+0vnV8zy5z6WaV1GCfLGmEgs7g=
 github.com/test-network-function/l2discovery-exports v0.0.1/go.mod h1:LXzJLrM5Ao0j4pN/HnlYrBQDpO3TCtlfiK4HmRk2ps8=
-github.com/test-network-function/l2discovery-lib v0.0.2 h1:bEdF16r4bxN9SEJqvUBl9QVDb+VB6CJS7tli6cGaFDw=
-github.com/test-network-function/l2discovery-lib v0.0.2/go.mod h1:h3UimGqykQ92YTeCsQekV3pU+rFcPOmPxS2ZEFhxSY0=
+github.com/test-network-function/l2discovery-lib v0.0.5 h1:rgH5Y7lIu0R7L4uXEu2f9UAL9DTZ+vaUGuKBjy+UMY0=
+github.com/test-network-function/l2discovery-lib v0.0.5/go.mod h1:h3UimGqykQ92YTeCsQekV3pU+rFcPOmPxS2ZEFhxSY0=
 github.com/test-network-function/privileged-daemonset v0.0.4 h1:MuBFeUq9tqaI09LH30yqqbmKUQnN7HXiVXbLgKNe8vg=
 github.com/test-network-function/privileged-daemonset v0.0.4/go.mod h1:c5m+hDVcPkn+pMYUNqGhB8N2ezc1mtxTOt/e7PCU94A=
 github.com/tetafro/godot v1.4.6/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -614,7 +614,7 @@ github.com/test-network-function/graphsolver-lib
 # github.com/test-network-function/l2discovery-exports v0.0.1
 ## explicit; go 1.19
 github.com/test-network-function/l2discovery-exports
-# github.com/test-network-function/l2discovery-lib v0.0.2
+# github.com/test-network-function/l2discovery-lib v0.0.2 => github.com/test-network-function/l2discovery-lib v0.0.5
 ## explicit; go 1.19
 github.com/test-network-function/l2discovery-lib
 github.com/test-network-function/l2discovery-lib/pkg/l2client
@@ -1371,6 +1371,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/cluster-node-tuning-operator => github.com/openshift/cluster-node-tuning-operator v0.0.0-20221109154259-940cf4ab1d74
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20221012165547-f859132ee700
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a
+# github.com/test-network-function/l2discovery-lib => github.com/test-network-function/l2discovery-lib v0.0.5
 # sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.0
 # sigs.k8s.io/json => sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2
 # github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20221118104808-b97559f25392


### PR DESCRIPTION
This is to fix a failure with the ptp node device interface test due to Virtual functions not removed from the list of potential PTP interfaces