### PR TITLE
ztp: Make formatting compatible with golang1.19

### DIFF
--- a/cnf-tests/testsuites/e2esuite/multinetworkpolicy/reachmatcher.go
+++ b/cnf-tests/testsuites/e2esuite/multinetworkpolicy/reachmatcher.go
@@ -350,17 +350,17 @@ func findContainerNameByImage(pod *corev1.Pod, image string) (string, error) {
 // makeConnectivityMatrix returns a string representation of the connectivity matrix between
 // specified pods. The following is a sample output:
 //
-//  Reachability matrix of 9 pods on UDP:5555 (X = true, . = false)
-//        x/a     x/b     x/c     y/a     y/b     y/c     z/a     z/b     z/c
-//  x/a   .       X       X       X       X       X       X       X       X
-//  x/b   X       .       X       X       X       X       X       X       X
-//  x/c   X       X       .       X       X       X       X       X       X
-//  y/a   X       X       X       .       X       X       X       X       X
-//  y/b   X       X       X       X       .       X       X       X       X
-//  y/c   X       X       X       X       X       .       X       X       X
-//  z/a   X       X       X       X       X       X       .       X       X
-//  z/b   X       X       X       X       X       X       X       .       X
-//  z/c   X       X       X       X       X       X       X       X       .
+//	Reachability matrix of 9 pods on UDP:5555 (X = true, . = false)
+//	      x/a     x/b     x/c     y/a     y/b     y/c     z/a     z/b     z/c
+//	x/a   .       X       X       X       X       X       X       X       X
+//	x/b   X       .       X       X       X       X       X       X       X
+//	x/c   X       X       .       X       X       X       X       X       X
+//	y/a   X       X       X       .       X       X       X       X       X
+//	y/b   X       X       X       X       .       X       X       X       X
+//	y/c   X       X       X       X       X       .       X       X       X
+//	z/a   X       X       X       X       X       X       .       X       X
+//	z/b   X       X       X       X       X       X       X       .       X
+//	z/c   X       X       X       X       X       X       X       X       .
 func makeConnectivityMatrix(destinationPort string, ipFamily corev1.IPFamily, protocol corev1.Protocol, pods ...*corev1.Pod) string {
 
 	type connectivityPair struct {

--- a/cnf-tests/testsuites/e2esuite/ovs_qos/ovs_qos.go
+++ b/cnf-tests/testsuites/e2esuite/ovs_qos/ovs_qos.go
@@ -726,11 +726,13 @@ func qosOnNode(node *corev1.Node, cmdWithNICTemplate string) (string, error) {
 }
 
 /*
-	findOvsPhysicalNic finds the physical nic attached to the br-ex interface, output of ovs-vsctl command should be something like:
-	/usr/bin/ovs-vsctl list-ports br-ex
-		eno1
-		patch-br-ex_HOSTNAME-to-br-int
-	we want the nic that is not the patch port
+findOvsPhysicalNic finds the physical nic attached to the br-ex interface, output of ovs-vsctl command should be something like:
+/usr/bin/ovs-vsctl list-ports br-ex
+
+	eno1
+	patch-br-ex_HOSTNAME-to-br-int
+
+we want the nic that is not the patch port
 */
 func findOvsPhysicalNic(ovsPod *corev1.Pod) (string, error) {
 	buf, err := pods.ExecCommand(client.Client, *ovsPod, []string{"/bin/bash", "-c", "/usr/bin/ovs-vsctl list-ports br-ex | /usr/bin/grep -v patch"})

--- a/cnf-tests/testsuites/pkg/pods/pods.go
+++ b/cnf-tests/testsuites/pkg/pods/pods.go
@@ -393,11 +393,11 @@ func ExecCommandInContainer(cs *testclient.ClientSet, pod corev1.Pod, containerN
 // DetectDefaultRouteInterface returns pod's interface bounded to the default route which contains
 // Destination=00000000 and Metric=00000000
 // Typical route table look like present below:
-//Iface	  Destination(1) Gateway 	Flags	RefCnt	Use	Metric	Mask(7)		MTU	Window	IRTT
-//enp2s0	00000000	016FA8C0	0003	0		0	101		00000000	0	0	0  < This is default route
-//tun0		0000800A	00000000	0001	0		0	0		0000FCFF	0	0	0
-//enp2s0	006FA8C0	00000000	0001	0		0	101		00FFFFFF	0	0	0
-//enp6s0	00C7A8C0	00000000	0001	0		0	102		00FFFFFF	0	0	0
+// Iface	  Destination(1) Gateway 	Flags	RefCnt	Use	Metric	Mask(7)		MTU	Window	IRTT
+// enp2s0	00000000	016FA8C0	0003	0		0	101		00000000	0	0	0  < This is default route
+// tun0		0000800A	00000000	0001	0		0	0		0000FCFF	0	0	0
+// enp2s0	006FA8C0	00000000	0001	0		0	101		00FFFFFF	0	0	0
+// enp6s0	00C7A8C0	00000000	0001	0		0	102		00FFFFFF	0	0	0
 func DetectDefaultRouteInterface(cs *testclient.ClientSet, pod corev1.Pod) (string, error) {
 	collectRoutesCommand := []string{"cat", "/proc/net/route"}
 	routeTableBuf, err := ExecCommand(cs, pod, collectRoutesCommand)

--- a/ztp/policygenerator/policyGen/policyHelper.go
+++ b/ztp/policygenerator/policyGen/policyHelper.go
@@ -31,21 +31,34 @@ func CreatePolicySubject(policyName string) utils.Subject {
 	return subject
 }
 
-/* Func CheckBindindRules checks the following invalid rules:
+/*
+	Func CheckBindindRules checks the following invalid rules:
+
 ----------------------
 bindingRules:
+
 	labelKey: ""
+
 bindingExcludedRules:
+
 	labelKey: ""
+
 -----------------------
 bindingRules:
+
 	labelKey: "labelValue"
+
 bindingExcludedRules:
+
 	labelKey: ""
+
 -----------------------
 bindingRules:
+
 	labelKey: "labelValue"
+
 bindingExcludedRules:
+
 	labelKey: "labelValue"
 */
 func CheckBindingRules(pgtName string,
@@ -135,9 +148,11 @@ func BuildObjectTemplate(resource generatedCR) utils.ObjectTemplates {
 // Each resource needs to be applied via ACM enforce policy controlled
 // by Topology Aware Lifecycle operator should have a Deploywave annotation.
 // For example,
-//   metadata:
-//     annotations:
-//       "ran.openshift.io/ztp-deploy-wave": "1"
+//
+//	metadata:
+//	  annotations:
+//	    "ran.openshift.io/ztp-deploy-wave": "1"
+//
 // Resources with same waves can be applied simultaneously in one
 // policy, otherwise, they should be applied via separated policies
 // in order.


### PR DESCRIPTION
`make ci-job` is broken after golang version update
This PR should fix the formatting errors