### PR TITLE
ztp: Add workloadHints to source-crs/PerformanceProfile

### DIFF
--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -30,3 +30,11 @@ spec:
   # To use the standard (non-realtime) kernel, set enabled to false
   realTimeKernel:
     enabled: true
+  workloadHints:
+    # WorkloadHints defines the set of upper level flags for different type of workloads.
+    # See https://github.com/openshift/cluster-node-tuning-operator/blob/master/docs/performanceprofile/performance_profile.md#workloadhints
+    # for detailed descriptions of each item.
+    # The configuration below is set for a low latency, performance mode.
+    realTime: true
+    highPowerConsumption: false
+    perPodPowerManagement: false


### PR DESCRIPTION
This commit updates source-crs/PerformanceProfile with workloadHints for powerstate configurations. The default configuration is set to performance mode.

Tests have been performed to validate that no reboot on SNO upgrade will be triggered as a result of this change.

Signed-off-by: Sharat Akhoury <sakhoury@redhat.com>

/assign @bartwensley @browsell @imiller0 