### PR TITLE
infra: Hide podman login in logs to prevent password leaks

### DIFF
--- a/hack/setup-build-index-image.sh
+++ b/hack/setup-build-index-image.sh
@@ -54,8 +54,10 @@ spec:
           wget https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/linux-amd64-opm
           mv linux-amd64-opm opm
           chmod +x ./opm
-          export pass=$( jq .\"image-registry.openshift-image-registry.svc:5000\".password /var/run/secrets/openshift.io/push/.dockercfg )
+          set +x
+          pass=$( jq .\"image-registry.openshift-image-registry.svc:5000\".password /var/run/secrets/openshift.io/push/.dockercfg )
           podman login -u serviceaccount -p ${pass:1:-1} image-registry.openshift-image-registry.svc:5000 --tls-verify=false
+          set -x
 
           git clone --single-branch --branch OPERATOR_RELEASES https://github.com/openshift/sriov-network-operator.git
           cd sriov-network-operator


### PR DESCRIPTION
Set +x before login so it's not leaked in logs, set -x back after a login.