### PR TITLE
ztp: Add NodeTuning operator to installConfigOverrides for 4.13

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: ran.openshift.io/v1
 kind: PolicyGenTemplate
 metadata:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
@@ -14,6 +14,14 @@ spec:
   clusters:
   - clusterName: "example-3node"
     networkType: "OVNKubernetes"
+    # installConfigOverrides is a generic way of passing install-config
+    # parameters through the siteConfig.  The 'capabilities' field configures
+    # the composable openshift feature.  In this 'capabilities' setting, we
+    # remove all but the marketplace component from the optional set of
+    # components.
+    # Notes:
+    # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
     clusterLabels:
       # These example cluster labels correspond to the bindingRules in the PolicyGenTemplate examples in ../policygentemplates:
       # ../policygentemplates/common-ranGen.yaml will apply to all clusters with 'common: true'

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -19,7 +19,9 @@ spec:
     # the composable openshift feature.  In this 'capabilities' setting, we
     # remove all but the marketplace component from the optional set of
     # components.
-    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\" ] }}"
+    # Notes:
+    # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
     clusterLabels:
       # These example cluster labels correspond to the bindingRules in the PolicyGenTemplate examples in ../policygentemplates:
       # ../policygentemplates/common-ranGen.yaml will apply to all clusters with 'common: true'

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
@@ -17,6 +17,14 @@ spec:
   clusters:
   - clusterName: "example-standard"
     networkType: "OVNKubernetes"
+    # installConfigOverrides is a generic way of passing install-config
+    # parameters through the siteConfig.  The 'capabilities' field configures
+    # the composable openshift feature.  In this 'capabilities' setting, we
+    # remove all but the marketplace component from the optional set of
+    # components.
+    # Notes:
+    # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
     clusterLabels:
       # These example cluster labels correspond to the bindingRules in the PolicyGenTemplate examples in ../policygentemplates:
       # ../policygentemplates/common-ranGen.yaml will apply to all clusters with 'common: true'


### PR DESCRIPTION
In 4.13, Node Tuning Operator is now an optional part of compososable
OpenShift, and we need to make sure it's there.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
