### PR TITLE
ztp: rename DefaultCatsrc to inform that CR is for disconnected env and update all subscriptions

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-common-ranGen.yaml
@@ -35,7 +35,7 @@ policies:
     - path: source-crs/DefaultCatsrc.yaml
       patches:
       - metadata:
-          name: redhat-operators
+          name: redhat-operators-disconnected
         spec:
           displayName: disconnected-redhat-operators
           image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.9

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
@@ -64,12 +64,13 @@ spec:
       policyName: "config-policy"
     - fileName: DefaultCatsrc.yaml
       policyName: "config-policy"
-      # The Subscriptions all point to redhat-operators. The OperatorHub CR
-      # disables the defaults and this CR replaces redhat-operators with a
+      # The Subscriptions all point to redhat-operators-disconnected. The OperatorHub CR
+      # disables the defaults and this CR replaces redhat-operators-disconnected with a
       # CatalogSource pointing to the disconnected registry. Including both of
       # these in the same policy orders their application to the cluster.
+      # Tip: for RH sources `image: registry.redhat.io/redhat/redhat-operator-index:v4.xx`
       metadata:
-        name: redhat-operators
+        name: redhat-operators-disconnected
       spec:
         displayName: disconnected-redhat-operators
         image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.9

--- a/ztp/source-crs/AmqSubscription.yaml
+++ b/ztp/source-crs/AmqSubscription.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   channel: 1.10.x
   name:  amq7-interconnect-operator
-  source: redhat-operators
+  source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
 status:

--- a/ztp/source-crs/BareMetalEventRelaySubscription.yaml
+++ b/ztp/source-crs/BareMetalEventRelaySubscription.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   channel: "stable"
   name: bare-metal-event-relay
-  source: redhat-operators
+  source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
 status:

--- a/ztp/source-crs/ClusterLogSubscription.yaml
+++ b/ztp/source-crs/ClusterLogSubscription.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   channel: "stable"
   name: cluster-logging
-  source: redhat-operators
+  source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
 status:

--- a/ztp/source-crs/PaoSubscription.yaml
+++ b/ztp/source-crs/PaoSubscription.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   channel: "4.10"
   name: performance-addon-operator
-  source: redhat-operators
+  source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
 status:

--- a/ztp/source-crs/PtpSubscription.yaml
+++ b/ztp/source-crs/PtpSubscription.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   channel: "stable"
   name: ptp-operator
-  source: redhat-operators
+  source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
 status:

--- a/ztp/source-crs/SriovSubscription.yaml
+++ b/ztp/source-crs/SriovSubscription.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   channel: "stable"
   name: sriov-network-operator
-  source: redhat-operators
+  source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
 status:

--- a/ztp/source-crs/StorageLVMOSubscription.yaml
+++ b/ztp/source-crs/StorageLVMOSubscription.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   channel: "stable-4.11"
   name: odf-lvm-operator
-  source: redhat-operators
+  source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
 status:

--- a/ztp/source-crs/StorageLVMSubscription.yaml
+++ b/ztp/source-crs/StorageLVMSubscription.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   channel: "stable-4.12"
   name: lvms-operator
-  source: redhat-operators
+  source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
 status:

--- a/ztp/source-crs/StorageSubscription.yaml
+++ b/ztp/source-crs/StorageSubscription.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   channel: "stable"
   name: local-storage-operator
-  source: redhat-operators
+  source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
 status:


### PR DESCRIPTION
CNF-8305. Using DefaultCatsrc CR means we are using disconnected env.

/cc @imiller0 
/cc @sabbir-47 