### PR TITLE
ztp: Expose disk cleaning option through SiteConfig

### DIFF
--- a/ztp/ran-crd/site-config-crd.yaml
+++ b/ztp/ran-crd/site-config-crd.yaml
@@ -318,6 +318,14 @@ spec:
                                 - UEFI
                                 - UEFISecureBoot
                                 - legacy
+                            automatedCleaningMode:
+                              description: When set to disabled, automated cleaning will be avoided
+                                during provisioning and deprovisioning.
+                              type: string
+                              default: disabled
+                              enum:
+                                - metadata
+                                - disabled
                             role:
                               description: The node role master|worker
                               type: string

--- a/ztp/siteconfig-generator/siteConfig/clusterCRs.go
+++ b/ztp/siteconfig-generator/siteConfig/clusterCRs.go
@@ -119,7 +119,7 @@ spec:
     disableCertificateVerification: true
     credentialsName: "{{ .Node.BmcCredentialsName.Name }}"
   bootMACAddress: "{{ .Node.BootMACAddress }}"
-  automatedCleaningMode: disabled
+  automatedCleaningMode: "{{ .Node.AutomatedCleaningMode }}"
   online: true
   rootDeviceHints: "{{ .Node.RootDeviceHints }}"
   userData:  "{{ .Node.UserData }}"

--- a/ztp/siteconfig-generator/siteConfig/siteConfig.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig.go
@@ -398,6 +398,7 @@ func (prt *Partitions) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type Nodes struct {
 	BmcAddress             string                 `yaml:"bmcAddress"`
 	BootMACAddress         string                 `yaml:"bootMACAddress"`
+	AutomatedCleaningMode  string                 `yaml:"automatedCleaningMode"`
 	RootDeviceHints        map[string]interface{} `yaml:"rootDeviceHints"`
 	Cpuset                 string                 `yaml:"cpuset"`
 	NodeNetwork            NodeNetwork            `yaml:"nodeNetwork"`
@@ -419,9 +420,10 @@ type Nodes struct {
 func (rv *Nodes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type ValueDefaulted Nodes
 	var defaults = ValueDefaulted{
-		BootMode:      "UEFI",
-		Role:          "master",
-		IronicInspect: "disabled",
+		BootMode:              "UEFI",
+		Role:                  "master",
+		IronicInspect:         "disabled",
+		AutomatedCleaningMode: "disabled",
 	}
 
 	out := defaults

--- a/ztp/siteconfig-generator/siteConfig/siteConfigHelper_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigHelper_test.go
@@ -130,7 +130,6 @@ metadata:
   name: node1
   namespace: cluster1
 spec:
-    automatedCleaningMode: disabled
 `}
 	var clusterCRs []interface{}
 
@@ -252,7 +251,6 @@ metadata:
   name: node1
   namespace: cluster1
 spec:
-    automatedCleaningMode: disabled
 `}
 
 	testcases := []struct {

--- a/ztp/siteconfig-generator/siteConfig/siteConfig_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig_test.go
@@ -2,10 +2,10 @@ package siteConfig
 
 import (
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
@@ -53,6 +53,7 @@ spec:
       bootMode: "legacy"
       role: "worker"
     - hostName: "master1-default"
+      automatedCleaningMode: "metadata"
     - hostName: "master2-explicit"
       bootMode: "UEFI"
       role: "master"
@@ -73,6 +74,12 @@ spec:
 	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[1].Role, "master")
 	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[2].Role, "master")
 	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[3].Role, "master")
+
+	// Validate AutomatedCleaningMode
+	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[0].AutomatedCleaningMode, "disabled")
+	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[1].AutomatedCleaningMode, "metadata")
+	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[2].AutomatedCleaningMode, "disabled")
+	assert.Equal(t, siteConfig.Spec.Clusters[0].Nodes[3].AutomatedCleaningMode, "disabled")
 }
 
 // Test cases for default values on fields in the
@@ -191,6 +198,7 @@ spec:
 func TestGetSiteConfigFieldValue(t *testing.T) {
 	pullSecretValue := "pullSecretName"
 	cluster0Node0BmcValue := "bmc-secret"
+	cluster0Node0AutomatedCleaningMode := "metadata"
 	cluster1Node1Name := "node1"
 	siteConfigStr := `
 apiVersion: ran.openshift.io/v1
@@ -208,6 +216,7 @@ spec:
       - hostName: "node0"
         bmcCredentialsName:
           name: ` + cluster0Node0BmcValue + `
+        automatedCleaningMode: ` + cluster0Node0AutomatedCleaningMode + `
   - clusterName: "test-site1"
     nodes:
       - hostName: "node0"
@@ -229,6 +238,9 @@ spec:
 
 	fieldV, _ = siteConfig.GetSiteConfigFieldValue("siteconfig.Spec.Clusters.Nodes.HostName", 1, 1)
 	assert.Equal(t, fieldV, cluster1Node1Name)
+
+	fieldV, _ = siteConfig.GetSiteConfigFieldValue("siteconfig.Spec.Clusters.Nodes.AutomatedCleaningMode", 0, 0)
+	assert.Equal(t, fieldV, cluster0Node0AutomatedCleaningMode)
 
 	// Test empty path
 	fieldV, _ = siteConfig.GetSiteConfigFieldValue("siteconfig.Spec.Clusters.Nodes.BmcCredentialsName.Name", 1, 1)

--- a/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride-badAnnotation.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride-badAnnotation.yaml
@@ -19,7 +19,7 @@ spec:
     disableCertificateVerification: true
     credentialsName: "{{ .Node.BmcCredentialsName.Name }}"
   bootMACAddress: "{{ .Node.BootMACAddress }}"
-  automatedCleaningMode: disabled
+  automatedCleaningMode: "{{ .Node.AutomatedCleaningMode }}"
   online: true
   rootDeviceHints: "{{ .Node.RootDeviceHints }}"
   userData:  "{{ .Node.UserData }}"

--- a/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride-badName.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride-badName.yaml
@@ -19,7 +19,7 @@ spec:
     disableCertificateVerification: true
     credentialsName: "{{ .Node.BmcCredentialsName.Name }}"
   bootMACAddress: "{{ .Node.BootMACAddress }}"
-  automatedCleaningMode: disabled
+  automatedCleaningMode: "{{ .Node.AutomatedCleaningMode }}"
   online: true
   rootDeviceHints: "{{ .Node.RootDeviceHints }}"
   userData:  "{{ .Node.UserData }}"

--- a/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride-badNamespace.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride-badNamespace.yaml
@@ -19,7 +19,7 @@ spec:
     disableCertificateVerification: true
     credentialsName: "{{ .Node.BmcCredentialsName.Name }}"
   bootMACAddress: "{{ .Node.BootMACAddress }}"
-  automatedCleaningMode: disabled
+  automatedCleaningMode: "{{ .Node.AutomatedCleaningMode }}"
   online: true
   rootDeviceHints: "{{ .Node.RootDeviceHints }}"
   userData:  "{{ .Node.UserData }}"

--- a/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride.yaml
@@ -19,7 +19,7 @@ spec:
     disableCertificateVerification: true
     credentialsName: "{{ .Node.BmcCredentialsName.Name }}"
   bootMACAddress: "{{ .Node.BootMACAddress }}"
-  automatedCleaningMode: disabled
+  automatedCleaningMode: "{{ .Node.AutomatedCleaningMode }}"
   online: true
   rootDeviceHints: "{{ .Node.RootDeviceHints }}"
   userData:  "{{ .Node.UserData }}"


### PR DESCRIPTION
- add the automatedCleaningMode field to the SiteConfig CRD and by default set it to "disabled" (path to the new field is SiteConfig.Spec.Cluster.Node.automatedCleaningMode)
- the automatedCleaningMode field from a SiteConfig CR will be translated into the spec.automatedCleaningMode field in the generated BareMetalHost CR(s)
- update testcases to reflect this new field