### PR TITLE
ztp: extramnifests searchPath section is re-written

### DIFF
--- a/ztp/gitops-subscriptions/argocd/README.md
+++ b/ztp/gitops-subscriptions/argocd/README.md
@@ -112,9 +112,16 @@ EOF
         - For SNO deployments, you must have exactly one host defined.
         - For 3-node deployments, you must have exactly three hosts defined.
         - For standard deployments, you must have exactly three hosts defined with `role: master` and one or more hosts defined with `role: worker`
-      - The ztp container version specific set of extra-manifest MachineConfigs can be inspected in out/argocd/extra-manifest, and will be automatically applied to the cluster as it is installed. *But it is strongly recommended that, user extracts `extra-manifest` and its content and push the content to users GIT repository*. Later, you must include the directory path at `extraManifests.searchPaths` in your SiteConfig.yaml, and those CR files will be applied during cluster installation. `extraManifests.searchPaths` accepts multiple directory path.
-        - Optional: For provisioning additional install-time manifests on the provisioned cluster, create another directory in your GIT repository (for example, `sno-extra-manifest/`) and add your custom manifest CRs to this directory.  In your SiteConfig.yaml, refer to this newly created directory via the `extraManifests.searchPaths` field, any CRs in this referenced directory will be appended to the default set of extra manifests. For the same named CR files in multiple directories, latter shall take precedence.
-        - For the 4.14 release, we will still support the behavior of `extraManifestPath` and applying default extra manifests from the container during site installation only if `extraManifests.searchPaths` is not declared in the SiteConfig file. Going forward, the behavior will be deprecated and we strongly recommend to use `extraManifests.searchPaths` instead.
+      - The ztp container version specific set of extra-manifest MachineConfigs can be inspected in out/argocd/extra-manifest. When `extraManifests.searchPaths` is defined in siteconfig, one must copy all the contents from out/argocd/extra-manifest to the user GIT repository, and include that GIT directory path under `extraManifests.searchPaths`. It will allow those CR files will be applied during cluster installation. When searchPath is defined, **the manifests will not be fetched from ztp container**. 
+      - *It is strongly recommended that, user extracts `extra-manifest` and its content and push the content to users GIT repository*. 
+        - For the 4.14 release, we will still support the behavior of `extraManifestPath` and applying default extra manifests from the container during site installation only if `extraManifests.searchPaths` is not declared in the SiteConfig file. Going forward, the behavior will be deprecated and we strongly recommend to use `extraManifests.searchPaths` instead. Deprecation warning of this field is also added in the release.
+        - Optional: For provisioning additional install-time manifests on the provisioned cluster, create another directory in your GIT repository (for example, `custom-manifest/`) and add your custom manifest CRs to this directory. In the SiteConfig, refer to this newly created directory via the `extraManifests.searchPaths` field, any CRs in this referenced directory will be appended in addition to the default set of extra manifests. For the same named CR files in multiple directories, the last found file in the directory will override the content.
+          ```
+          extraManifests:
+            searchPaths:
+             - sno-extra-manifest/ <-- ztp-containers's reference manifests
+             - custom-manifests/ <-- user's custom manifests
+          ```      
    3. Add the SiteConfig CR to the kustomization.yaml in the 'generators' section, much like in the example out/argocd/example/siteconfig/kustomization.yaml
    4. Commit your SiteConfig and associated kustomization.yaml in git.
 3. Create the PolicyGenTemplate CR for your site in your local clone of the git repository:


### PR DESCRIPTION
Updated upstream doc explaining the behavior of `extramnifests.searchPaths`