### PR TITLE
cnf-tests: sriov-network-operator bump 4.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ replace (
 
 // Test deps
 replace (
-	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230119162442-a99248c658d7 // release-4.13
+	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230323192312-6bee5db68ac6 // release-4.13
 	github.com/k8stopologyawareschedwg/resource-topology-exporter => github.com/k8stopologyawareschedwg/resource-topology-exporter v0.8.0
 	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230123113337-fa1059e25fe1 // release-4.13
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10

--- a/go.sum
+++ b/go.sum
@@ -937,8 +937,8 @@ github.com/openshift/ptp-operator v0.0.0-20230206122400-e0231ea64d3a/go.mod h1:x
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912/go.mod h1:0OXNy7VoqFexkxKqyQbHJLPwn1MFp1/CxRJAgKHM+/o=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b h1:NlOsWwZI4tYu6XbqG1/9jtg2I20+zs+8vy7d4X7ieZs=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b/go.mod h1:ESuS9sfrzo0EpEHaHNEvjo1oThseBnGU5s+RT1psTRA=
-github.com/openshift/sriov-network-operator v0.0.0-20230119162442-a99248c658d7 h1:d6l/8uU+ncn/3Xnwi4Mm7gb+0O/HpVY13CO8xDDC8dE=
-github.com/openshift/sriov-network-operator v0.0.0-20230119162442-a99248c658d7/go.mod h1:Kr08YB4WiPZHPKIb77HI5Nj1gHT4SBWA/9A1BsXPV+Y=
+github.com/openshift/sriov-network-operator v0.0.0-20230323192312-6bee5db68ac6 h1:V24WETWr00vR9/Cnwb2NfFLiRK2boc3V4jmvcMl3OR4=
+github.com/openshift/sriov-network-operator v0.0.0-20230323192312-6bee5db68ac6/go.mod h1:nByQyTNEG4I8UDI+fkzy/zYCJyrCJ5WNHzpS8i/O4K0=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/helper.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/helper.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,8 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	render "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/render"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/render"
 )
 
 const (
@@ -379,6 +379,7 @@ func (p *SriovNetworkNodePolicy) generateVfGroup(iface *InterfaceExt) (*VfGroup,
 		PolicyName:   p.GetName(),
 		Mtu:          p.Spec.Mtu,
 		IsRdma:       p.Spec.IsRdma,
+		VdpaType:     p.Spec.VdpaType,
 	}, nil
 }
 

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/sriovnetworknodepolicy_types.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/sriovnetworknodepolicy_types.go
@@ -54,6 +54,9 @@ type SriovNetworkNodePolicySpec struct {
 	// +kubebuilder:validation:Enum=legacy;switchdev
 	// NIC Device Mode. Allowed value "legacy","switchdev".
 	EswitchMode string `json:"eSwitchMode,omitempty"`
+	// +kubebuilder:validation:Enum=virtio
+	// VDPA device type. Allowed value "virtio"
+	VdpaType string `json:"vdpaType,omitempty"`
 }
 
 type SriovNetworkNicSelector struct {

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/sriovnetworknodestate_types.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/sriovnetworknodestate_types.go
@@ -46,6 +46,7 @@ type VfGroup struct {
 	PolicyName   string `json:"policyName,omitempty"`
 	Mtu          int    `json:"mtu,omitempty"`
 	IsRdma       bool   `json:"isRdma,omitempty"`
+	VdpaType     string `json:"vdpaType,omitempty"`
 }
 
 type Interfaces []Interface
@@ -90,6 +91,8 @@ type SriovNetworkNodeStateStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Sync Status",type=string,JSONPath=`.status.syncStatus`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // SriovNetworkNodeState is the Schema for the sriovnetworknodestates API
 type SriovNetworkNodeState struct {

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go
@@ -15,26 +15,25 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/discovery"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/execute"
-
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/clean"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/namespaces"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/network"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/nodes"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/pod"
+	admission "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
-	admission "k8s.io/api/admissionregistration/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/clean"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/discovery"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/execute"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/namespaces"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/network"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/nodes"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/pod"
 )
 
 var waitingTime time.Duration = 20 * time.Minute

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client/clients.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client/clients.go
@@ -6,8 +6,6 @@ import (
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	"github.com/golang/glog"
-	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
-	clientsriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/typed/sriovnetwork/v1"
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	clientmachineconfigv1 "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -16,10 +14,12 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	clientsriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/typed/sriovnetwork/v1"
 )
 
 // ClientSet provides the struct to talk with relevant API

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/discovery/discovery.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/discovery/discovery.go
@@ -5,12 +5,13 @@ import (
 	"os"
 	"strconv"
 
-	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster"
 )
 
 // Enabled indicates whether test discovery mode is enabled.

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/namespaces/namespaces.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/namespaces/namespaces.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +13,7 @@ import (
 	"k8s.io/utils/pointer"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	testclient "github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client"
 )
 

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/nodes/nodes.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/nodes/nodes.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"os"
 
-	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client"
 )
 
 // NodesSelector represent the label selector used to filter impacted nodes.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -225,7 +225,7 @@ github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/client/clientset/version
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1
-# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20230119162442-a99248c658d7
+# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20230323192312-6bee5db68ac6
 ## explicit; go 1.19
 github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
 github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/scheme
@@ -1264,7 +1264,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20230130232623-47904dd9ff5a
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a
 # github.com/test-network-function/l2discovery-lib => github.com/test-network-function/l2discovery-lib v0.0.5
-# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230119162442-a99248c658d7
+# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230323192312-6bee5db68ac6
 # github.com/k8stopologyawareschedwg/resource-topology-exporter => github.com/k8stopologyawareschedwg/resource-topology-exporter v0.8.0
 # github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230123113337-fa1059e25fe1
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b


### PR DESCRIPTION
SR-IOV Network Operator dependency bumped with commands:

```
go mod edit -replace \
github.com/k8snetworkplumbingwg/sriov-network-operator=\
github.com/openshift/sriov-network-operator@release-4.14
go mod tidy
go mod vendor
```