### PR TITLE
OCPBUGS-7540: ztp: Add `soakSeconds` annotation to informDUValidator

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-validator-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-validator-ranGen.yaml
@@ -20,3 +20,8 @@ spec:
     - fileName: validatorCRs/informDuValidator.yaml
       remediationAction: inform
       policyName: "du-policy"
+
+      # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
+      # using a bindingExcludeRules entry with ztp-done
+      evaluationInterval:
+        compliant: 5s

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-validator-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-validator-ranGen.yaml
@@ -20,3 +20,8 @@ spec:
     - fileName: validatorCRs/informDuValidator.yaml
       remediationAction: inform
       policyName: "du-policy"
+      
+      # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
+      # using a bindingExcludeRules entry with ztp-done
+      evaluationInterval:
+        compliant: 5s

--- a/ztp/policygenerator-kustomize-plugin/kustomization.yaml
+++ b/ztp/policygenerator-kustomize-plugin/kustomization.yaml
@@ -4,3 +4,25 @@ generators:
 - testPolicyGenTemplate/group-du-sno-ranGen.yaml
 - testPolicyGenTemplate/site-du-sno-1-ranGen.yaml
 - testPolicyGenTemplate/site-du-sno-2-ranGen.yaml
+- testPolicyGenTemplate/example-group-du-sno-validator-ranGen.yaml
+
+# Updates to the PerformanceProfile or MachineConfigurations may take a short period of time before 
+# causing the MachineConfigPool to move to degraded. This patch adds an annotation to validator policy.
+# This soak time ensures that the upgrading status can be set prior to considering the validation policy
+# in compliance
+patches:
+- patch: |-
+    apiVersion: policy.open-cluster-management.io/v1
+    kind: Policy
+    metadata:
+      annotations:
+        # first time TALM observes this policy as compliant, it won't move on.
+        # In future reconcilations if the specified number of seconds has passed 
+        # since the first compliancy time and policy is still compliant, then TALM
+        # will move on from this policy
+        ran.openshift.io/soak-seconds: "30"
+
+      # The 'name' an 'namespace' values must match the values in the validator policy
+      # the policy name format is as {name}-{spec.sourceFiles[x].policyName}
+      name: example-group-du-sno-validator-du-policy
+      namespace: ztp-group

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/example-group-du-sno-validator-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/example-group-du-sno-validator-ranGen.yaml
@@ -3,25 +3,22 @@ kind: PolicyGenTemplate
 metadata:
   # The name will be used to generate the placementBinding name as {name}-placementBinding, the placementRule name as {name}-placementRule,
   # and the policy name as {name}-{spec.sourceFiles[x].policyName}
-  name: "group-du-standard-validator"
+  name: "example-group-du-sno-validator"
   namespace: "ztp-group"
 spec:
-  # This policy will correspond to all clusters with label specified in bindingRules and
-  # without label specified in bindingExcludedRules.
   bindingRules:
-    group-du-standard: ""
+    # This policy will correspond to all clusters with label specified in bindingRules and
+    # without label specified in bindingExcludedRules.
+    group-du-sno: ""
   bindingExcludedRules:
     # The ztp-done label is used in coordination with the Topology Aware Lifecycle Operator(TALO).
     # Please do not change this label.
     ztp-done: ""
-  mcp: "worker"
+  mcp: "master"
   sourceFiles:
-    # Create inform policy to validate configuration CRs that will be applied to all standard clusters
+    # Create inform policy to validate configuration CRs that will be applied to all SNO clusters
     - fileName: validatorCRs/informDuValidator.yaml
       remediationAction: inform
       policyName: "du-policy"
-      
-      # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
-      # using a bindingExcludeRules entry with ztp-done
       evaluationInterval:
         compliant: 5s


### PR DESCRIPTION
first time TALM observes a policy with this annotation as compliant, it won't move on. In future reconcilations if the specified number of seconds has passed since the first compliancy time and policy is still compliant, then TALM will move on from this policy.