### PR TITLE
CNF-7818: ztp: Uncomment workloadHints object in PerformanceProfile

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-3node-ranGen.yaml
@@ -178,10 +178,6 @@ policies:
             pools.operator.machineconfiguration.openshift.io/master: ""
           nodeSelector:
             node-role.kubernetes.io/master: ''
-          workloadHints:
-            realTime: true
-            highPowerConsumption: false
-            perPodPowerManagement: false
     - path: source-crs/TunedPerformancePatch.yaml
       patches:
       - spec:

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
@@ -245,10 +245,6 @@ policies:
             pools.operator.machineconfiguration.openshift.io/master: ""
           nodeSelector:
             node-role.kubernetes.io/master: ''
-          workloadHints:
-            realTime: true
-            highPowerConsumption: false
-            perPodPowerManagement: false
     - path: source-crs/TunedPerformancePatch.yaml
       patches:
       - spec:

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-standard-ranGen.yaml
@@ -183,10 +183,6 @@ policies:
             pools.operator.machineconfiguration.openshift.io/worker: ""
           nodeSelector:
             node-role.kubernetes.io/worker: ''
-          workloadHints:
-            realTime: true
-            highPowerConsumption: false
-            perPodPowerManagement: false
     - path: source-crs/TunedPerformancePatch.yaml
       patches:
       - spec:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
@@ -38,10 +38,6 @@ spec:
           pages:
             - size: 1G
               count: 32
-        workloadHints:
-          realTime: true
-          highPowerConsumption: false
-          perPodPowerManagement: false
     - fileName: TunedPerformancePatch.yaml
       policyName: "config-policy"
       spec:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -116,10 +116,6 @@ spec:
           pages:
             - size: 1G
               count: 32
-        workloadHints:
-          realTime: true
-          highPowerConsumption: false
-          perPodPowerManagement: false
     - fileName: TunedPerformancePatch.yaml
       policyName: "config-policy"
       spec:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
@@ -38,10 +38,6 @@ spec:
           pages:
             - size: 1G
               count: 32
-        workloadHints:
-          realTime: true
-          highPowerConsumption: false
-          perPodPowerManagement: false
     - fileName: TunedPerformancePatch.yaml
       policyName: "config-policy"
       spec:

--- a/ztp/source-crs/PerformanceProfile-SetSelector.yaml
+++ b/ztp/source-crs/PerformanceProfile-SetSelector.yaml
@@ -31,11 +31,11 @@ spec:
   # To use the standard (non-realtime) kernel, set enabled to false
   realTimeKernel:
     enabled: true
-  # workloadHints:
+  workloadHints:
     # WorkloadHints defines the set of upper level flags for different type of workloads.
     # See https://github.com/openshift/cluster-node-tuning-operator/blob/master/docs/performanceprofile/performance_profile.md#workloadhints
     # for detailed descriptions of each item.
     # The configuration below is set for a low latency, performance mode.
-    # realTime: true
-    # highPowerConsumption: false
-    # perPodPowerManagement: false
+    realTime: true
+    highPowerConsumption: false
+    perPodPowerManagement: false

--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -32,11 +32,11 @@ spec:
   # To use the standard (non-realtime) kernel, set enabled to false
   realTimeKernel:
     enabled: true
-  # workloadHints:
+  workloadHints:
     # WorkloadHints defines the set of upper level flags for different type of workloads.
     # See https://github.com/openshift/cluster-node-tuning-operator/blob/master/docs/performanceprofile/performance_profile.md#workloadhints
     # for detailed descriptions of each item.
     # The configuration below is set for a low latency, performance mode.
-    # realTime: true
-    # highPowerConsumption: false
-    # perPodPowerManagement: false
+    realTime: true
+    highPowerConsumption: false
+    perPodPowerManagement: false


### PR DESCRIPTION
The is PR re-introduces the `workloadHints` object in the PerformanceProfile source-crs. It was initially added in 4.13, however it had to be commented out because at that point QE was experiencing issues deploying tests as ZTP was version unaware.

Now, with ZTP version awareness - it can be safely added back.

/cc @imiller0 @bartwensley  @serngawy @sabbir-47 