### PR TITLE
cnf-tests: Make junit report readable by Prow

### DIFF
--- a/cnf-tests/hack/fill-empty-docs.sh
+++ b/cnf-tests/hack/fill-empty-docs.sh
@@ -11,5 +11,5 @@ entrypoint/test-run.sh -junit _cache/junit --ginkgo.dry-run -ginkgo.v
 
 go build -o _cache/docgen docgen/main.go 
 # use the junit files to fill the descriptions
-_cache/docgen fill --junit _cache/junit/cnftests-junit.xml --description docgen/e2e.json
-_cache/docgen fill --junit _cache/junit/validation_junit.xml --description docgen/validation.json
+_cache/docgen fill --junit _cache/junit/junit_cnftests.xml --description docgen/e2e.json
+_cache/docgen fill --junit _cache/junit/junit_validation.xml --description docgen/validation.json

--- a/cnf-tests/testsuites/configsuite/test_suite_test.go
+++ b/cnf-tests/testsuites/configsuite/test_suite_test.go
@@ -61,7 +61,7 @@ var _ = AfterSuite(func() {
 
 var _ = ReportAfterSuite("setup", func(report types.Report) {
 	if *junitPath != "" {
-		junitFile := path.Join(*junitPath, "setup_junit.xml")
+		junitFile := path.Join(*junitPath, "junit_setup.xml")
 		reporters.GenerateJUnitReportWithConfig(report, junitFile, reporters.JunitReportConfig{
 			OmitTimelinesForSpecState: types.SpecStatePassed | types.SpecStateSkipped,
 			OmitLeafNodeType:          true,

--- a/cnf-tests/testsuites/e2esuite/test_suite_test.go
+++ b/cnf-tests/testsuites/e2esuite/test_suite_test.go
@@ -115,7 +115,7 @@ var _ = AfterSuite(func() {
 
 var _ = ReportAfterSuite("cnftests", func(report types.Report) {
 	if *junitPath != "" {
-		junitFile := path.Join(*junitPath, "cnftests-junit.xml")
+		junitFile := path.Join(*junitPath, "junit_cnftests.xml")
 		reporters.GenerateJUnitReportWithConfig(report, junitFile, reporters.JunitReportConfig{
 			OmitTimelinesForSpecState: types.SpecStatePassed | types.SpecStateSkipped,
 			OmitLeafNodeType:          true,

--- a/cnf-tests/testsuites/validationsuite/test_suite_test.go
+++ b/cnf-tests/testsuites/validationsuite/test_suite_test.go
@@ -59,7 +59,7 @@ var _ = AfterSuite(func() {
 
 var _ = ReportAfterSuite("validation", func(report types.Report) {
 	if *junitPath != "" {
-		junitFile := path.Join(*junitPath, "validation_junit.xml")
+		junitFile := path.Join(*junitPath, "junit_validation.xml")
 		reporters.GenerateJUnitReportWithConfig(report, junitFile, reporters.JunitReportConfig{
 			OmitTimelinesForSpecState: types.SpecStatePassed | types.SpecStateSkipped,
 			OmitLeafNodeType:          true,


### PR DESCRIPTION
CI Operator needs junit output files to be in the
form "junit*.xml" to be shown on the job page.