### PR TITLE
OCPBUGS-4378: Fix the hwlatdetect default window duration

### DIFF
--- a/cnf-tests/pod-utils/hwlatdetect-runner/main.go
+++ b/cnf-tests/pod-utils/hwlatdetect-runner/main.go
@@ -20,8 +20,8 @@ func main() {
 	threshold := flag.Int("threshold", 20, " value above which is considered an hardware latency")
 	hardlimit := flag.Int("hardlimit", 20, " value above which the test is considered to fail")
 	duration := flag.String("duration", "15s", "total time to test for hardware latency: <n>{smdw}")
-	window := flag.Duration("window", time.Microsecond*10000000, "time between samples: <n>{usmss}")
-	width := flag.Duration("width", time.Microsecond*950000, "time to actually measure: <n>{usmss}")
+	window := flag.Duration("window", time.Microsecond*1_000_000, "time between samples: <n>{usmss}")
+	width := flag.Duration("width", time.Microsecond*950_000, "time to actually measure: <n>{usmss}")
 	hwlatdetectStartDelay := flag.Int("hwlatdetect-start-delay", 0, "delay in second before running the hwlatdetect binary")
 
 	flag.Parse()


### PR DESCRIPTION
The window length and width determine how often will hwlat detector check for cpu time unaccounted for.

Our opinionated default should be 95% of every second.

There was a typo in the code that reduced that to 9.5% as it was scanning for 0.95 s every 10 s. This patch fixes that.