### PR TITLE
ztp: configure composable Openshift with installConfigOverrides

### DIFF
--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
@@ -16,6 +16,7 @@ spec:
     biosConfigRef:
       filePath: "testSiteConfig/testHW.profile"
     networkType: OVNKubernetes
+    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\" ] }}"
     extraManifestPath: testSiteConfig/testUserExtraManifest
     clusterLabels:
       group-du-sno: ""


### PR DESCRIPTION
installConfigOverrides is the generic way of passing install-config parameters through the siteConfig.
This change adds a sample installConfigOverrides that configures the composable openshift feature with the 'capabilities' field.  It removes all but the marketplace component from the optional set of components.  The resulting 'capabilities' in the install-config will be:

capabilities:
  baselineCapabilitySet: None
    additionalEnabledCapabilities:
      - marketplace