### PR TITLE
Bug OCPBUGS-14921: ztp: Use HTTP as default transport for cloud events 

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
@@ -72,8 +72,6 @@ policies:
 #      - spec:
 #          daemonNodeSelector:
 #            node-role.kubernetes.io/worker: ""
-#          ptpEventConfig:
-#            storageType: "storage-class-http-events"
     - path: source-crs/PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
       patches:
       - metadata:
@@ -331,7 +329,6 @@ policies:
 #      patches:
 #      - spec:
 #          nodeSelector: {}
-#          transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
-          #transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
-          #storageType: "storage-class-http-events"
+#          # transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+#          transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
 #          logLevel: "debug"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -56,8 +56,6 @@ spec:
     #   spec:
     #     daemonNodeSelector:
     #       node-role.kubernetes.io/worker: ""
-    #     ptpEventConfig:
-    #       storageType: "storage-class-http-events"
 
     - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
       policyName: "config-policy"
@@ -94,14 +92,6 @@ spec:
           fsType: xfs
           devicePaths:
           - /dev/sdb2
-        # This is required if PTP and BMER operators use HTTP transport.
-        # The disk labels are created by ignitionConfigOverride in siteConfig.
-        # - storageClassName: "storage-class-http-events"
-        #   volumeMode: Filesystem
-        #   fsType: xfs
-        #   devicePaths:
-        #   - /dev/disk/by-partlabel/httpevent1
-        #   - /dev/disk/by-partlabel/httpevent2
     - fileName: DisableSnoNetworkDiag.yaml
       policyName: "config-policy"
     - fileName: PerformanceProfile.yaml
@@ -153,9 +143,8 @@ spec:
     #   policyName: "config-events-policy"
     #   spec:
     #     nodeSelector: {}
-    #     transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
-    #     # transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
-    #     # storageType: "storage-class-http-events"
+    #     # transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    #     transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
     #     logLevel: "debug"
 #    --- sources needed for image registry (check ImageRegistry.md for more details)----
 #    - fileName: StorageClass.yaml

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -72,9 +72,6 @@ spec:
 #              - mount_point: /var/imageregistry
 #                size: 102500
 #                start: 344844
-       # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
-       # disk id and and size needs to be adjusted to the hardware
-       # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
         nodeNetwork:
           interfaces:
             - name: eno1

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
@@ -65,28 +65,6 @@ spec:
       metadata:
         labels:
           machineconfiguration.openshift.io/role: master
-    - fileName: StorageLV.yaml
-      policyName: "config-policy"
-      spec:
-        storageClassDevices:
-        - storageClassName: "example-storage-class-1"
-          volumeMode: Filesystem
-          fsType: xfs
-          devicePaths:
-          - /dev/sdb1
-        - storageClassName: "example-storage-class-2"
-          volumeMode: Filesystem
-          fsType: xfs
-          devicePaths:
-          - /dev/sdb2
-        # This is required if PTP and BMER operators use HTTP transport.
-        # The disk labels are created by ignitionConfigOverride in siteConfig.
-        # - storageClassName: "storage-class-http-events"
-        #   volumeMode: Filesystem
-        #   fsType: xfs
-        #   devicePaths:
-        #   - /dev/disk/by-partlabel/httpevent1
-        #   - /dev/disk/by-partlabel/httpevent2
     # # AmqInstance is required if PTP and BMER operators use AMQP transport
     # - fileName: AmqInstance.yaml
     #   policyName: "config-events-policy"
@@ -96,7 +74,6 @@ spec:
     #   policyName: "config-events-policy"
     #   spec:
     #     nodeSelector: {}
-    #     transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
-    #     # transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
-    #     # storageType: "storage-class-http-events"
+    #     # transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    #     transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
     #     logLevel: "debug"

--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
@@ -55,9 +55,6 @@ spec:
         cpuset: "2-19,22-39"
         installerArgs: '{"args": ["--append-karg", "nameserver=8.8.8.8", "-n"]}'
         ignitionConfigOverride: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/containers/registries.conf", "overwrite": true, "contents": {"source": "data:text/plain;base64,aGVsbG8gZnJvbSB6dHAgcG9saWN5IGdlbmVyYXRvcg=="}}]}}'
-        # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
-        # disk id and and size needs to be adjusted to the hardware
-        # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"files": [{"path": "/etc/containers/registries.conf", "overwrite": true, "contents": {"source": "data:text/plain;base64,aGVsbG8gZnJvbSB6dHAgcG9saWN5IGdlbmVyYXRvcg=="}}],"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
         nodeNetwork:
           interfaces:
             - name: eno1

--- a/ztp/source-crs/HardwareEvent.yaml
+++ b/ztp/source-crs/HardwareEvent.yaml
@@ -7,5 +7,5 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   nodeSelector: {}
-  transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+  transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
   logLevel: "trace"

--- a/ztp/source-crs/PtpOperatorConfigForEvent-SetSelector.yaml
+++ b/ztp/source-crs/PtpOperatorConfigForEvent-SetSelector.yaml
@@ -10,4 +10,4 @@ spec:
 #    node-role.kubernetes.io/worker: ""
   ptpEventConfig:
     enableEventPublisher: true
-    transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    transportHost: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"

--- a/ztp/source-crs/PtpOperatorConfigForEvent.yaml
+++ b/ztp/source-crs/PtpOperatorConfigForEvent.yaml
@@ -10,4 +10,4 @@ spec:
     node-role.kubernetes.io/$mcp: ""
   ptpEventConfig:
     enableEventPublisher: true
-    transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    transportHost: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"


### PR DESCRIPTION
Replace PVC with ConfigMap to persist subscriber data for HTTP transport