### PR TITLE
owners: add zeeke in cnf-features-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,12 +27,14 @@ aliases:
     - swatisehgal
     - bartwensley
     - sakhoury
+    - zeeke
   cnf-features-approvers:
     - fedepaol
     - SchSeba
     - ffromani
     - yuvalk
     - imiller0
+    - zeeke
   RAN-approvers:
     - ijolliffe
     - lack


### PR DESCRIPTION
@zeeke has been actively contributing to cnf-features-deploy in the form of code (24 PRs / 28 commits) and review contributions.