### PR TITLE
cnf-tests: add PSA for performance tests` NS

### DIFF
--- a/cnf-tests/testsuites/pkg/namespaces/namespaces.go
+++ b/cnf-tests/testsuites/pkg/namespaces/namespaces.go
@@ -129,7 +129,7 @@ func Create(namespace string, cs corev1client.NamespacesGetter) error {
 		metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {
-		return nil
+		return AddPSALabelsToNamespace(namespace, cs)
 	}
 	return err
 }


### PR DESCRIPTION
The performance testing are running privileged pods, hence we need to annotate the performance testing namespace, to signal we need higher privileges.

The risk is minimal, since this is a controled environment and the namespace will get deleted at the end of the test anyway.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>