### PR TITLE
OCPBUGS-16094: Revert "OCPBUGS-3513: use manifestsConfigMapRefs "

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/clusterCRs.go
+++ b/ztp/siteconfig-generator/siteConfig/clusterCRs.go
@@ -37,8 +37,8 @@ spec:
     workerAgents: "{{ .Cluster.NumWorkers }}"
   proxy: "{{ .Cluster.ProxySettings }}"
   sshPublicKey: "{{ .Site.SshPublicKey }}"
-  manifestsConfigMapRefs:
-  - name: "{{ .Cluster.ClusterName }}"
+  manifestsConfigMapRef:
+    name: "{{ .Cluster.ClusterName }}"
 ---
 apiVersion: hive.openshift.io/v1
 kind: ClusterDeployment

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
@@ -285,16 +285,6 @@ func (scbuilder *SiteConfigBuilder) getClusterCR(clusterId int, siteConfigTemp S
 				return mapIntf, err
 			}
 			mapIntf[k] = value
-		} else if reflect.ValueOf(v).Kind() == reflect.Slice {
-			sliceValues := make([]interface{}, 0)
-			for _, item := range v.([]interface{}) {
-				val, err := scbuilder.getClusterCR(clusterId, siteConfigTemp, item.(map[string]interface{}), nodeId)
-				if err != nil {
-					return mapIntf, err
-				}
-				sliceValues = append(sliceValues, val)
-			}
-			mapIntf[k] = sliceValues
 		} else if reflect.ValueOf(v).Kind() == reflect.String &&
 			strings.HasPrefix(v.(string), "{{") &&
 			strings.HasSuffix(v.(string), "}}") {

--- a/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/mergeMC.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/mergeMC.yaml
@@ -23,8 +23,8 @@ spec:
         name: cluster1
     imageSetRef:
         name: openshift-v4.8.0
-    manifestsConfigMapRefs:
-        - name: cluster1
+    manifestsConfigMapRef:
+        name: cluster1
     networking: {}
     provisionRequirements:
         controlPlaneAgents: 1

--- a/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/splitMC.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/splitMC.yaml
@@ -23,8 +23,8 @@ spec:
         name: cluster1
     imageSetRef:
         name: openshift-v4.8.0
-    manifestsConfigMapRefs:
-        - name: cluster1
+    manifestsConfigMapRef:
+        name: cluster1
     networking: {}
     provisionRequirements:
         controlPlaneAgents: 1

--- a/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/onlyUserCR.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/onlyUserCR.yaml
@@ -23,8 +23,8 @@ spec:
         name: cluster1
     imageSetRef:
         name: openshift-v4.8.0
-    manifestsConfigMapRefs:
-        - name: cluster1
+    manifestsConfigMapRef:
+        name: cluster1
     networking: {}
     provisionRequirements:
         controlPlaneAgents: 1

--- a/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/partialfilter.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/partialfilter.yaml
@@ -23,8 +23,8 @@ spec:
         name: cluster1
     imageSetRef:
         name: openshift-v4.8.0
-    manifestsConfigMapRefs:
-        - name: cluster1
+    manifestsConfigMapRef:
+        name: cluster1
     networking: {}
     provisionRequirements:
         controlPlaneAgents: 1

--- a/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/removeAll.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/removeAll.yaml
@@ -23,8 +23,8 @@ spec:
         name: cluster1
     imageSetRef:
         name: openshift-v4.8.0
-    manifestsConfigMapRefs:
-        - name: cluster1
+    manifestsConfigMapRef:
+        name: cluster1
     networking: {}
     provisionRequirements:
         controlPlaneAgents: 1

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningDeprecatedTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningDeprecatedTestOutput.yaml
@@ -24,8 +24,8 @@ spec:
         name: cluster1
     imageSetRef:
         name: openshift-v4.8.0
-    manifestsConfigMapRefs:
-        - name: cluster1
+    manifestsConfigMapRef:
+        name: cluster1
     networking: {}
     provisionRequirements:
         controlPlaneAgents: 1

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningNewTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningNewTestOutput.yaml
@@ -23,8 +23,8 @@ spec:
         name: cluster1
     imageSetRef:
         name: openshift-v4.8.0
-    manifestsConfigMapRefs:
-        - name: cluster1
+    manifestsConfigMapRef:
+        name: cluster1
     networking: {}
     provisionRequirements:
         controlPlaneAgents: 1

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigDualStackStandardClusterTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigDualStackStandardClusterTestOutput.yaml
@@ -31,8 +31,8 @@ spec:
     ingressVIPs:
         - 10.16.231.3
         - 2001:DB8::3
-    manifestsConfigMapRefs:
-        - name: cluster1
+    manifestsConfigMapRef:
+        name: cluster1
     networking:
         clusterNetwork:
             - cidr: 10.128.0.0/14

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterTestOutput.yaml
@@ -25,8 +25,8 @@ spec:
     imageSetRef:
         name: openshift-v4.9.0
     ingressVIP: 10.16.231.3
-    manifestsConfigMapRefs:
-        - name: cluster1
+    manifestsConfigMapRef:
+        name: cluster1
     networking:
         clusterNetwork:
             - cidr: 10.128.0.0/14

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
@@ -24,8 +24,8 @@ spec:
         name: cluster1
     imageSetRef:
         name: openshift-v4.8.0
-    manifestsConfigMapRefs:
-        - name: cluster1
+    manifestsConfigMapRef:
+        name: cluster1
     networking:
         clusterNetwork:
             - cidr: 10.128.0.0/14


### PR DESCRIPTION
Reverts openshift-kni/cnf-features-deploy#1526

see: https://issues.redhat.com/browse/OCPBUGS-16094 

/cc @lack 
/cc @imiller0 