### PR TITLE
OCPBUGS-9413: ztp: remove the deprecated curation section from ClusterLogging CR

### DIFF
--- a/feature-configs/5g-ref-nw/clusters/otwaon34567sno/nw-config/logging/README.md
+++ b/feature-configs/5g-ref-nw/clusters/otwaon34567sno/nw-config/logging/README.md
@@ -69,10 +69,6 @@ metadata:
   namespace: openshift-logging
 spec:
   managementState: "Managed"
-  curation:
-    type: "curator"
-    curator:
-      schedule: "30 3 * * *" 
   collection:
     logs:
       type: "fluentd"  

--- a/feature-configs/5g-ref-nw/profile-base/sno-general/cluster-logging.yaml
+++ b/feature-configs/5g-ref-nw/profile-base/sno-general/cluster-logging.yaml
@@ -5,10 +5,6 @@ metadata:
   namespace: openshift-logging
 spec:
   managementState: "Managed"
-  curation:
-    type: "curator"
-    curator:
-      schedule: "30 3 * * *" 
   collection:
     logs:
       type: "fluentd"  

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -35,9 +35,6 @@ spec:
     - fileName: ClusterLogging.yaml
       policyName: "config-policy"
       spec:
-        curation:
-          curator:
-            schedule: "30 3 * * *"
         collection:
           logs:
             type: "fluentd"

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
@@ -33,9 +33,6 @@ spec:
     - fileName: ClusterLogging.yaml
       policyName: "log-policy"
       spec:
-        curation:
-          curator:
-            schedule: "30 3 * * *"
         collection:
           logs:
             type: "fluentd"

--- a/ztp/policygenerator/README.md
+++ b/ztp/policygenerator/README.md
@@ -27,9 +27,6 @@ spec:
     - fileName: ClusterLogging.yaml
       policyName: "log-policy"
       spec:
-        curation:
-          curator:
-            schedule: "30 3 * * *"
         collection:
           logs:
             type: "fluentd"
@@ -116,10 +113,6 @@ spec:
                 logs:
                   fluentd: {}
                   type: fluentd
-              curation:
-                curator:
-                  schedule: 30 3 * * *
-                type: curator
               managementState: Managed
         remediationAction: inform
         severity: low

--- a/ztp/ran-crd/policy-gen-template-ex.yaml
+++ b/ztp/ran-crd/policy-gen-template-ex.yaml
@@ -19,9 +19,6 @@ spec:
       evaluationInterval:
         compliant: 30m
       spec:
-        curation:
-          curator:
-            schedule: "30 3 * * *"
         collection:
           logs:
             type: "fluentd"

--- a/ztp/source-crs/ClusterLogging.yaml
+++ b/ztp/source-crs/ClusterLogging.yaml
@@ -7,10 +7,6 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   managementState: "Managed"
-  curation:
-    type: "curator"
-    curator:
-      schedule: $schedule
   collection: $collection
 
 #apiVersion: logging.openshift.io/v1
@@ -20,10 +16,6 @@ spec:
 #  namespace: openshift-logging
 #spec:
 #  managementState: "Managed"
-#  curation:
-#    type: "curator"
-#    curator:
-#      schedule: "30 3 * * *"
 #  collection:
 #    logs:
 #      type: "fluentd"


### PR DESCRIPTION
The curation section is now completely deprecated in cluster logging 5.7 which can be safely cleaned up. Removing it shouldn't have any impact on users who currently have it configured.