### PR TITLE
s2i: add capabilities on testpmd and testbbdev bins

### DIFF
--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -67,6 +67,10 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 
 RUN setcap cap_sys_resource,cap_ipc_lock=+ep /usr/libexec/s2i/run
 
+# Allows non-root users to use dpdk-testpmd.
+RUN setcap cap_sys_resource,cap_ipc_lock,cap_net_raw+ep /usr/local/bin/dpdk-testpmd
+RUN setcap cap_sys_resource,cap_ipc_lock,cap_net_raw+ep /usr/local/bin/dpdk-test-bbdev
+
 # This is needed for the s2i to work
 # in the pod yaml we still use the runAsUser:0 we w/a the ulimit issue
 USER 1001


### PR DESCRIPTION
This adds the sys_resource, ipc_lock and net_raw (for mellanox) on the testpmd and testbbdev binaries for unpriviledged pods.