### PR TITLE
OCPBUGS-11065: [release-4.13] cnf-tests: sriov-network-operator bump 4.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ replace (
 
 // Test deps
 replace (
-	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230119162442-a99248c658d7 // release-4.13
+	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230330150324-84715294edb9 // release-4.13
 	github.com/k8stopologyawareschedwg/resource-topology-exporter => github.com/k8stopologyawareschedwg/resource-topology-exporter v0.8.0
 	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230123113337-fa1059e25fe1 // release-4.13
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10

--- a/go.sum
+++ b/go.sum
@@ -937,8 +937,8 @@ github.com/openshift/ptp-operator v0.0.0-20230206122400-e0231ea64d3a/go.mod h1:x
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912/go.mod h1:0OXNy7VoqFexkxKqyQbHJLPwn1MFp1/CxRJAgKHM+/o=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b h1:NlOsWwZI4tYu6XbqG1/9jtg2I20+zs+8vy7d4X7ieZs=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b/go.mod h1:ESuS9sfrzo0EpEHaHNEvjo1oThseBnGU5s+RT1psTRA=
-github.com/openshift/sriov-network-operator v0.0.0-20230119162442-a99248c658d7 h1:d6l/8uU+ncn/3Xnwi4Mm7gb+0O/HpVY13CO8xDDC8dE=
-github.com/openshift/sriov-network-operator v0.0.0-20230119162442-a99248c658d7/go.mod h1:Kr08YB4WiPZHPKIb77HI5Nj1gHT4SBWA/9A1BsXPV+Y=
+github.com/openshift/sriov-network-operator v0.0.0-20230330150324-84715294edb9 h1:FHIYzOus9fNPaJC4DAsOhYakwXob9I9KwHYBs9hOKt0=
+github.com/openshift/sriov-network-operator v0.0.0-20230330150324-84715294edb9/go.mod h1:qcsO9FbnUCtdnm8wrsx/EyfWtVhZYWHKFDdjThu6HLs=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/helper.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/helper.go
@@ -379,6 +379,7 @@ func (p *SriovNetworkNodePolicy) generateVfGroup(iface *InterfaceExt) (*VfGroup,
 		PolicyName:   p.GetName(),
 		Mtu:          p.Spec.Mtu,
 		IsRdma:       p.Spec.IsRdma,
+		VdpaType:     p.Spec.VdpaType,
 	}, nil
 }
 

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/sriovnetworknodepolicy_types.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/sriovnetworknodepolicy_types.go
@@ -54,6 +54,9 @@ type SriovNetworkNodePolicySpec struct {
 	// +kubebuilder:validation:Enum=legacy;switchdev
 	// NIC Device Mode. Allowed value "legacy","switchdev".
 	EswitchMode string `json:"eSwitchMode,omitempty"`
+	// +kubebuilder:validation:Enum=virtio
+	// VDPA device type. Allowed value "virtio"
+	VdpaType string `json:"vdpaType,omitempty"`
 }
 
 type SriovNetworkNicSelector struct {

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/sriovnetworknodestate_types.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1/sriovnetworknodestate_types.go
@@ -46,6 +46,7 @@ type VfGroup struct {
 	PolicyName   string `json:"policyName,omitempty"`
 	Mtu          int    `json:"mtu,omitempty"`
 	IsRdma       bool   `json:"isRdma,omitempty"`
+	VdpaType     string `json:"vdpaType,omitempty"`
 }
 
 type Interfaces []Interface

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/network/network.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/network/network.go
@@ -86,7 +86,7 @@ func CreateSriovPolicy(clientSet *testclient.ClientSet, generatedName string, op
 func GetNicsByPrefix(pod *k8sv1.Pod, ifcPrefix string) ([]string, error) {
 	var nets []Network
 	nics := []string{}
-	err := json.Unmarshal([]byte(pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks-status"]), &nets)
+	err := json.Unmarshal([]byte(pod.ObjectMeta.Annotations[netattdefv1.NetworkStatusAnnot]), &nets)
 	if err != nil {
 		return nil, err
 	}
@@ -101,15 +101,15 @@ func GetNicsByPrefix(pod *k8sv1.Pod, ifcPrefix string) ([]string, error) {
 // GetSriovNicIPs returns the list of ip addresses related to the given
 // interface name for the given pod.
 func GetSriovNicIPs(pod *k8sv1.Pod, ifcName string) ([]string, error) {
-	networksStatus, ok := pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks-status"]
+	networksStatus, ok := pod.ObjectMeta.Annotations[netattdefv1.NetworkStatusAnnot]
 	if !ok {
-		return nil, fmt.Errorf("pod [%s] has no annotation `k8s.v1.cni.cncf.io/networks-status`", pod.Name)
+		return nil, fmt.Errorf("pod [%s] has no annotation `%s`", netattdefv1.NetworkStatusAnnot, pod.Name)
 	}
 
 	var nets []Network
 	err := json.Unmarshal([]byte(networksStatus), &nets)
 	if err != nil {
-		return nil, fmt.Errorf("can't unmarshal annotation `k8s.v1.cni.cncf.io/networks-status`: %w", err)
+		return nil, fmt.Errorf("can't unmarshal annotation `%s`: %w", netattdefv1.NetworkStatusAnnot, err)
 	}
 	for _, net := range nets {
 		if net.Interface != ifcName {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -225,7 +225,7 @@ github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/client/clientset/version
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1
-# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20230119162442-a99248c658d7
+# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20230330150324-84715294edb9
 ## explicit; go 1.19
 github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
 github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/scheme
@@ -1264,7 +1264,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20230130232623-47904dd9ff5a
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a
 # github.com/test-network-function/l2discovery-lib => github.com/test-network-function/l2discovery-lib v0.0.5
-# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230119162442-a99248c658d7
+# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230330150324-84715294edb9
 # github.com/k8stopologyawareschedwg/resource-topology-exporter => github.com/k8stopologyawareschedwg/resource-topology-exporter v0.8.0
 # github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230123113337-fa1059e25fe1
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b


### PR DESCRIPTION
SR-IOV Network Operator dependency bumped with commands:

```
go mod edit -replace \
github.com/k8snetworkplumbingwg/sriov-network-operator=\
github.com/openshift/sriov-network-operator@release-4.13
go mod tidy
go mod vendor
```