### PR TITLE
OCPBUGS-6763: ztp: Cleanup some source CRs

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
@@ -47,13 +47,10 @@ spec:
       spec:
         profile:
           - name: performance-patch
-            # The cmdline_crash CPU set must match the 'isolated' set in the PerformanceProfile above
             data: |
               [main]
               summary=Configuration changes profile inherited from performance created tuned
               include=openshift-node-performance-openshift-node-performance-profile
-              [bootloader]
-              cmdline_crash=nohz_full=2-19,22-39
               [sysctl]
               kernel.timer_migration=1
               [scheduler]

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -12,8 +12,6 @@ spec:
     du-profile: "latest"
   mcp: "master"
   sourceFiles:
-    - fileName: ConsoleOperatorDisable.yaml
-      policyName: "config-policy"
     # Set ClusterLogForwarder & ClusterLogging as example might be better to create another policyTemp-Group
     - fileName: ClusterLogForwarder.yaml
       policyName: "config-policy"
@@ -83,7 +81,6 @@ spec:
       spec:
         configDaemonNodeSelector:
           node-role.kubernetes.io/worker: ""
-        disableDrain: true
     - fileName: StorageLV.yaml
       policyName: "config-policy"
       spec:
@@ -129,13 +126,10 @@ spec:
       spec:
         profile:
           - name: performance-patch
-            # The cmdline_crash CPU set must match the 'isolated' set in the PerformanceProfile above
             data: |
               [main]
               summary=Configuration changes profile inherited from performance created tuned
               include=openshift-node-performance-openshift-node-performance-profile
-              [bootloader]
-              cmdline_crash=nohz_full=2-19,22-39
               [sysctl]
               kernel.timer_migration=1
               [scheduler]

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
@@ -47,13 +47,10 @@ spec:
       spec:
         profile:
           - name: performance-patch
-            # The cmdline_crash CPU set must match the 'isolated' set in the PerformanceProfile above
             data: |
               [main]
               summary=Configuration changes profile inherited from performance created tuned
               include=openshift-node-performance-openshift-node-performance-profile
-              [bootloader]
-              cmdline_crash=nohz_full=2-19,22-39
               [sysctl]
               kernel.timer_migration=1
               [scheduler]

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
@@ -10,8 +10,6 @@ spec:
     group-du-sno: ""
   mcp: "master"
   sourceFiles:
-    - fileName: ConsoleOperatorDisable.yaml
-      policyName: "console-policy"
     # Set ClusterLogForwarder & ClusterLogging as example might be better to create another policyTemp-Group
     - fileName: ClusterLogForwarder.yaml
       policyName: "log-forwarder-policy"
@@ -59,8 +57,6 @@ spec:
           phc2sysOpts: "-a -r -n 24"
     - fileName: SriovOperatorConfig.yaml
       policyName: "sriov-operconfig-policy"
-      spec:
-        disableDrain: true
     - fileName: MachineConfigAcceleratedStartup.yaml
       policyName: "mc-accelerated-policy"
       metadata:

--- a/ztp/policygenerator/README.md
+++ b/ztp/policygenerator/README.md
@@ -10,7 +10,7 @@ By default, the policies created have `remediationAction: inform`, so that other
 To use the Topology Aware Lifecycle Operator roll out the policies, ZTP deploy waves are used to order how policies are applied to the spoke cluster.  All policies created by PolicyGen have a ztp deploy wave by default. The ztp deploy wave of each policy is set by using the `ran.openshift.io/ztp-deploy-wave` annotation which is based on the same wave annotation from each [source CR](../source-crs/README.md) included in the policy. The policies have lower values should be applied first. All CRs have the same wave should be applied in the same policy. For the CRs with different waves, which means they have dependency between each other, so they are supposed to be applied in the separate policies. It's also possible to override the default source CR wave via the PolicyGenTemplate so that the CR can be included the same policy and the wave overrides should be reflected in the policy level.
 
 ### Examples
-- Example 1: Consider the PolicyGenTemplate below to create ACM policies for both [ConsoleOperatorDisable.yaml](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/source-crs/ConsoleOperatorDisable.yaml) and [ClusterLogging.yaml](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/source-crs/ClusterLogging.yaml).
+- Example 1: Consider the PolicyGenTemplate below to create ACM policies for both [DisableSnoNetworkDiag.yaml](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/source-crs/DisableSnoNetworkDiag.yaml) and [ClusterLogging.yaml](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/source-crs/ClusterLogging.yaml).
 ```
 apiVersion: ran.openshift.io/v1
 kind: PolicyGenTemplate
@@ -22,8 +22,8 @@ spec:
     group-du-sno: ""
   mcp: "master"
   sourceFiles:
-    - fileName: ConsoleOperatorDisable.yaml
-      policyName: "console-policy"
+    - fileName: DisableSnoNetworkDiag.yaml
+      policyName: "network-policy"
     - fileName: ClusterLogging.yaml
       policyName: "log-policy"
       spec:
@@ -47,7 +47,7 @@ metadata:
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
     policy.open-cluster-management.io/standards: NIST SP 800-53
     ran.openshift.io/ztp-deploy-wave: "10"
-  name: group-du-sno-console-policy
+  name: group-du-sno-network-policy
   namespace: group-du-sno-policies
 spec:
   disabled: false
@@ -56,8 +56,11 @@ spec:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
       metadata:
-        name: group-du-sno-console-policy-config
+        name: group-du-sno-network-policy-config
       spec:
+        evaluationInterval:
+          compliant: 10m
+          noncompliant: 10s
         namespaceselector:
           exclude:
           - kube-*
@@ -67,18 +70,11 @@ spec:
         - complianceType: musthave
           objectDefinition:
             apiVersion: operator.openshift.io/v1
-            kind: Console
+            kind: Network
             metadata:
-              annotations:
-                include.release.openshift.io/ibm-cloud-managed: "false"
-                include.release.openshift.io/self-managed-high-availability: "false"
-                include.release.openshift.io/single-node-developer: "false"
-                release.openshift.io/create-only: "true"
               name: cluster
             spec:
-              logLevel: Normal
-              managementState: Removed
-              operatorLogLevel: Normal
+              disableNetworkDiagnostics: true
         remediationAction: inform
         severity: low
   remediationAction: inform

--- a/ztp/ran-crd/policy-gen-template-ex.yaml
+++ b/ztp/ran-crd/policy-gen-template-ex.yaml
@@ -14,10 +14,6 @@ spec:
     noncompliant: 15s
 
   sourceFiles:
-    - fileName: ConsoleOperatorDisable.yaml
-      policyName: "console-policy"
-      evaluationInterval:
-        compliant: never
     - fileName: ClusterLogging.yaml
       policyName: "cluster-log-policy"
       evaluationInterval:

--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
@@ -7,7 +7,7 @@ spec:
   baseDomain: "example.com"
   pullSecretRef:
     name: "pullSecretName"
-  clusterImageSetNameRef: "openshift-v4.8.0"
+  clusterImageSetNameRef: "openshift-v4.13.0"
   sshPublicKey: "ssh-rsa "
   sshPrivateKeySecretRef:
     name: "sshPrvKey"
@@ -16,6 +16,7 @@ spec:
     biosConfigRef:
       filePath: "testSiteConfig/testHW.profile"
     networkType: OVNKubernetes
+    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
     extraManifestPath: testSiteConfig/testUserExtraManifest
     clusterLabels:
       group-du-sno: ""

--- a/ztp/source-crs/SriovOperatorConfig.yaml
+++ b/ztp/source-crs/SriovOperatorConfig.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   configDaemonNodeSelector:
     "node-role.kubernetes.io/$mcp": ""
-  disableDrain: false
   # Injector and OperatorWebhook pods can be disabled (set to "false") below
   # to reduce the number of management pods. It is recommended to start with the 
   # webhook and injector pods enabled, and only disable them after verifying the

--- a/ztp/source-crs/TunedPerformancePatch.yaml
+++ b/ztp/source-crs/TunedPerformancePatch.yaml
@@ -11,15 +11,12 @@ spec:
       # Please note:
       # - The 'include' line must match the associated PerformanceProfile name, following below pattern
       #   include=openshift-node-performance-${PerformanceProfile.metadata.name}
-      # - The 'cmdline_crash' CPU set must match the 'isolated' set in the associated PerformanceProfile
       # - When using the standard (non-realtime) kernel, remove the kernel.timer_migration override from
       #   the [sysctl] section and remove the entire section if it is empty.
       data: |
         [main]
         summary=Configuration changes profile inherited from performance created tuned
         include=openshift-node-performance-openshift-node-performance-profile
-        [bootloader]
-        cmdline_crash=nohz_full=${isolated_cores}
         [sysctl]
         kernel.timer_migration=1
         [scheduler]


### PR DESCRIPTION
- 'nohz_full=${isolated_cores}' is removed from TunedPerformancePatch.yaml as it's covered in the auto-created tuned patch for the performanceProfile already.

- The reference to ConsoleOperatorDisable.yaml is removed from the PGT example as the console operator is not installed in the first place when disabling baselineCapabilitySet via SiteConfig

- 'disableDrain: false' is removed from SriovOperatorConfig.yaml as it's set automatically by the operator. It's marked to true when the cluster is SNO and false for other types