### PR TITLE
infra: Add feature-deploy-on-ci task to Makefile for U/S CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,11 @@ wait-and-validate:
 	@echo "Validating"
 	SKIP_TESTS="$(SKIP_TESTS)" DONT_FOCUS=true TEST_SUITES="validationsuite" hack/run-functests.sh
 
-functests-on-ci: setup-test-cluster setup-build-index-image feature-deploy feature-wait functests
+functests-on-ci: feature-deploy-on-ci functests
 
 functests-on-ci-no-index-build: setup-test-cluster feature-deploy feature-wait functests
+
+feature-deploy-on-ci: setup-test-cluster setup-build-index-image feature-deploy feature-wait
 
 origin-tests:
 	@echo "Running origin-tests"


### PR DESCRIPTION
One of jobs will need to deploy features, but not to run functest. It will run origin tests probably. Add a task that prepare for it.