### PR TITLE
OCPBUGS-15470: Fix PCI addr calculation in DPDK tests

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -924,7 +924,7 @@ func findNUMAForSRIOV(pod *corev1.Pod) (int, error) {
 	pciAddress := ""
 	pciEnvVariableName := fmt.Sprintf("PCIDEVICE_OPENSHIFT_IO_%s", strings.ToUpper(dpdkResourceName))
 	for _, line := range strings.Split(buff.String(), "\r\n") {
-		if strings.Contains(line, pciEnvVariableName) {
+		if strings.Contains(line, pciEnvVariableName+"=") {
 			envSplit := strings.Split(line, "=")
 			Expect(len(envSplit)).To(Equal(2))
 			pciAddress = envSplit[1]


### PR DESCRIPTION
DPDK workloads get multiple environment variables injected by the device plugin, e.g:

```
PCIDEVICE_OPENSHIFT_IO_DU_FH=0000:1a:03.4
PCIDEVICE_OPENSHIFT_IO_DU_FH_INFO={"0000:1a:03.4":{"generic":
{"deviceID":"0000:1a:03.4"},
"vfio":{"dev-mount":"/dev/vfio/206","mount":"/dev/vfio/vfio"}}}
```

`findNUMAForSRIOV` had chances to read the
`PCIDEVICE_OPENSHIFT_IO_*_INFO` variable, as listing them has no predictable order.