### PR TITLE
OCPBUGS-12965: ztp: update isRdma to false to match default value suggested in SriovNetworkNodePolicy doc

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-multinode-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-multinode-site.yaml
@@ -24,7 +24,7 @@ spec:
         name: "sriov-nnp-du-fh"
       spec:
         deviceType: netdevice
-        isRdma: true
+        isRdma: false
         nicSelector:
           pfNames: ["ens5f0"]
         numVfs: 8

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
@@ -23,7 +23,7 @@ spec:
         name: "sriov-nnp-du-fh"
       spec:
         deviceType: netdevice
-        isRdma: true
+        isRdma: false
         nicSelector:
           pfNames: ["ens5f0"]
         numVfs: 8


### PR DESCRIPTION
We should use the default config as mentioned in the official doc. See [this](https://docs.openshift.com/container-platform/4.12/networking/hardware_networks/configuring-sriov-device.html) for the latest.