### PR TITLE
cnf-tests: dynamically created KubeletConfig

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/numa_node_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/numa_node_sriov.go
@@ -2,6 +2,7 @@ package dpdk
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -13,17 +14,24 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/client"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/discovery"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/machineconfigpool"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/namespaces"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/networks"
-	utilNodes "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/nodes"
-	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/performanceprofile"
+	utilnodes "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/nodes"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/pods"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
 
 var _ = Describe("[sriov] NUMA node alignment", Ordered, func() {
@@ -38,16 +46,10 @@ var _ = Describe("[sriov] NUMA node alignment", Ordered, func() {
 			Skip("Discovery mode not supported")
 		}
 
-		isSNO, err := utilNodes.IsSingleNodeCluster()
+		isSNO, err := utilnodes.IsSingleNodeCluster()
 		Expect(err).ToNot(HaveOccurred())
 		if isSNO {
 			Skip("Single Node openshift not yet supported")
-		}
-
-		perfProfile, err := performanceprofile.FindDefaultPerformanceProfile(performanceProfileName)
-		Expect(err).ToNot(HaveOccurred())
-		if !performanceprofile.IsSingleNUMANode(perfProfile) {
-			Skip("SR-IOV NUMA test suite expects a performance profile with 'single-numa-node' to be present")
 		}
 
 		err = namespaces.Create(sriovnamespaces.Test, client.Client)
@@ -117,6 +119,13 @@ var _ = Describe("[sriov] NUMA node alignment", Ordered, func() {
 
 		By("Waiting for SRIOV devices to get configured")
 		networks.WaitStable(sriovclient)
+
+		cleanupFn, err := machineconfigpool.ApplyKubeletConfigToNode(
+			testingNode, "test-sriov-numa", makeKubeletConfigWithReservedNUMA0(testingNode))
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(cleanupFn)
+
+		By("KubeletConfig test-sriov-numa applied to " + testingNode.Name)
 	})
 
 	BeforeEach(func() {
@@ -341,4 +350,31 @@ func expectPodCPUsAreOnNUMANode(pod *corev1.Pod, expectedCPUsNUMA int) {
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	ExpectWithOffset(1, numaNode).To(Equal(expectedCPUsNUMA))
+}
+
+// makeKubeletConfigWithReservedNUMA0 creates a KubeletConfig.Spec that sets all NUMA0 CPUs as systemReservedCPUs
+// and topology manager to "single-numa-node".
+func makeKubeletConfigWithReservedNUMA0(node *corev1.Node) *mcv1.KubeletConfigSpec {
+	numaToCpu, err := nodes.GetNumaNodes(node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, len(numaToCpu)).
+		To(BeNumerically(">=", 2),
+			fmt.Sprintf("Node %s has only one NUMA node[%v]. At least two expected", node.Name, numaToCpu))
+
+	kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{}
+	kubeletConfig.CPUManagerPolicy = "static"
+	kubeletConfig.CPUManagerReconcilePeriod = metav1.Duration{Duration: 5 * time.Second}
+	kubeletConfig.TopologyManagerPolicy = kubeletconfigv1beta1.SingleNumaNodeTopologyManagerPolicy
+	kubeletConfig.ReservedSystemCPUs = components.ListToString(numaToCpu[0])
+
+	raw, err := json.Marshal(kubeletConfig)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	ret := &mcv1.KubeletConfigSpec{
+		KubeletConfig: &runtime.RawExtension{
+			Raw: raw,
+		},
+	}
+
+	return ret
 }


### PR DESCRIPTION
Make NUMA/SR-IOV integration tests creating their own PerformanceProfile that sets single-numa-node policy and reserve an enitre NUMA node as Isolated.

Add functions to manipulate `node-role.kubernetes.io/x` labels on node to apply the performacen profile to arbitrary nodes.

cc @gregkopels 