### PR TITLE
Update references to `networks-status`

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -996,7 +996,6 @@ func checkDownwardApi(pod *corev1.Pod, path string, c string) (string, error) {
 func getPodMac(pod *corev1.Pod) string {
 	var output string
 	podMacAdd := pod.ObjectMeta.Annotations
-	fmt.Println(podMacAdd["networks-status:"])
 	contMacAdd, _ := json.Marshal(podMacAdd)
 	strout := string(contMacAdd)
 	for _, line := range strings.Split(strout, "\".\"") {

--- a/cnf-tests/testsuites/e2esuite/multinetworkpolicy/reachmatcher.go
+++ b/cnf-tests/testsuites/e2esuite/multinetworkpolicy/reachmatcher.go
@@ -316,9 +316,9 @@ func getMultusNicIP(pod *corev1.Pod, ipFamily corev1.IPFamily) string {
 
 func getNicIPs(pod *corev1.Pod, ifcName string) ([]string, error) {
 
-	networksStatus, ok := pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks-status"]
+	networksStatus, ok := pod.ObjectMeta.Annotations[nadv1.NetworkStatusAnnot]
 	if !ok {
-		return nil, fmt.Errorf("cannot get networks status from pod [%s] annotation [k8s.v1.cni.cncf.io/networks-status]", pod.Name)
+		return nil, fmt.Errorf("cannot get networks status from pod [%s] annotation [%s]", nadv1.NetworkStatusAnnot, pod.Name)
 	}
 
 	var nets []nadv1.NetworkStatus


### PR DESCRIPTION
Annotation `k8s.v1.cni.cncf.io/networks-status` has been changed to `k8s.v1.cni.cncf.io/network-status` and the former is no longer supported. Use the new key in e2e tests utilities.

Refs:
k8snetworkplumbingwg/network-attachment-definition-client/pull/45