### PR TITLE
cnf-tests: Rewrite the cnf-tests container to contain only the latency tests

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -1,35 +1,3 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
-WORKDIR /go/src/github.com/openshift-kni/cnf-features-deploy
-COPY . .
-RUN make test-bin
-RUN git rev-list -1 HEAD > ./cnf-tests/bin/cnftests-sha.txt
-
-FROM quay.io/openshift/origin-oc-rpms:4.13 AS oc
-
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder-stresser
-ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
-ENV PKG_PATH=/go/src/$PKG_NAME
-ENV TESTER_PATH=$PKG_PATH/cnf-tests/pod-utils/stresser
-
-RUN mkdir -p $PKG_PATH
-
-COPY . $PKG_PATH/
-WORKDIR $TESTER_PATH
-
-RUN go build -mod=vendor -o /stresser
-
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder-sctptester
-ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
-ENV PKG_PATH=/go/src/$PKG_NAME
-ENV TESTER_PATH=$PKG_PATH/cnf-tests/pod-utils/sctptester
-
-RUN mkdir -p $PKG_PATH
-
-COPY . $PKG_PATH/
-WORKDIR $TESTER_PATH
-
-RUN go build -mod=vendor -o /sctptest
-
 # build latency-test's runner binaries
 FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder-latency-test-runners
 
@@ -46,6 +14,13 @@ RUN go build -mod=vendor -o /oslat-runner oslat-runner/main.go && \
     go build -mod=vendor -o /cyclictest-runner cyclictest-runner/main.go && \
     go build -mod=vendor -o /hwlatdetect-runner hwlatdetect-runner/main.go
 
+# build latency testing suite
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS go-builder
+WORKDIR /app
+COPY . .
+RUN make test-bin
+
+
 # Build latency-test binaries
 FROM centos:7 as builder-latency-test-tools
 
@@ -61,15 +36,16 @@ RUN yum install -y numactl-devel make gcc && \
     cp hwlatdetect /hwlatdetect && \
     cp cyclictest /cyclictest
 
+FROM quay.io/openshift/origin-oc-rpms:4.13 AS oc
+
+
+# Final image
 FROM centos:7
 
 # python3 is needed for hwlatdetect
 RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs linuxptp iperf3 python3 nc iptables
 
 RUN mkdir -p /usr/local/etc/cnf
-
-COPY --from=builder-stresser /stresser /usr/bin/stresser
-COPY --from=builder-sctptester /sctptest /usr/bin/sctptest
 
 COPY --from=builder-latency-test-runners /oslat-runner /usr/bin/oslat-runner
 COPY --from=builder-latency-test-tools /oslat /usr/bin/oslat
@@ -81,14 +57,15 @@ COPY --from=builder-latency-test-runners /hwlatdetect-runner /usr/bin/hwlatdetec
 COPY --from=builder-latency-test-tools /hwlatdetect /usr/bin/hwlatdetect
 
 COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests /usr/bin/cnftests
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/configsuite /usr/bin/configsuite
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/validationsuite /usr/bin/validationsuite
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/entrypoint/test-run.sh /usr/bin/test-run.sh
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/mirror /usr/bin/mirror
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/mirror/images.json /usr/local/etc/cnf
-COPY --from=builder /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/bin/cnftests-sha.txt /usr/local/etc/cnf
+
+COPY --from=go-builder /app/cnf-tests/bin/mirror /usr/bin/mirror
+COPY --from=go-builder /app/cnf-tests/mirror/images.json /usr/local/etc/cnf
+COPY --from=go-builder /app/cnf-tests/entrypoint/test-run.sh /usr/bin/test-run.sh
+
 COPY tools/oot-driver/ /usr/src/oot-driver/
+
+# Copy test suite
+COPY --from=go-builder /app/cnf-tests/submodules/cluster-node-tuning-operator/build/_output/bin/latency-e2e.test /usr/bin/latency-e2e.test
 
 ENV SUITES_PATH=/usr/bin/
 

--- a/cnf-tests/entrypoint/test-run.sh
+++ b/cnf-tests/entrypoint/test-run.sh
@@ -3,19 +3,13 @@ set -e
 # Setting -e is fine as we want both config and validiation to succeed
 # before running the "real" tests.
 
-TEST_SUITES=${TEST_SUITES:-"validationsuite configsuite cnftests"}
-SUITES_PATH="${SUITES_PATH:-~/usr/bin}"
+LATENCY_TEST_RUN="${LATENCY_TEST_RUN:-true}"
+DISCOVERY_MODE="${DISCOVERY_MODE:-true}"
+FEATURES="${FEATURES:-performance}"
 
-suites=( $TEST_SUITES )
 if [ "$IMAGE_REGISTRY" != "" ] && [[ "$IMAGE_REGISTRY" != */ ]]; then
     export IMAGE_REGISTRY="$IMAGE_REGISTRY/"
 fi
 
-for suite in "${suites[@]}"; do
-    if [ "$DISCOVERY_MODE" == "true" ] &&  [ "$suite" == "configsuite" ]; then
-        echo "Discovery mode enabled, skipping setup"
-        continue
-    fi
-    echo running "$SUITES_PATH/$suite" "$@"
-    "$SUITES_PATH/$suite" "$@"
-done
+echo running "/usr/bin/latency-e2e.test"
+LATENCY_TEST_RUN="$LATENCY_TEST_RUN" DISCOVERY_MODE="$DISCOVERY_MODE" FEATURES="$FEATURES" "/usr/bin/latency-e2e.test"

--- a/cnf-tests/hack/build-test-bin.sh
+++ b/cnf-tests/hack/build-test-bin.sh
@@ -16,27 +16,12 @@ export GOFLAGS="${GOFLAGS:-"-mod=vendor"}"
 export PATH=$PATH:$GOPATH/bin
 DONT_REBUILD_TEST_BINS="${DONT_REBUILD_TEST_BINS:-false}"
 
-if ! which ginkgo; then
-	echo "Installing ginkgo tool from vendor"
-	go install -mod=vendor github.com/onsi/ginkgo/v2/ginkgo
-fi
-
-mkdir -p bin
-
-function build_and_move_suite {
-  suite=$1
-  target=$2
-
-  if [ "$DONT_REBUILD_TEST_BINS" == "false" ] || [ ! -f "$target" ]; then
-    ginkgo build ./testsuites/"$suite"
-    mv ./testsuites/"$suite"/"$suite".test "$target"
-  fi
-}
-
-build_and_move_suite "e2esuite" "./bin/cnftests"
-build_and_move_suite "configsuite" "./bin/configsuite"
-build_and_move_suite "validationsuite" "./bin/validationsuite"
-
 if [ "$DONT_REBUILD_TEST_BINS" == "false" ] || [ -f ./cnf-tests/bin/mirror ]; then
+  echo "Building mirror ... "
   go build -o ./bin/mirror mirror/mirror.go
 fi
+
+pushd submodules/cluster-node-tuning-operator
+echo "Building latency tools ... "
+make dist-latency-tests
+popd


### PR DESCRIPTION
The cnf-tests split implementation #1501  breaks the cnf-tests container.
We don't build the test binaries anymore nor run the functional tests in a containerized way.

cnf-tests container is a supported product for running latency tests, 
so we need to rewrite the cnf-tests container Dockerfiles to include only the latency test.

Additionally it would be a god time to improve user interface to allow users 
to easily invoke the tests without providing many different parameters and environment variables, 
thus providing better UX and preventing errors.