### PR TITLE
[release-4.12] Bug OCPBUGS-16782: ztp: Use HTTP as default transport for cloud events

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -129,6 +129,18 @@ spec:
               [service]
               service.stalld=start,enable
               service.chronyd=stop,disable
+    # # AmqInstance is required if PTP and BMER operators use AMQP transport
+    # - fileName: AmqInstance.yaml
+    #   policyName: "config-events-policy"
+    #   annotations:
+    #     ran.openshift.io/ztp-deploy-wave: "10"
+    # - fileName: HardwareEvent.yaml
+    #   policyName: "config-events-policy"
+    #   spec:
+    #     nodeSelector: {}
+    #     # transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    #     transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
+    #     logLevel: "debug"
 #    --- sources needed for image registry (check ImageRegistry.md for more details)----
 #    - fileName: StorageClass.yaml
 #      policyName: "config-policy"

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
@@ -72,3 +72,15 @@ spec:
       metadata:
         labels:
           machineconfiguration.openshift.io/role: master
+    # # AmqInstance is required if PTP and BMER operators use AMQP transport
+    # - fileName: AmqInstance.yaml
+    #   policyName: "config-events-policy"
+    #   annotations:
+    #     ran.openshift.io/ztp-deploy-wave: "10"
+    # - fileName: HardwareEvent.yaml
+    #   policyName: "config-events-policy"
+    #   spec:
+    #     nodeSelector: {}
+    #     # transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    #     transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
+    #     logLevel: "debug"

--- a/ztp/source-crs/HardwareEvent.yaml
+++ b/ztp/source-crs/HardwareEvent.yaml
@@ -7,5 +7,5 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   nodeSelector: {}
-  transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+  transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
   logLevel: "trace"

--- a/ztp/source-crs/PtpOperatorConfigForEvent.yaml
+++ b/ztp/source-crs/PtpOperatorConfigForEvent.yaml
@@ -10,4 +10,4 @@ spec:
     node-role.kubernetes.io/$mcp: ""
   ptpEventConfig:
     enableEventPublisher: true
-    transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    transportHost: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"


### PR DESCRIPTION
Replace PVC with ConfigMap to persist subscriber data for HTTP transport