### PR TITLE
OCPBUGS-5121: cnf-tests: fix xt_u32 negative test

### DIFF
--- a/cnf-tests/testsuites/e2esuite/xt_u32/xt_u32.go
+++ b/cnf-tests/testsuites/e2esuite/xt_u32/xt_u32.go
@@ -110,7 +110,9 @@ var _ = Describe("[xt_u32]", func() {
 				"u32", "--u32", "6 & 0xFF = 1 && 4 & 0x3FFF = 0 && 0 >> 22 & 0x3C @ 0 >> 24 = 8",
 				"-j", "DROP"}
 			out, err := pods.ExecCommand(client.Client, *xt_u32Pod, cmd)
-			Expect(out.String()).Should(ContainSubstring("Couldn't load match `u32':No such file or directory"))
+			Expect(out.String()).To(Or(
+				ContainSubstring("Couldn't load match `u32':No such file or directory"),
+				ContainSubstring("Extension u32 revision 0 not supported, missing kernel module?")))
 		})
 	})
 


### PR DESCRIPTION
A patch [1] in iptables v1.8.8 changed the expected output of a negative xt_u32 cnf-test. This patch was backported in RHEL 8.7 (which cnf-tests container image is based on currently) in iptables-1.8.4-23 RPM.
```
  /remote-source/app/cnf-tests/testsuites/e2esuite/xt_u32/xt_u32.go:95
  Expected
      <string>: Warning: Extension u32 revision 0 not supported, missing kernel module?
      iptables v1.8.4 (nf_tables):  RULE_APPEND failed (No such file or directory): rule in chain INPUT

  to contain substring
      <string>: Couldn't load match `u32':No such file or directory
  /remote-source/app/cnf-tests/testsuites/e2esuite/xt_u32/xt_u32.go:113
```
[1] https://git.netfilter.org/iptables/commit/?id=17534cb18ed0a5052dc45c117401251359dba6aa