### PR TITLE
features: remove the deploy of sriov configs from ran-profile

### DIFF
--- a/feature-configs/cn-ran-overlays/ran-profile/kustomization.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/kustomization.yaml
@@ -3,6 +3,5 @@ kind: Kustomization
 
 bases:
   - cluster-config
-  - site.1.fqdn
 
 


### PR DESCRIPTION
Remove the site specific configs(sriov) example from the ran-profile deploy. This should not be applied on the virtual cluster(AWS/GCP) without sriov devices. 