### PR TITLE
cnf-tests: psa: don't bail out if labels are missing

### DIFF
--- a/cnf-tests/testsuites/pkg/namespaces/namespaces.go
+++ b/cnf-tests/testsuites/pkg/namespaces/namespaces.go
@@ -141,10 +141,8 @@ func AddPSALabelsToNamespace(namespace string, cs corev1client.NamespacesGetter)
 	}
 
 	if ns.Labels == nil {
-		ns.Labels = GetPSALabels()
-		return nil
+		ns.Labels = make(map[string]string)
 	}
-
 	for k, v := range GetPSALabels() {
 		ns.Labels[k] = v
 	}


### PR DESCRIPTION
If the namespace we want to add PSA labels to has no labels at all, the current code adds the PSA labels and drops out, without Update()ing back the namespace object in the apiserver. This seems wrong, but probably never triggers because k8s namespace already have labels provided by the system.

Nevertheless, let's make sure we update back also in this flow.

Signed-off-by: Francesco Romani <fromani@redhat.com>