### PR TITLE
ztp: update performance profile to load vfio-pci

### DIFF
--- a/ztp/source-crs/PerformanceProfile-SetSelector.yaml
+++ b/ztp/source-crs/PerformanceProfile-SetSelector.yaml
@@ -13,6 +13,8 @@ spec:
   additionalKernelArgs:
   - "rcupdate.rcu_normal_after_boot=0"
   - "efi=runtime"
+  - "vfio_pci.enable_sriov=1"
+  - "vfio_pci.disable_idle_d3=1"
   - "module_blacklist=irdma"  
   cpu:
 #    isolated: $isolated

--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -13,6 +13,8 @@ spec:
   additionalKernelArgs:
   - "rcupdate.rcu_normal_after_boot=0"
   - "efi=runtime"
+  - "vfio_pci.enable_sriov=1"
+  - "vfio_pci.disable_idle_d3=1"
   - "module_blacklist=irdma"  
   cpu:
     isolated: $isolated


### PR DESCRIPTION
load the vfio-pci driver on boot with the parameters needed by the sriov-fec