### PR TITLE
[release-4.13] Bug OCPBUGS-16627: ztp: Use HTTP as default transport for cloud events

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -58,8 +58,6 @@ spec:
     #   spec:
     #     daemonNodeSelector:
     #       node-role.kubernetes.io/worker: ""
-    #     ptpEventConfig:
-    #       storageType: "storage-class-http-events"
 
     - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
       policyName: "config-policy"
@@ -96,14 +94,6 @@ spec:
           fsType: xfs
           devicePaths:
           - /dev/sdb2
-        # This is required if PTP and BMER operators use HTTP transport.
-        # The disk labels are created by ignitionConfigOverride in siteConfig.
-        # - storageClassName: "storage-class-http-events"
-        #   volumeMode: Filesystem
-        #   fsType: xfs
-        #   devicePaths:
-        #   - /dev/disk/by-partlabel/httpevent1
-        #   - /dev/disk/by-partlabel/httpevent2
     - fileName: DisableSnoNetworkDiag.yaml
       policyName: "config-policy"
     - fileName: PerformanceProfile.yaml
@@ -148,9 +138,8 @@ spec:
     #   policyName: "config-events-policy"
     #   spec:
     #     nodeSelector: {}
-    #     transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
-    #     # transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
-    #     # storageType: "storage-class-http-events"
+    #     # transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    #     transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
     #     logLevel: "debug"
     #
     # These CRs are to enable crun on master and worker nodes for 4.13+ only

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -67,9 +67,6 @@ spec:
 #              - mount_point: /var/imageregistry
 #                size: 102500
 #                start: 344844
-       # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
-       # disk id and and size needs to be adjusted to the hardware
-       # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
         cpuset: "0-1,20-21" # match the value with PerformanceProfile's .spec.cpu.reserved for workload partitioning. See /example/policygentemplates/group-du-sno-ranGen.yaml
         nodeNetwork:
           interfaces:

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
@@ -68,28 +68,6 @@ spec:
       metadata:
         labels:
           machineconfiguration.openshift.io/role: master
-    - fileName: StorageLV.yaml
-      policyName: "config-policy"
-      spec:
-        storageClassDevices:
-        - storageClassName: "example-storage-class-1"
-          volumeMode: Filesystem
-          fsType: xfs
-          devicePaths:
-          - /dev/sdb1
-        - storageClassName: "example-storage-class-2"
-          volumeMode: Filesystem
-          fsType: xfs
-          devicePaths:
-          - /dev/sdb2
-        # This is required if PTP and BMER operators use HTTP transport.
-        # The disk labels are created by ignitionConfigOverride in siteConfig.
-        # - storageClassName: "storage-class-http-events"
-        #   volumeMode: Filesystem
-        #   fsType: xfs
-        #   devicePaths:
-        #   - /dev/disk/by-partlabel/httpevent1
-        #   - /dev/disk/by-partlabel/httpevent2
     # # AmqInstance is required if PTP and BMER operators use AMQP transport
     # - fileName: AmqInstance.yaml
     #   policyName: "config-events-policy"
@@ -99,7 +77,6 @@ spec:
     #   policyName: "config-events-policy"
     #   spec:
     #     nodeSelector: {}
-    #     transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
-    #     # transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
-    #     # storageType: "storage-class-http-events"
+    #     # transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    #     transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
     #     logLevel: "debug"

--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
@@ -55,9 +55,6 @@ spec:
         cpuset: "2-19,22-39"
         installerArgs: '{"args": ["--append-karg", "nameserver=8.8.8.8", "-n"]}'
         ignitionConfigOverride: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/containers/registries.conf", "overwrite": true, "contents": {"source": "data:text/plain;base64,aGVsbG8gZnJvbSB6dHAgcG9saWN5IGdlbmVyYXRvcg=="}}]}}'
-        # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
-        # disk id and and size needs to be adjusted to the hardware
-        # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"files": [{"path": "/etc/containers/registries.conf", "overwrite": true, "contents": {"source": "data:text/plain;base64,aGVsbG8gZnJvbSB6dHAgcG9saWN5IGdlbmVyYXRvcg=="}}],"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
         nodeNetwork:
           interfaces:
             - name: eno1

--- a/ztp/source-crs/HardwareEvent.yaml
+++ b/ztp/source-crs/HardwareEvent.yaml
@@ -7,5 +7,5 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   nodeSelector: {}
-  transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+  transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
   logLevel: "trace"

--- a/ztp/source-crs/PtpOperatorConfigForEvent.yaml
+++ b/ztp/source-crs/PtpOperatorConfigForEvent.yaml
@@ -10,4 +10,4 @@ spec:
     node-role.kubernetes.io/$mcp: ""
   ptpEventConfig:
     enableEventPublisher: true
-    transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    transportHost: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"


### PR DESCRIPTION
Replace PVC with ConfigMap to persist subscriber data for HTTP transport