### PR TITLE
cnf-tests: Avoid clean pods after test in tuningcni tests

### DIFF
--- a/cnf-tests/testsuites/e2esuite/security/tuning.go
+++ b/cnf-tests/testsuites/e2esuite/security/tuning.go
@@ -28,9 +28,10 @@ var _ = Describe("[tuningcni]", func() {
 	execute.BeforeAll(func() {
 		err := namespaces.Create(namespaces.TuningTest, apiclient)
 		Expect(err).ToNot(HaveOccurred())
+
 	})
 
-	AfterEach(func() {
+	BeforeEach(func() {
 		namespaces.CleanPods(namespaces.TuningTest, apiclient)
 	})
 

--- a/cnf-tests/testsuites/e2esuite/security/tuning.go
+++ b/cnf-tests/testsuites/e2esuite/security/tuning.go
@@ -19,20 +19,19 @@ import (
 )
 
 const (
-	TestNamespace = "tuning-testing"
-	Sysctl        = "net.ipv4.conf.%s.send_redirects"
+	Sysctl = "net.ipv4.conf.%s.send_redirects"
 )
 
 var _ = Describe("[tuningcni]", func() {
 	apiclient := client.New("")
 
 	execute.BeforeAll(func() {
-		err := namespaces.Create(TestNamespace, apiclient)
+		err := namespaces.Create(namespaces.TuningTest, apiclient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		namespaces.CleanPods(TestNamespace, apiclient)
+		namespaces.CleanPods(namespaces.TuningTest, apiclient)
 	})
 
 	Context("tuningcni over macvlan", func() {
@@ -42,12 +41,12 @@ var _ = Describe("[tuningcni]", func() {
 				sysctlValue := "1"
 				sysctls, err := networks.SysctlConfig(map[string]string{fmt.Sprintf(Sysctl, "IFNAME"): "1"})
 				Expect(err).ToNot(HaveOccurred())
-				nad, err := networks.NewNetworkAttachmentDefinitionBuilder(TestNamespace, nadName).WithMacVlan().WithStaticIpam("10.10.0.1").WithTuning(sysctls).Build()
+				nad, err := networks.NewNetworkAttachmentDefinitionBuilder(namespaces.TuningTest, nadName).WithMacVlan().WithStaticIpam("10.10.0.1").WithTuning(sysctls).Build()
 				Expect(err).ToNot(HaveOccurred())
 				err = client.Client.Create(context.Background(), nad)
 				Expect(err).ToNot(HaveOccurred())
-				podDefinition := pods.DefineWithNetworks(TestNamespace, []string{fmt.Sprintf("%s/%s", TestNamespace, nadName)})
-				pod, err := client.Client.Pods(TestNamespace).Create(context.Background(), podDefinition, metav1.CreateOptions{})
+				podDefinition := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s", namespaces.TuningTest, nadName)})
+				pod, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				err = pods.WaitForPhase(client.Client, pod, corev1.PodRunning, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
@@ -65,29 +64,29 @@ var _ = Describe("[tuningcni]", func() {
 
 			sysctls, err := networks.SysctlConfig(map[string]string{fmt.Sprintf(Sysctl, "IFNAME"): "1"})
 			Expect(err).ToNot(HaveOccurred())
-			nad1, err := networks.NewNetworkAttachmentDefinitionBuilder(TestNamespace, nad1Name).WithMacVlan().WithStaticIpam(ip1).WithTuning(sysctls).Build()
+			nad1, err := networks.NewNetworkAttachmentDefinitionBuilder(namespaces.TuningTest, nad1Name).WithMacVlan().WithStaticIpam(ip1).WithTuning(sysctls).Build()
 			Expect(err).ToNot(HaveOccurred())
 			err = client.Client.Create(context.Background(), nad1)
 			Expect(err).ToNot(HaveOccurred())
 
 			sysctls, err = networks.SysctlConfig(map[string]string{fmt.Sprintf(Sysctl, "IFNAME"): "1"})
 			Expect(err).ToNot(HaveOccurred())
-			nad2, err := networks.NewNetworkAttachmentDefinitionBuilder(TestNamespace, nad2Name).WithMacVlan().WithStaticIpam(ip2).WithTuning(sysctls).Build()
+			nad2, err := networks.NewNetworkAttachmentDefinitionBuilder(namespaces.TuningTest, nad2Name).WithMacVlan().WithStaticIpam(ip2).WithTuning(sysctls).Build()
 			Expect(err).ToNot(HaveOccurred())
 			err = client.Client.Create(context.Background(), nad2)
 			Expect(err).ToNot(HaveOccurred())
 
-			podDefinition := pods.DefineWithNetworks(TestNamespace, []string{fmt.Sprintf("%s/%s", TestNamespace, nad1Name)})
-			pod, err := client.Client.Pods(TestNamespace).Create(context.Background(), podDefinition, metav1.CreateOptions{})
+			podDefinition := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s", namespaces.TuningTest, nad1Name)})
+			pod, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			err = pods.WaitForPhase(client.Client, pod, corev1.PodRunning, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
-			podDefinition2 := pods.DefineWithNetworks(TestNamespace, []string{fmt.Sprintf("%s/%s", TestNamespace, nad2Name)})
+			podDefinition2 := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s", namespaces.TuningTest, nad2Name)})
 			podDefinition2 = pods.RedefineWithCommand(podDefinition2, []string{"/bin/bash", "-c", fmt.Sprintf("ping -c 1 %s", ip1)}, nil)
 			podDefinition2 = pods.RedefineWithRestartPolicy(podDefinition2, corev1.RestartPolicyNever)
 			podDefinition2.Spec.NodeName = pod.Spec.NodeName
-			pod2, err := client.Client.Pods(TestNamespace).Create(context.Background(), podDefinition2, metav1.CreateOptions{})
+			pod2, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition2, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			err = pods.WaitForPhase(client.Client, pod2, corev1.PodSucceeded, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
@@ -105,32 +104,32 @@ var _ = Describe("[tuningcni]", func() {
 				sysctls, err := networks.SysctlConfig(map[string]string{fmt.Sprintf(Sysctl, "IFNAME"): "1"})
 				Expect(err).ToNot(HaveOccurred())
 
-				bondWithTuningNad1, err := networks.NewNetworkAttachmentDefinitionBuilder(TestNamespace, bondNadName1).WithBond("net3", "net1", "net2", 1300).WithStaticIpam(ip1).WithTuning(sysctls).Build()
+				bondWithTuningNad1, err := networks.NewNetworkAttachmentDefinitionBuilder(namespaces.TuningTest, bondNadName1).WithBond("net3", "net1", "net2", 1300).WithStaticIpam(ip1).WithTuning(sysctls).Build()
 				Expect(err).ToNot(HaveOccurred())
 				err = client.Client.Create(context.Background(), bondWithTuningNad1)
 				Expect(err).ToNot(HaveOccurred())
 
-				bondWithTuningNad2, err := networks.NewNetworkAttachmentDefinitionBuilder(TestNamespace, bondNadName2).WithBond("net3", "net1", "net2", 1300).WithStaticIpam("10.10.0.23").WithTuning(sysctls).Build()
+				bondWithTuningNad2, err := networks.NewNetworkAttachmentDefinitionBuilder(namespaces.TuningTest, bondNadName2).WithBond("net3", "net1", "net2", 1300).WithStaticIpam("10.10.0.23").WithTuning(sysctls).Build()
 				Expect(err).ToNot(HaveOccurred())
 				err = client.Client.Create(context.Background(), bondWithTuningNad2)
 				Expect(err).ToNot(HaveOccurred())
 
-				macVlandNad, err := networks.NewNetworkAttachmentDefinitionBuilder(TestNamespace, macvlanNadName).WithMacVlan().Build()
+				macVlandNad, err := networks.NewNetworkAttachmentDefinitionBuilder(namespaces.TuningTest, macvlanNadName).WithMacVlan().Build()
 				Expect(err).ToNot(HaveOccurred())
 				err = client.Client.Create(context.Background(), macVlandNad)
 				Expect(err).ToNot(HaveOccurred())
 
-				podDefinition1 := pods.DefineWithNetworks(TestNamespace, []string{fmt.Sprintf("%s/%s, %s/%s, %s/%s", TestNamespace, macvlanNadName, TestNamespace, macvlanNadName, TestNamespace, bondNadName1)})
-				pod1, err := client.Client.Pods(TestNamespace).Create(context.Background(), podDefinition1, metav1.CreateOptions{})
+				podDefinition1 := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s, %s/%s, %s/%s", namespaces.TuningTest, macvlanNadName, namespaces.TuningTest, macvlanNadName, namespaces.TuningTest, bondNadName1)})
+				pod1, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition1, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				err = pods.WaitForPhase(client.Client, pod1, corev1.PodRunning, 1*time.Minute)
 				Expect(err).ToNot(HaveOccurred())
 
-				podDefinition2 := pods.DefineWithNetworks(TestNamespace, []string{fmt.Sprintf("%s/%s, %s/%s, %s/%s", TestNamespace, macvlanNadName, TestNamespace, macvlanNadName, TestNamespace, bondNadName2)})
+				podDefinition2 := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s, %s/%s, %s/%s", namespaces.TuningTest, macvlanNadName, namespaces.TuningTest, macvlanNadName, namespaces.TuningTest, bondNadName2)})
 				podDefinition2 = pods.RedefineWithCommand(podDefinition2, []string{"/bin/bash", "-c", fmt.Sprintf("ping -c 1 %s", ip1)}, nil)
 				podDefinition2 = pods.RedefineWithRestartPolicy(podDefinition2, corev1.RestartPolicyNever)
 				podDefinition2.Spec.NodeName = pod1.Spec.NodeName
-				pod2, err := client.Client.Pods(TestNamespace).Create(context.Background(), podDefinition2, metav1.CreateOptions{})
+				pod2, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition2, metav1.CreateOptions{})
 
 				Expect(err).ToNot(HaveOccurred())
 				err = pods.WaitForPhase(client.Client, pod2, corev1.PodSucceeded, 1*time.Minute)
@@ -159,21 +158,21 @@ var _ = Describe("[tuningcni]", func() {
 			updatedSysctls := originalSysctls + "\n^" + sysctl + "$"
 
 			podSysctls, err := networks.SysctlConfig(map[string]string{sysctl: "1"})
-			macVlandNad, err := networks.NewNetworkAttachmentDefinitionBuilder(TestNamespace, macvlanNadName).WithMacVlan().WithTuning(podSysctls).Build()
+			macVlandNad, err := networks.NewNetworkAttachmentDefinitionBuilder(namespaces.TuningTest, macvlanNadName).WithMacVlan().WithTuning(podSysctls).Build()
 			Expect(err).ToNot(HaveOccurred())
 			err = client.Client.Create(context.Background(), macVlandNad)
 			Expect(err).ToNot(HaveOccurred())
 
-			podDefinition := pods.DefineWithNetworks(TestNamespace, []string{fmt.Sprintf("%s/%s", TestNamespace, macvlanNadName)})
-			pod, err := client.Client.Pods(TestNamespace).Create(context.Background(), podDefinition, metav1.CreateOptions{})
+			podDefinition := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s", namespaces.TuningTest, macvlanNadName)})
+			pod, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
-				checkPod, err := client.Client.Pods(TestNamespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+				checkPod, err := client.Client.Pods(namespaces.TuningTest).Get(context.Background(), pod.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				if checkPod.Status.Phase != corev1.PodPending {
 					return false
 				}
-				eventExists, err := syscltFailureEventExists(pod.Name, TestNamespace, sysctl)
+				eventExists, err := syscltFailureEventExists(pod.Name, namespaces.TuningTest, sysctl)
 				Expect(err).NotTo(HaveOccurred())
 				return eventExists
 			}, 15*time.Second, 3*time.Second).Should(BeTrue())

--- a/cnf-tests/testsuites/e2esuite/security/tuning_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/security/tuning_sriov.go
@@ -35,7 +35,7 @@ var _ = Describe("[sriov] Tuning CNI integration", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
+	BeforeEach(func() {
 		namespaces.CleanPods(namespaces.SriovTuningTest, apiclient)
 	})
 
@@ -44,10 +44,10 @@ var _ = Describe("[sriov] Tuning CNI integration", func() {
 			if discovery.Enabled() {
 				Skip("Tuned sriov tests disabled for discovery mode")
 			}
+
 		})
 
 		execute.BeforeAll(func() {
-			namespaces.CleanPods(namespaces.SriovTuningTest, sriovclient)
 			networks.CleanSriov(sriovclient)
 			sysctls, err := networks.SysctlConfig(map[string]string{fmt.Sprintf(Sysctl, "IFNAME"): "1"})
 			Expect(err).ToNot(HaveOccurred())

--- a/cnf-tests/testsuites/e2esuite/security/tuning_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/security/tuning_sriov.go
@@ -21,10 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const (
-	SriovTestNamespace = "tuningsriov-testing"
-)
-
 var sriovclient *sriovtestclient.ClientSet
 
 func init() {
@@ -35,12 +31,12 @@ var _ = Describe("[sriov] Tuning CNI integration", func() {
 	apiclient := client.New("")
 
 	execute.BeforeAll(func() {
-		err := namespaces.Create(SriovTestNamespace, apiclient)
+		err := namespaces.Create(namespaces.SriovTuningTest, apiclient)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		namespaces.CleanPods(SriovTestNamespace, apiclient)
+		namespaces.CleanPods(namespaces.SriovTuningTest, apiclient)
 	})
 
 	Context("tuning cni over sriov", func() {
@@ -51,11 +47,12 @@ var _ = Describe("[sriov] Tuning CNI integration", func() {
 		})
 
 		execute.BeforeAll(func() {
-			namespaces.CleanPods(SriovTestNamespace, sriovclient)
+			namespaces.CleanPods(namespaces.SriovTuningTest, sriovclient)
 			networks.CleanSriov(sriovclient)
 			sysctls, err := networks.SysctlConfig(map[string]string{fmt.Sprintf(Sysctl, "IFNAME"): "1"})
 			Expect(err).ToNot(HaveOccurred())
-			networks.CreateSriovPolicyAndNetwork(sriovclient, namespaces.SRIOVOperator, "test-network", "testresource", fmt.Sprintf("{%s}", sysctls))
+			networks.CreateSriovPolicyAndNetwork(
+				sriovclient, namespaces.SRIOVOperator, "test-network", "testresource", fmt.Sprintf("{%s}", sysctls))
 
 			By("Checking the network-attachment-defintion is ready")
 			Eventually(func() error {
@@ -70,8 +67,10 @@ var _ = Describe("[sriov] Tuning CNI integration", func() {
 		})
 
 		It("pods with sysctl's over sriov interface should start", func() {
-			podDefinition := pods.DefineWithNetworks(SriovTestNamespace, []string{fmt.Sprintf("%s/%s", namespaces.SRIOVOperator, "test-network")})
-			pod, err := client.Client.Pods(SriovTestNamespace).Create(context.Background(), podDefinition, metav1.CreateOptions{})
+			podDefinition := pods.DefineWithNetworks(namespaces.SriovTuningTest,
+				[]string{fmt.Sprintf("%s/%s", namespaces.SRIOVOperator, "test-network")})
+			pod, err := client.Client.Pods(namespaces.SriovTuningTest).
+				Create(context.Background(), podDefinition, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			err = pods.WaitForCondition(client.Client, pod, corev1.ContainersReady, corev1.ConditionTrue, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
@@ -83,17 +82,19 @@ var _ = Describe("[sriov] Tuning CNI integration", func() {
 			bondLinkName := "bond0"
 			sysctls, err := networks.SysctlConfig(map[string]string{fmt.Sprintf(Sysctl, "IFNAME"): "1"})
 			Expect(err).ToNot(HaveOccurred())
-			bondNetworkAttachmentDefinition, err := networks.NewNetworkAttachmentDefinitionBuilder(SriovTestNamespace, "bond").WithBond(bondLinkName, "net1", "net2", 1300).WithHostLocalIpam("1.1.1.0").WithTuning(sysctls).Build()
+			bondNetworkAttachmentDefinition, err := networks.NewNetworkAttachmentDefinitionBuilder(namespaces.SriovTuningTest, "bond").
+				WithBond(bondLinkName, "net1", "net2", 1300).WithHostLocalIpam("1.1.1.0").WithTuning(sysctls).Build()
 			Expect(err).ToNot(HaveOccurred())
 			err = client.Client.Create(context.Background(), bondNetworkAttachmentDefinition)
 			Expect(err).ToNot(HaveOccurred())
 
-			podDefinition := pods.DefineWithNetworks(SriovTestNamespace, []string{
+			podDefinition := pods.DefineWithNetworks(namespaces.SriovTuningTest, []string{
 				fmt.Sprintf("%s/%s", namespaces.SRIOVOperator, "test-network"),
 				fmt.Sprintf("%s/%s", namespaces.SRIOVOperator, "test-network"),
-				fmt.Sprintf("%s/%s@%s", SriovTestNamespace, "bond", bondLinkName),
+				fmt.Sprintf("%s/%s@%s", namespaces.SriovTuningTest, "bond", bondLinkName),
 			})
-			pod, err := client.Client.Pods(SriovTestNamespace).Create(context.Background(), podDefinition, metav1.CreateOptions{})
+			pod, err := client.Client.Pods(namespaces.SriovTuningTest).
+				Create(context.Background(), podDefinition, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			err = pods.WaitForCondition(client.Client, pod, corev1.ContainersReady, corev1.ConditionTrue, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())

--- a/cnf-tests/testsuites/pkg/features/features.go
+++ b/cnf-tests/testsuites/pkg/features/features.go
@@ -9,7 +9,6 @@ import (
 	perfClean "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/clean"
 
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/fec"
-	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/security"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/sro"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/vrf"
 	testclient "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/client"
@@ -96,7 +95,7 @@ func (p *SriovFixture) Setup() error {
 func (p *SriovFixture) Cleanup() error {
 	sriovClean.All()
 
-	err := namespaces.Delete(security.SriovTestNamespace, testclient.Client)
+	err := namespaces.Delete(namespaces.SriovTuningTest, testclient.Client)
 	if err != nil {
 		return err
 	}
@@ -168,7 +167,7 @@ func (p *TuningcniFixture) Setup() error {
 }
 
 func (p *TuningcniFixture) Cleanup() error {
-	return namespaces.Delete(security.TestNamespace, testclient.Client)
+	return namespaces.Delete(namespaces.TuningTest, testclient.Client)
 }
 
 type BondcniFixture struct {

--- a/cnf-tests/testsuites/pkg/namespaces/namespaces.go
+++ b/cnf-tests/testsuites/pkg/namespaces/namespaces.go
@@ -44,6 +44,12 @@ var SroTestNamespace = "oot-driver"
 
 var BondTestNamespace = "bond-testing"
 
+// TuningTest is the namespace used for testing tuningcni features
+var TuningTest = "tuning-testing"
+
+// SriovTuingTest is the namespace used for testing feature related to both tuningcni and sriov
+var SriovTuningTest = "tuningsriov-testing"
+
 // SCTPTest is the namespace of the sctp test suite
 var SCTPTest string
 

--- a/cnf-tests/testsuites/pkg/utils/reporter.go
+++ b/cnf-tests/testsuites/pkg/utils/reporter.go
@@ -95,6 +95,7 @@ func NewReporter(reportPath string) (*k8sreporter.KubernetesReporter, error) {
 		perfUtils.NamespaceTesting:              "performance",
 		namespaces.DpdkTest:                     "dpdk",
 		sriovNamespaces.Test:                    "sriov",
+		namespaces.SriovTuningTest:              "sriov",
 		MultiNetworkPolicyNamespaceX:            "multinetworkpolicy",
 		MultiNetworkPolicyNamespaceY:            "multinetworkpolicy",
 		MultiNetworkPolicyNamespaceZ:            "multinetworkpolicy",
@@ -117,6 +118,7 @@ func NewReporter(reportPath string) (*k8sreporter.KubernetesReporter, error) {
 		namespaces.SroTestNamespace:             "sro",
 		namespaces.BondTestNamespace:            "bondcni",
 		namespaces.MetalLBOperator:              "metallb",
+		namespaces.TuningTest:                   "tuningcni",
 	}
 
 	crds := []k8sreporter.CRData{


### PR DESCRIPTION
Cleaning resources in AfterEach decorator makes the reporter not collect test resources. It's preferable to do it in the clean section and at the end of the suite (i.e. in *Fixtures in features.go)