### PR TITLE
OCPBUGS-12966: ztp: fix argocd patch volume keys

### DIFF
--- a/ztp/gitops-subscriptions/argocd/deployment/argocd-openshift-gitops-patch.json
+++ b/ztp/gitops-subscriptions/argocd/deployment/argocd-openshift-gitops-patch.json
@@ -17,8 +17,7 @@
       "volumes": [
         {
           "name": "kustomize",
-          "readOnly": false,
-          "path": "/.config"
+          "emptyDir": {}
         }
       ],
       "initContainers": [


### PR DESCRIPTION
See argoCD operator [apis](https://github.com/argoproj-labs/argocd-operator/blob/9fefa311208ed0e39f41a6c72c4834dba943b2f5/api/v1alpha1/argocd_types.go#L449). It a standard `[]corev1.Volume` which expects a `name` and `VolumeSource` e.g emptyDir/AzureDisk/hostPath. 

If not specified, the Volume is implied to be an EmptyDir. Which is why there was warning but everything worked as expected. 

/cc @imiller0 
/cc @lack 