### PR TITLE
[wip] ztp: some code to get started with diffing

### DIFF
--- a/ztp/policygenerator/policyGen/policyBuilder.go
+++ b/ztp/policygenerator/policyGen/policyBuilder.go
@@ -68,7 +68,7 @@ func (pbuilder *PolicyBuilder) Build(policyGenTemp utils.PolicyGenTemplate) (map
 					}
 					name = strings.Join(nameParts, "-")
 				}
-				output := path.Join(utils.CustomResource, policyGenTemp.Metadata.Name, name)
+				output := path.Join(sFile.FileName, name)
 				policies[output] = resources
 			} else {
 				// Generate a policy-wrapped CR, with the filename based on the policy and source filename

--- a/ztp/policygenerator/policyGenerator.go
+++ b/ztp/policygenerator/policyGenerator.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"github.com/openshift-kni/cnf-features-deploy/ztp/policygenerator/policyGen"
+	"github.com/openshift-kni/cnf-features-deploy/ztp/policygenerator/utils"
+	"gopkg.in/yaml.v3"
 	"log"
 	"reflect"
 	"strings"
-
-	policyGen "github.com/openshift-kni/cnf-features-deploy/ztp/policygenerator/policyGen"
-	utils "github.com/openshift-kni/cnf-features-deploy/ztp/policygenerator/utils"
-	"gopkg.in/yaml.v3"
 )
 
 func main() {
@@ -101,6 +100,12 @@ func InitiatePolicyGen(fHandler *utils.FilesHandler, pgtFiles []string, wrapInPo
 					}
 				}
 				if pErr == nil {
+					// write to file if CRs are unwrapped
+					if !policyGenTemp.Spec.WrapInPolicy {
+						if fHandler.OutDir == utils.UnsetStringValue {
+							fHandler.OutDir = utils.DefaultOutDir
+						}
+					}
 					// write to file when out dir is provided, otherwise write to standard output
 					if fHandler.OutDir != utils.UnsetStringValue {
 						err := fHandler.WriteFile(k+utils.FileExt, policy)

--- a/ztp/policygenerator/policyGenerator.go
+++ b/ztp/policygenerator/policyGenerator.go
@@ -17,14 +17,29 @@ func main() {
 	sourceCRsPath := flag.String("sourcePath", utils.SourceCRsPath, "Directory where source-crs files exist")
 	pgtPath := flag.String("pgtPath", utils.UnsetStringValue, "Directory where policyGenTemp files exist")
 	outPath := flag.String("outPath", utils.UnsetStringValue, "Directory to write the generated policies")
-	wrapInPolicy := flag.Bool("wrapInPolicy", true, "Wrap the CRs in acm Policy")
+	wrapInPolicy := flag.Bool("wrapInPolicy", false, "Wrap the CRs in acm Policy")
 
-	// Parse command input
+	p := "/Users/np-rh/redhat/copy/cnf-features-deploy/ztp/policygenerator-kustomize-plugin/pub-pgt"
+	pgtPath = &p
+
+	// includes all SOURCE-crS in one dir (consider making this source-crPath to an array)
+	s := "/Users/np-rh/redhat/all/source-crs"
+	sourceCRsPath = &s
+
+	o := "/Users/np-rh/redhat/copy/cnf-features-deploy/ztp/policygenerator-kustomize-plugin/v-out/git-out"
+	outPath = &o
 	flag.Parse()
 
 	// Collect and parse policyGenTemp files paths
 	policyGenTemps := flag.Args()
 
+	start(sourceCRsPath, pgtPath, outPath, policyGenTemps, wrapInPolicy)
+
+	// start the whole thing again but in diff mode
+
+}
+
+func start(sourceCRsPath *string, pgtPath *string, outPath *string, policyGenTemps []string, wrapInPolicy *bool) {
 	fHandler := utils.NewFilesHandler(*sourceCRsPath, *pgtPath, *outPath)
 	if fHandler.PgtDir != utils.UnsetStringValue {
 		files, err := fHandler.GetTempFiles()

--- a/ztp/policygenerator/utils/filesHandler.go
+++ b/ztp/policygenerator/utils/filesHandler.go
@@ -22,16 +22,30 @@ func (fHandler *FilesHandler) WriteFile(filePath string, content []byte) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		os.MkdirAll(path, 0775)
 	}
-	err := ioutil.WriteFile(fHandler.OutDir+"/"+filePath, content, 0644)
+	file := fHandler.OutDir + "/" + filePath
+
+	//create new or append if exist
+	f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	if _, err = f.WriteString(string(content)); err != nil {
+		return err
+	}
 
 	return err
 }
 
 func (fHandler *FilesHandler) getFiles(path string) ([]os.FileInfo, error) {
+	// todo: update deprecated
 	return ioutil.ReadDir(path)
 }
 
 func (fHandler *FilesHandler) ReadFile(filePath string) ([]byte, error) {
+	// todo: update deprecated
 	return ioutil.ReadFile(filePath)
 }
 

--- a/ztp/policygenerator/utils/utils.go
+++ b/ztp/policygenerator/utils/utils.go
@@ -1,17 +1,20 @@
 package utils
 
-const ExistOper = "Exists"
-const InOper = "In"
-const DoesNotExistOper = "DoesNotExist"
-const NotInOper = "NotIn"
-const CustomResource = "customResource"
-const SourceCRsPath = "source-crs"
-const FileExt = ".yaml"
-const UnsetStringValue = "__unset_value__"
-const ZtpDeployWaveAnnotation = "ran.openshift.io/ztp-deploy-wave"
-const DefaultCompliantEvaluationInterval = "10m"
-const DefaultNonCompliantEvaluationInterval = "10s"
-const DisableEvaluationInterval = "never"
+const (
+	ExistOper                             = "Exists"
+	InOper                                = "In"
+	DoesNotExistOper                      = "DoesNotExist"
+	NotInOper                             = "NotIn"
+	CustomResource                        = "customResource"
+	SourceCRsPath                         = "source-crs"
+	FileExt                               = ".yaml"
+	UnsetStringValue                      = "__unset_value__"
+	ZtpDeployWaveAnnotation               = "ran.openshift.io/ztp-deploy-wave"
+	DefaultCompliantEvaluationInterval    = "10m"
+	DefaultNonCompliantEvaluationInterval = "10s"
+	DisableEvaluationInterval             = "never"
+	DefaultOutDir                         = "out"
+)
 
 // ComplianceType of "mustonlyhave" uses significant CPU to enforce. Default to
 // "musthave" so that we realize the CPU reductions unless explicitly told otherwise


### PR DESCRIPTION
The idea here similar to how one would test public APIs

1. "record" mode.
    1. Feed PGT binary with all of customers' PGT (a dir with all site+common+group)
    2. run the PGT binary and because it's diff record mode..the file names generated will be generic (depended on the source filename)

2. "diff" mode
    1.  Feed PGT binary with all of [reference](https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/gitops-subscriptions/argocd/example/policygentemplates) PGT (common-ranGen.yaml  + example-sno-site.yaml + group-du-sno-ranGen.yaml)
    2. run PGT binary (3 cases to handle) (the filenames should be the same as 1)2) )
        1. Exact match e.g both record and diff mode generated the same file (/v-out/git-out/ClusterLogNS.yaml/Namespace-openshift-logging.yaml). Do a diff.  No new file generated.
        2. Partial match. Sometimes exactly match might not be possible just by looking at file name but the directory name maybe same. e.g `/v-out/git-out/SriovNetworkNodePolicy.yaml/SriovNetworkNodePolicy-sriov-MY-MID-BAND-openshift-sriov-network-operator.yaml` vs `SriovNetworkNodePolicy.yaml/SriovNetworkNodePolicy-sriov-THEIR-MID-BAND-openshift-sriov-network-operator.yaml`. Attempt to diff there. No new file generated
        3. No match (we have it but they are not using it). Create a new file to record that.

/cc @lack 