### PR TITLE
OCPBUGS-8238: ztp: Remove incorrect macAddress field

### DIFF
--- a/ztp/gitops-subscriptions/argocd/SNOExpansion.md
+++ b/ztp/gitops-subscriptions/argocd/SNOExpansion.md
@@ -274,7 +274,6 @@ EOF
               - name: eno1
                 type: ethernet
                 state: up
-                macAddress: "<MAC of the machine network interface>"
                 ipv4:
                   enabled: false
                 ipv6:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
@@ -59,7 +59,6 @@ spec:
               - name: eno1
                 type: ethernet
                 state: up
-                macAddress: "AA:BB:CC:DD:EE:11"
                 ipv4:
                   enabled: false
                 ipv6:
@@ -97,7 +96,6 @@ spec:
               - name: eno1
                 type: ethernet
                 state: up
-                macAddress: "AA:BB:CC:DD:EE:22"
                 ipv4:
                   enabled: false
                 ipv6:
@@ -135,7 +133,6 @@ spec:
               - name: eno1
                 type: ethernet
                 state: up
-                macAddress: "AA:BB:CC:DD:EE:33"
                 ipv4:
                   enabled: false
                 ipv6:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -74,7 +74,6 @@ spec:
               - name: eno1
                 type: ethernet
                 state: up
-                macAddress: "AA:BB:CC:DD:EE:11"
                 ipv4:
                   enabled: false
                 ipv6:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
@@ -59,7 +59,6 @@ spec:
               - name: eno1
                 type: ethernet
                 state: up
-                macAddress: "AA:BB:CC:DD:EE:11"
                 ipv4:
                   enabled: false
                 ipv6:
@@ -97,7 +96,6 @@ spec:
               - name: eno1
                 type: ethernet
                 state: up
-                macAddress: "AA:BB:CC:DD:EE:22"
                 ipv4:
                   enabled: false
                 ipv6:
@@ -135,7 +133,6 @@ spec:
               - name: eno1
                 type: ethernet
                 state: up
-                macAddress: "AA:BB:CC:DD:EE:33"
                 ipv4:
                   enabled: false
                 ipv6:
@@ -173,7 +170,6 @@ spec:
               - name: eno1
                 type: ethernet
                 state: up
-                macAddress: "AA:BB:CC:DD:EE:44"
                 ipv4:
                   enabled: false
                 ipv6:
@@ -211,7 +207,6 @@ spec:
               - name: eno1
                 type: ethernet
                 state: up
-                macAddress: "AA:BB:CC:DD:EE:55"
                 ipv4:
                   enabled: false
                 ipv6:

--- a/ztp/ran-crd/site-config-cr-ex.yaml
+++ b/ztp/ran-crd/site-config-cr-ex.yaml
@@ -62,10 +62,9 @@ spec:
             - name: eth1
               macAddress: 02:00:00:80:12:15
           config:
-            # Example for the nmstate config. The interface names & macAddresses must match the defined interfaces above.
+            # Example for the nmstate config. The interface names must match the defined interfaces above.
             interfaces:
               - name: eno1
-                macAddress: 00:00:00:01:20:30
                 type: ethernet
                 ipv4:
                   enabled: true

--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
@@ -65,7 +65,6 @@ spec:
           config:
             interfaces:
               - name: eno1
-                macAddress: "00:00:00:01:20:30"
                 type: ethernet
                 ipv4:
                   enabled: true

--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-expansion.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-expansion.yaml
@@ -66,7 +66,6 @@ spec:
           config:
             interfaces:
               - name: eno1
-                macAddress: "00:00:00:01:20:30"
                 type: ethernet
                 ipv4:
                   enabled: true
@@ -144,7 +143,6 @@ spec:
           config:
             interfaces:
               - name: eno1
-                macAddress: "00:00:00:01:20:30"
                 type: ethernet
                 ipv4:
                   enabled: true

--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site2-sno-du.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site2-sno-du.yaml
@@ -52,7 +52,6 @@ spec:
           config:
             interfaces:
               - name: eno1
-                macAddress: "00:00:00:01:20:30"
                 type: ethernet
                 ipv6:
                   enabled: true

--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site2-standard-du.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site2-standard-du.yaml
@@ -56,7 +56,6 @@ spec:
           config:
             interfaces:
               - name: eno1
-                macAddress: "00:00:00:01:20:30"
                 type: ethernet
                 ipv6:
                   enabled: true
@@ -99,7 +98,6 @@ spec:
           config:
             interfaces:
               - name: eno1
-                macAddress: "00:00:00:01:20:40"
                 type: ethernet
                 ipv6:
                   enabled: true

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -69,7 +69,6 @@ spec:
           config:
             interfaces:
               - name: eno1
-                macAddress: "00:00:00:01:20:30"
                 type: ethernet
                 ipv4:
                   enabled: true
@@ -135,7 +134,6 @@ spec:
           config:
             interfaces:
               - name: eno1
-                macAddress: "00:00:00:01:20:30"
                 type: ethernet
                 ipv4:
                   enabled: true

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
@@ -77,7 +77,6 @@ spec:
             - ipv4:
                 dhcp: false
                 enabled: true
-              macAddress: "00:00:00:01:20:30"
               name: eno1
               type: ethernet
     interfaces:


### PR DESCRIPTION
The macAddress field under
spec.clusters[].nodes[].nodeNetwork.config.interfaces[] is not needed. The network configuration is matched to interfaces based on the macAddress under the spec.clusters[].nodes[].nodeNetwork.interfaces[]. In addition, if the config.interfaces field is included it needs to be mac-addresses. Since it is not necessary this PR simply removes it.