### PR TITLE
Add diskpartition attributes and doc to Siteconfig CRD

### DIFF
--- a/ztp/ran-crd/site-config-crd.yaml
+++ b/ztp/ran-crd/site-config-crd.yaml
@@ -237,7 +237,7 @@ spec:
                                   type: string
                       diskPartition:
                         description: /
-                          Optional disk partition paremeters. It can be only used to partition an existing disk to store Images of a Registry. So, the Start param has to be set minimum to 25000
+                          Optional disk partition parameters. It can be only used to partition an existing disk to store Images of a Registry. So, the start parameter has to be set minimum to 25000
                         type: array
                         items:
                           type: object

--- a/ztp/ran-crd/site-config-crd.yaml
+++ b/ztp/ran-crd/site-config-crd.yaml
@@ -235,6 +235,34 @@ spec:
                                 thumbprint:
                                   description: Tang server trusted thumbprint
                                   type: string
+                      diskPartition:
+                        description: /
+                          Optional disk partition paremeters. It can be only used to partition an existing disk to store Images of a Registry. So, the Start param has to be set minimum to 25000
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            device:
+                              description: A Linux device name like "/dev/vda". The hint must match the actual value exactly.
+                              type: string
+                            partitions:
+                              description: A list of partitions
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  mount_point: 
+                                    description: The mount-point of the filesystem. Absolute value, ex /var/registry
+                                    type: string
+                                  start:
+                                    description: The first sector to be used by the partition. Minimum value 25000
+                                    type: int
+                                  size:
+                                    description: Partition size
+                                    type: int
+                                  file_system_format:
+                                    description:  the filesystem format (ext4, btrfs, xfs, vfat, or swap). xfs by default
+                                    type: string
                       crTemplates:
                         description: |
                           An optional map of CR type names to file paths which


### PR DESCRIPTION
Not sure about the description of all the parameters. Maybe this is documented in other place, but it took me a while to understand how to use this feature. Now, the only way of using it, it is to understand how the image-registry MC works. Or, following: 
https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/gitops-subscriptions/argocd/ImageRegistry.md

