### PR TITLE
ztp: example config of composable Openshift

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -14,6 +14,12 @@ spec:
   clusters:
   - clusterName: "example-sno"
     networkType: "OVNKubernetes"
+    # installConfigOverrides is a generic way of passing install-config
+    # parameters through the siteConfig.  The 'capabilities' field configures
+    # the composable openshift feature.  In this 'capabilities' setting, we
+    # remove all but the marketplace component from the optional set of
+    # components.
+    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\" ] }}"
     clusterLabels:
       # These example cluster labels correspond to the bindingRules in the PolicyGenTemplate examples in ../policygentemplates:
       # ../policygentemplates/common-ranGen.yaml will apply to all clusters with 'common: true'


### PR DESCRIPTION
installConfigOverrides is the generic way of passing install-config parameters through the siteConfig.
This change adds a sample installConfigOverrides that configures the composable openshift feature with the 'capabilities' field.  It removes all but the marketplace component from the optional set of components.  The resulting 'capabilities' in the install-config will be:

capabilities:
  baselineCapabilitySet: None
    additionalEnabledCapabilities:
      - marketplace