### PR TITLE
Bug 2111108: ztp: Remove container-mount-namespace.service installation warnings

### DIFF
--- a/ztp/extra-manifests-builder/01-container-mount-ns-and-kubelet-conf/build.sh
+++ b/ztp/extra-manifests-builder/01-container-mount-ns-and-kubelet-conf/build.sh
@@ -16,7 +16,7 @@ MCPROLE=${MCPROLE:-master}
 ${MCMAKER} -name container-mount-namespace-and-kubelet-conf -mcp ${MCPROLE} -stdout \
         file -source extractExecStart -path /usr/local/bin/extractExecStart -mode 0755 \
         file -source nsenterCmns -path /usr/local/bin/nsenterCmns -mode 0755 \
-        unit -source container-mount-namespace.service \
+        unit -source container-mount-namespace.service -enable=false \
         dropin -source 90-container-mount-namespace.conf -for crio.service \
         dropin -source 90-container-mount-namespace-kubelet.conf -name 90-container-mount-namespace.conf -for kubelet.service \
         dropin -source 30-kubelet-interval-tuning.conf -for kubelet.service

--- a/ztp/source-crs/extra-manifest/01-container-mount-ns-and-kubelet-conf-master.yaml
+++ b/ztp/source-crs/extra-manifest/01-container-mount-ns-and-kubelet-conf-master.yaml
@@ -36,7 +36,6 @@ spec:
           ExecStartPre=touch ${BIND_POINT}
           ExecStart=unshare --mount=${BIND_POINT} --propagation slave mount --make-rshared /
           ExecStop=umount -R ${RUNTIME_DIRECTORY}
-        enabled: true
         name: container-mount-namespace.service
       - dropins:
         - contents: |

--- a/ztp/source-crs/extra-manifest/01-container-mount-ns-and-kubelet-conf-worker.yaml
+++ b/ztp/source-crs/extra-manifest/01-container-mount-ns-and-kubelet-conf-worker.yaml
@@ -36,7 +36,6 @@ spec:
           ExecStartPre=touch ${BIND_POINT}
           ExecStart=unshare --mount=${BIND_POINT} --propagation slave mount --make-rshared /
           ExecStop=umount -R ${RUNTIME_DIRECTORY}
-        enabled: true
         name: container-mount-namespace.service
       - dropins:
         - contents: |


### PR DESCRIPTION
The unit doesn't need to be enabled as it's set up as a dependency of
crio and kubelet.  Removing the 'enabled' flag from the MachineConfig
will remove an ignition warning message that could be concerning to
users.

/hold until testing is completed
