### PR TITLE
ztp: [CNF-8046] Replacing LVMS source-crs instead of LVMO 

### DIFF
--- a/ztp/source-crs/LVMOperatorStatus.yaml
+++ b/ztp/source-crs/LVMOperatorStatus.yaml
@@ -1,0 +1,26 @@
+# This CR verifies the installation/upgrade of the Sriov Network Operator
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+  name: lvms-operator.openshift-storage
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+status:
+  components:
+    refs:
+    - kind: Subscription
+      namespace: openshift-storage
+      conditions:
+      - type: CatalogSourcesUnhealthy
+        status: "False"
+    - kind: InstallPlan
+      namespace: openshift-storage
+      conditions:
+      - type: Installed
+        status: "True"
+    - kind: ClusterServiceVersion
+      namespace: openshift-storage
+      conditions:
+      - type: Succeeded
+        status: "True"
+        reason: InstallSucceeded

--- a/ztp/source-crs/StorageLVMCluster.yaml
+++ b/ztp/source-crs/StorageLVMCluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: lvm.topolvm.io/v1alpha1
 kind: LVMCluster
 metadata:
-  name: odf-lvmcluster
+  name: lvmcluster
   namespace: openshift-storage
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"

--- a/ztp/source-crs/StorageLVMSubscription.yaml
+++ b/ztp/source-crs/StorageLVMSubscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lvms-operator
+  namespace: openshift-storage
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  channel: "stable-4.12"
+  name: lvms-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/ztp/source-crs/StorageLVMSubscriptionNS.yaml
+++ b/ztp/source-crs/StorageLVMSubscriptionNS.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-storage
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"

--- a/ztp/source-crs/StorageLVMSubscriptionOperGroup.yaml
+++ b/ztp/source-crs/StorageLVMSubscriptionOperGroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: lvms-operator-operatorgroup
+  namespace: openshift-storage
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  targetNamespaces:
+  - openshift-storage


### PR DESCRIPTION
Notice that in OCP 4.12+ the odf-lvmo operator was replaced by lvms operator. The source-crs were included in 4.11, this means that several overrides to those need to be made in order to install the LVMS operator in 4.12+.

This PR wants to ease the process of installing LVMS in OCP 4.12+. Therefore:

* New source-crs were included for LVMS. The old ones were not replaced by the new ones,  they are foreseen to be removed in 4.14. So the docs are still valid.
* The LVM cluster source-cr name was modified. This does not change anything in 4.11 or 4.12+.
* A new source-cr to validate the proper installation of the LVMS is included. If you want to use in 4.11 a name override must be added.

Documentation needs to be modified accordingly cc/ @amolnar-rh

cc/ @imiller0 