### PR TITLE
cnf-tests: log test pod events on failure

### DIFF
--- a/cnf-tests/testsuites/e2esuite/security/tuning.go
+++ b/cnf-tests/testsuites/e2esuite/security/tuning.go
@@ -50,7 +50,7 @@ var _ = Describe("[tuningcni]", func() {
 				pod, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				err = pods.WaitForPhase(client.Client, pod, corev1.PodRunning, 1*time.Minute)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), pods.GetStringEventsForPodFn(client.Client, pod))
 				sysctlForInterface := fmt.Sprintf(Sysctl, "net1")
 				statsCommand := []string{"sysctl", sysctlForInterface}
 				commandOutput, err := pods.ExecCommand(client.Client, *pod, statsCommand)
@@ -81,7 +81,7 @@ var _ = Describe("[tuningcni]", func() {
 			pod, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			err = pods.WaitForPhase(client.Client, pod, corev1.PodRunning, 1*time.Minute)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), pods.GetStringEventsForPodFn(client.Client, pod))
 
 			podDefinition2 := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s", namespaces.TuningTest, nad2Name)})
 			podDefinition2 = pods.RedefineWithCommand(podDefinition2, []string{"/bin/bash", "-c", fmt.Sprintf("ping -c 1 %s", ip1)}, nil)
@@ -90,7 +90,7 @@ var _ = Describe("[tuningcni]", func() {
 			pod2, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition2, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			err = pods.WaitForPhase(client.Client, pod2, corev1.PodSucceeded, 1*time.Minute)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), pods.GetStringEventsForPodFn(client.Client, pod2))
 		})
 	})
 
@@ -124,7 +124,7 @@ var _ = Describe("[tuningcni]", func() {
 				pod1, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition1, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				err = pods.WaitForPhase(client.Client, pod1, corev1.PodRunning, 1*time.Minute)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), pods.GetStringEventsForPodFn(client.Client, pod1))
 
 				podDefinition2 := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s, %s/%s, %s/%s", namespaces.TuningTest, macvlanNadName, namespaces.TuningTest, macvlanNadName, namespaces.TuningTest, bondNadName2)})
 				podDefinition2 = pods.RedefineWithCommand(podDefinition2, []string{"/bin/bash", "-c", fmt.Sprintf("ping -c 1 %s", ip1)}, nil)
@@ -134,7 +134,7 @@ var _ = Describe("[tuningcni]", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				err = pods.WaitForPhase(client.Client, pod2, corev1.PodSucceeded, 1*time.Minute)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), pods.GetStringEventsForPodFn(client.Client, pod2))
 			})
 	})
 
@@ -183,7 +183,7 @@ var _ = Describe("[tuningcni]", func() {
 			err = updateAllowlistConfig(updatedSysctls)
 			Expect(err).NotTo(HaveOccurred())
 			err = pods.WaitForPhase(client.Client, pod, corev1.PodRunning, 1*time.Minute)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), pods.GetStringEventsForPodFn(client.Client, pod))
 		})
 	})
 })

--- a/cnf-tests/testsuites/e2esuite/vrf/vrf.go
+++ b/cnf-tests/testsuites/e2esuite/vrf/vrf.go
@@ -113,26 +113,27 @@ func addVRFNad(cs *client.ClientSet, NadName string, vrfName string) netattdefv1
 }
 
 func getOverlapIP(cs *client.ClientSet, namespace string, nodeName string, podNamePrefix string) string {
+	var tempPod *k8sv1.Pod
 	tempPodDefinition := redefineAsNetRawWithNamePrefix(pods.DefinePodOnNode(namespace, nodeName), podNamePrefix)
 	err := cs.Create(context.Background(), tempPodDefinition)
 	Expect(err).ToNot(HaveOccurred())
 	Eventually(func() k8sv1.PodPhase {
-		tempPod, _ := cs.Pods(namespace).Get(context.Background(), tempPodDefinition.Name, metav1.GetOptions{})
+		tempPod, _ = cs.Pods(namespace).Get(context.Background(), tempPodDefinition.Name, metav1.GetOptions{})
 		return tempPod.Status.Phase
-	}, podWaitingTime, time.Second).Should(Equal(k8sv1.PodRunning))
-
+	}, podWaitingTime, time.Second).Should(Equal(k8sv1.PodRunning), pods.GetStringEventsForPodFn(cs, tempPod))
 	pod, err := cs.Pods(namespace).Get(context.Background(), tempPodDefinition.Name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	return pod.Status.PodIP
 }
 
 func waitUntilPodCreatedAndRunning(cs *client.ClientSet, podStruct *k8sv1.Pod) {
+	var tempPod *k8sv1.Pod
 	err := cs.Create(context.Background(), podStruct)
 	Expect(err).ToNot(HaveOccurred())
 	Eventually(func() k8sv1.PodPhase {
-		tempPod, _ := cs.Pods(podStruct.Namespace).Get(context.Background(), podStruct.Name, metav1.GetOptions{})
+		tempPod, _ = cs.Pods(podStruct.Namespace).Get(context.Background(), podStruct.Name, metav1.GetOptions{})
 		return tempPod.Status.Phase
-	}, podWaitingTime, time.Second).Should(Equal(k8sv1.PodRunning))
+	}, podWaitingTime, time.Second).Should(Equal(k8sv1.PodRunning), pods.GetStringEventsForPodFn(cs, tempPod))
 }
 
 func podHasCorrectVRFConfig(cs *client.ClientSet, pod *k8sv1.Pod, vrfMapsConfig []map[string]string) {

--- a/cnf-tests/testsuites/pkg/pods/pods.go
+++ b/cnf-tests/testsuites/pkg/pods/pods.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/utils/pointer"
 )
@@ -412,4 +413,24 @@ func DetectDefaultRouteInterface(cs *testclient.ClientSet, pod corev1.Pod) (stri
 		}
 	}
 	return "", fmt.Errorf("default route not present")
+}
+
+func getStringEventsForPod(cs corev1client.EventsGetter, pod *corev1.Pod) string {
+	var res string
+	events, err := cs.Events(pod.Namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pod.Name), TypeMeta: metav1.TypeMeta{Kind: "Pod"}})
+	if err != nil {
+		return err.Error()
+	}
+	for _, item := range events.Items {
+		eventStr := fmt.Sprintf("%s: %s", item.LastTimestamp, item.Message)
+		res = res + fmt.Sprintf("%s\n", eventStr)
+	}
+
+	return res
+}
+
+func GetStringEventsForPodFn(cs *testclient.ClientSet, pod *corev1.Pod) func() string {
+	return func() string {
+		return getStringEventsForPod(cs, pod)
+	}
 }


### PR DESCRIPTION
Add a print to the test pod's events on test failure, to help with troubleshooting.

Example for the output of GetStringEventsForPod:
`2023-07-23 14:14:54 +0300 IDT: Successfully assigned l2-6521/external-local-lb-lgwgg to kind-worker 2023-07-23 14:14:55 +0300 IDT: Container image "registry.k8s.io/e2e-test-images/agnhost:2.43" already present on machine 2023-07-23 14:14:55 +0300 IDT: Created container netexec 2023-07-23 14:14:55 +0300 IDT: Started container netexec`