### PR TITLE
OCPBUGS 7464: ztp: Comment out workloadHints in ZTP 4.13

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
@@ -37,6 +37,10 @@ spec:
           pages:
             - size: 1G
               count: 32
+        workloadHints:
+          realTime: true
+          highPowerConsumption: false
+          perPodPowerManagement: false
     - fileName: TunedPerformancePatch.yaml
       policyName: "config-policy"
       spec:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -108,6 +108,10 @@ spec:
           pages:
             - size: 1G
               count: 32
+        workloadHints:
+          realTime: true
+          highPowerConsumption: false
+          perPodPowerManagement: false
     - fileName: TunedPerformancePatch.yaml
       policyName: "config-policy"
       spec:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
@@ -37,6 +37,10 @@ spec:
           pages:
             - size: 1G
               count: 32
+        workloadHints:
+          realTime: true
+          highPowerConsumption: false
+          perPodPowerManagement: false
     - fileName: TunedPerformancePatch.yaml
       policyName: "config-policy"
       spec:

--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -30,11 +30,11 @@ spec:
   # To use the standard (non-realtime) kernel, set enabled to false
   realTimeKernel:
     enabled: true
-  workloadHints:
+  # workloadHints:
     # WorkloadHints defines the set of upper level flags for different type of workloads.
     # See https://github.com/openshift/cluster-node-tuning-operator/blob/master/docs/performanceprofile/performance_profile.md#workloadhints
     # for detailed descriptions of each item.
     # The configuration below is set for a low latency, performance mode.
-    realTime: true
-    highPowerConsumption: false
-    perPodPowerManagement: false
+    # realTime: true
+    # highPowerConsumption: false
+    # perPodPowerManagement: false


### PR DESCRIPTION
A new `workloadHints` object was added to 4.13 PerformanceProfile source-crs specification which does not exist in previous ZTP versions. This results in an installation failure for earlier releases.

This commit comments out the workloadHints object and adds it to the example files. When ZTP becomes version-aware, the `workloadHints` object will be uncommented.

Signed-off-by: Sharat Akhoury <sakhoury@redhat.com>

/cc @browsell @imiller0 @bartwensley 