### PR TITLE
ztp: update the sriov-fec to use vfio-pci for PR also

### DIFF
--- a/ztp/source-crs/SriovFecClusterConfig.yaml
+++ b/ztp/source-crs/SriovFecClusterConfig.yaml
@@ -13,7 +13,7 @@ spec:
   acceleratorSelector:
     pciAddress: $pciAddress
   physicalFunction:  
-    pfDriver: "pci-pf-stub"
+    pfDriver: "vfio-pci"
     vfDriver: "vfio-pci"
     vfAmount: 16
     bbDevConfig: $bbDevConfig


### PR DESCRIPTION
Be aware after this change when starting a dpdk application ther is a need to also use the vfio-token that is injected into the pod