### PR TITLE
ran-profile CI and ZTP policygenerator intergration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,12 @@ origin-tests-disconnected-environment:
 
 validate-on-ci: setup-test-cluster setup-build-index-image feature-deploy wait-and-validate
 
+ran-profile-ci: generate-ran-artifacts validate-on-ci
+
+generate-ran-artifacts:
+	@echo "Generating the RAN DU features"
+	hack/generate-ran-artifacts.sh
+
 gofmt:
 	@echo "Running gofmt"
 	hack/gofmt.sh

--- a/feature-configs/cn-ran-overlays/ran-profile-std-cloud/policygentemplates/common-ranGen-overrides.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile-std-cloud/policygentemplates/common-ranGen-overrides.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  # The name should be same as the one defined in ran-profile common PGT
+  name: "common-latest"
+  namespace: "ztp-common"
+spec:
+  sourceFiles:
+    - fileName: SriovSubscription.yaml
+      policyName: "subscriptions-policy"
+      spec:
+        channel: "alpha"
+        source: ci-index
+        installPlanApproval: Automatic
+    - fileName: PtpSubscription.yaml
+      policyName: "subscriptions-policy"
+      spec:
+        channel: "alpha"
+        source: ci-index
+        installPlanApproval: Automatic
+    - fileName: ClusterLogSubscription.yaml
+      policyName: "subscriptions-policy"
+      spec:
+        installPlanApproval: Automatic
+    - fileName: StorageSubscription.yaml
+      policyName: "subscriptions-policy"
+      spec:
+        installPlanApproval: Automatic

--- a/feature-configs/cn-ran-overlays/ran-profile-std-cloud/policygentemplates/group-du-standard-ranGen-overrides.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile-std-cloud/policygentemplates/group-du-standard-ranGen-overrides.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  # The name should be same as the one defined in ran-profile group-du-standard PGT
+  name: "group-du-standard-latest"
+  namespace: "ztp-group"
+spec:
+  mcp: "worker-cnf"
+  sourceFiles:
+    - fileName: PtpConfigSlave.yaml
+      policyName: "config-policy"
+      metadata:
+        name: "du-ptp-slave"
+      spec:
+        profile:
+        - interface: "ens5"
+    - fileName: PerformanceProfile.yaml
+      policyName: "config-policy"
+      spec:
+        additionalKernelArgs: []
+        cpu:
+          isolated: "0"
+          reserved: "1-3"
+        hugepages:
+          defaultHugepagesSize: 1G
+          pages:
+          - count: 1
+            node: 0
+            size: 1G
+    - fileName: TunedPerformancePatch.yaml
+      policyName: "config-policy"
+      spec:
+        profile:
+          - name: performance-patch
+            data: |
+              [main]
+              summary=Configuration changes profile inherited from performance created tuned
+              include=openshift-node-performance-openshift-node-performance-profile
+              [sysctl]
+              kernel.timer_migration=1
+              [scheduler]
+              group.ice-ptp=0:f:10:*:ice-ptp.*
+              [service]
+              service.stalld=start,enable
+              service.chronyd=stop,disable
+    - fileName: optional-extra-manifest/enable-crun-worker.yaml
+      policyName: "config-policy"
+      metadata:
+        name: enable-crun-worker-cnf
+      spec:
+        machineConfigPoolSelector:
+            matchLabels:
+                pools.operator.machineconfiguration.openshift.io/worker-cnf: ""
+    - fileName: MachineConfigSctp.yaml
+      policyName: "config-policy"
+    - fileName: MachineConfigSctp.yaml
+      policyName: "config-policy"
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker-cnf
+        name: load-sctp-module-worker-cnf

--- a/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/common-ranGen.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/common-ranGen.yaml
@@ -1,0 +1,1 @@
+../../../../ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml

--- a/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/example-multinode-site.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/example-multinode-site.yaml
@@ -1,0 +1,1 @@
+../../../../ztp/gitops-subscriptions/argocd/example/policygentemplates/example-multinode-site.yaml

--- a/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/example-sno-site.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/example-sno-site.yaml
@@ -1,0 +1,1 @@
+../../../../ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml

--- a/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/group-du-3node-ranGen.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/group-du-3node-ranGen.yaml
@@ -1,0 +1,1 @@
+../../../../ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml

--- a/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/group-du-sno-ranGen.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/group-du-sno-ranGen.yaml
@@ -1,0 +1,1 @@
+../../../../ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml

--- a/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/group-du-standard-ranGen.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/policygentemplates/group-du-standard-ranGen.yaml
@@ -1,0 +1,1 @@
+../../../../ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml

--- a/hack/generate-ran-artifacts.sh
+++ b/hack/generate-ran-artifacts.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# generate du ran artifacts based on the given PGTs
+
+set -e
+
+# Set ENV variables for ztp generator cli
+export policyGenPath=$(pwd)/feature-configs/${FEATURES_ENVIRONMENT}/${FEATURES}/policyGen
+
+feature=${FEATURES}
+du_source_profile="ran-profile"
+du_ci_std_profile="ran-profile-std-cloud"
+
+# Supported DU features
+du_features=($du_source_profile $du_ci_std_profile)
+
+if [ "$FEATURES_ENVIRONMENT" != "cn-ran-overlays" ]; then
+	echo "[ERROR]: FEATURES_ENVIRONMENT $FEATURES_ENVIRONMENT is not cn-ran-overlays"
+	exit 1
+fi
+
+if [[ ! "${du_features[@]}" =~ "$feature" ]]; then
+	echo "[ERROR]: FEATURES $FEATURES is not a DU feature"
+	exit 1
+fi
+
+# Prepare resources required by ztp generator cli
+ztp_generator_cli=ztp/resource-generator/entrypoints/generator
+mkdir -p ${policyGenPath}
+cp -r ztp/source-crs ${policyGenPath}
+go build -o ${policyGenPath}/PolicyGenTemplate ./ztp/policygenerator
+
+cluster_type="${CLUSTER_TYPE:-standard}"
+if [ $feature == $du_ci_std_profile ]; then
+    cluster_type="standard"
+fi
+
+feature_env_dir=$(pwd)/feature-configs/${FEATURES_ENVIRONMENT}/
+feature_dir=${feature_env_dir}/${feature}/
+source_du_dir=${feature_env_dir}/${du_source_profile}
+output_artifacts_dir=${feature_dir}/cluster-config
+
+# Determine source PGTs based on cluster type
+source_pgts=("common-ranGen.yaml")
+if [ $cluster_type == "standard" ];then
+    source_pgts+=("group-du-standard-ranGen.yaml" "example-multinode-site.yaml")
+elif [ $cluster_type == "sno" ]; then
+    source_pgts+=("group-du-sno-ranGen.yaml" "example-sno-site.yaml")
+elif [ $cluster_type == "3node" ]; then
+    source_pgts+=("group-du-3node-ranGen.yaml" "example-multinode-site.yaml")
+fi
+
+# Call ztp generator cli to generate the non-policy wrapped cluster config CRs based on the source PGTs
+# and export the generated CRs to the $feature_dir/cluster-config
+for source_pgt in "${source_pgts[@]}"; do
+    source_config_CRs="${ztp_generator_cli} config -N ${source_du_dir}/policygentemplates/${source_pgt} ${output_artifacts_dir}"
+    if ! $source_config_CRs; then
+        echo "[ERROR] Failed to generate the configuration CRs based on the source PGT: ${source_du_dir}/policygentemplates/${source_pgt}"
+        exit 1
+    fi
+done
+
+# Call ztp generator cli to generate the configuration CRs based on the overrided PGTs for CI environment
+# and export the generated CRs to the $feature_dir/cluster-config.
+# The PGTs in the CI feature repo don't overwrite everything but only define the least necessary updates
+# for the CI test cluster and the newly generated CRs will replace the old ones generated based on the
+# source PGTs above.
+if [ $feature != $du_source_profile ]; then
+    ci_config_CRs="${ztp_generator_cli} config -N ${feature_dir}/policygentemplates ${output_artifacts_dir}"
+    if ! $ci_config_CRs; then
+        echo "[ERROR] Failed to generate the configuration CRs based on the overrided PGTs for CI environment: ${feature_dir}/policygentemplates"
+        exit 1
+    fi
+fi
+
+if [[ ! -d ${output_artifacts_dir} ]]; then
+  echo "${output_artifacts_dir} doesn't exist"
+  exit 1
+fi
+
+excluded_configs="placeholder"
+# Exclude the sriov configs for CI env running on cloud environment
+if [ $feature == $du_ci_std_profile ]; then
+    excluded_configs="SriovNetwork|SriovNetworkNodePolicy"
+fi
+
+# Auto-create kustomization yaml
+cd ${feature_dir}
+cat > kustomization.yaml << EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+EOF
+
+find cluster-config/ -type f -name '*.yaml' | grep -viE ${excluded_configs} | while read config_yaml; do
+  echo "- $config_yaml" >> kustomization.yaml
+done
+cd -
+
+echo "[INFO] Display the generated kustomization.yaml"
+cat ${feature_dir}/kustomization.yaml

--- a/hack/setup-test-cluster.sh
+++ b/hack/setup-test-cluster.sh
@@ -53,6 +53,7 @@ metadata:
   name: ${ROLE_WORKER_CNF}
   labels:
     machineconfiguration.openshift.io/role: ${ROLE_WORKER_CNF}
+    pools.operator.machineconfiguration.openshift.io/${ROLE_WORKER_CNF}: ""
 spec:
   machineConfigSelector:
     matchExpressions:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
@@ -57,26 +57,26 @@ spec:
     #   policyName: "subscriptions-policy"
     - fileName: ReduceMonitoringFootprint.yaml
       policyName: "config-policy"
-    #
-    # These CRs are in support of installation from a disconnected registry
-    #
-    - fileName: OperatorHub.yaml
-      policyName: "config-policy"
-    - fileName: DefaultCatsrc.yaml
-      policyName: "config-policy"
-      # The Subscriptions all point to redhat-operators. The OperatorHub CR
-      # disables the defaults and this CR replaces redhat-operators with a
-      # CatalogSource pointing to the disconnected registry. Including both of
-      # these in the same policy orders their application to the cluster.
-      metadata:
-        name: redhat-operators
-      spec:
-        displayName: disconnected-redhat-operators
-        image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.9
-    - fileName: DisconnectedICSP.yaml
-      policyName: "config-policy"
-      spec:
-        repositoryDigestMirrors:
-        - mirrors:
-          - registry.example.com:5000
-          source: registry.redhat.io
+#    #
+#    # These CRs are in support of installation from a disconnected registry
+#    #
+#    - fileName: OperatorHub.yaml
+#      policyName: "config-policy"
+#    - fileName: DefaultCatsrc.yaml
+#      policyName: "config-policy"
+#      # The Subscriptions all point to redhat-operators. The OperatorHub CR
+#      # disables the defaults and this CR replaces redhat-operators with a
+#      # CatalogSource pointing to the disconnected registry. Including both of
+#      # these in the same policy orders their application to the cluster.
+#      metadata:
+#        name: redhat-operators
+#      spec:
+#        displayName: disconnected-redhat-operators
+#        image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.9
+#    - fileName: DisconnectedICSP.yaml
+#      policyName: "config-policy"
+#      spec:
+#        repositoryDigestMirrors:
+#        - mirrors:
+#          - registry.example.com:5000
+#          source: registry.redhat.io

--- a/ztp/resource-generator/entrypoints/generator
+++ b/ztp/resource-generator/entrypoints/generator
@@ -7,9 +7,9 @@ SUB_COMMAND=$1
 EMS_ONLY="false"
 NOT_WRAP_IN_POLICY="false"
 
-basePath="/kustomize/plugin/ran.openshift.io/v1"
-policyGenPath=${basePath}/policygentemplate
-siteConfigPath=${basePath}/siteconfig
+basePath="${basePath:-/kustomize/plugin/ran.openshift.io/v1}"
+policyGenPath="${policyGenPath:-${basePath}/policygentemplate}"
+siteConfigPath="${siteConfigPath:-${basePath}/siteconfig}"
 
 # default dest dir in the container that is mounted from the host
 DEFAULT_MOUNT_DIR="/resources"
@@ -312,9 +312,6 @@ function verify_arguments {
 
     srcPath=$(realpath -m $srcPath)
     destDir=$(realpath -m $destDir)
-
-    is_dir_mounted $srcPath
-    is_dir_mounted $destDir
  
     local srcDir
     sourceFileArr=()
@@ -329,7 +326,13 @@ function verify_arguments {
         sourceFileArr=($srcPath/*.yaml)
     else
         echo "Error: $srcPath is not found" >&2
+        is_dir_mounted $srcPath
         exit 1
+    fi
+
+    if [[ ! -d $destDir ]]; then
+        mkdir -p $destDir
+        is_dir_mounted $destDir
     fi
 
     # go to source directory which contains siteconfigs or pgts


### PR DESCRIPTION
This PR aims to replace the old DU RAN profile with the ZTP policy generator generated artifacts used in the ran-profile CI. 
- The ran-profile directory is now pointed to the true DU profile which is a set of PGTs located in the ztp directory. The ran-profile-std-cloud contains the overlay for the ran profile deployed on cloud environment. 
- The generate-ran-artifacts.sh script is added to generate the DU artifacts based on the true DU profile prior to feature deploy.
- ran-profile-ci entry is added in Makefile for the ran-profile CI job.
 
Jira: [CNF-2983](https://issues.redhat.com//browse/CNF-2983)