### PR TITLE
[release-4.13] Bump metallb vendor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,8 @@ require (
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.1.1 // indirect
-	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
+	github.com/Masterminds/semver/v3 v3.2.0 // indirect
+	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
@@ -188,7 +188,7 @@ replace (
 replace (
 	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230330150324-84715294edb9 // release-4.13
 	github.com/k8stopologyawareschedwg/resource-topology-exporter => github.com/k8stopologyawareschedwg/resource-topology-exporter v0.8.0
-	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230123113337-fa1059e25fe1 // release-4.13
+	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230807120428-6267b32eaa61 // release-4.13
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10
 	github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc // release-4.9
 	github.com/openshift/cluster-node-tuning-operator => github.com/openshift/cluster-node-tuning-operator v0.0.0-20230711003646-5b4af42e9cfb // release-4.13

--- a/go.sum
+++ b/go.sum
@@ -523,12 +523,14 @@ github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF0
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
+github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
-github.com/Masterminds/sprig/v3 v3.2.2 h1:17jRggJu518dr3QaafizSXOjKYp94wKfABxUmyxvxX8=
 github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
+github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
+github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -1822,6 +1824,7 @@ github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbc
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
@@ -2385,8 +2388,8 @@ github.com/openshift/custom-resource-status v0.0.0-20210221154447-420d9ecf2a00/g
 github.com/openshift/library-go v0.0.0-20230130232623-47904dd9ff5a/go.mod h1:xO4nAf0qa56dgvEJWVD1WuwSJ8JWPU1TYLBQrlutWnE=
 github.com/openshift/machine-config-operator v0.0.1-0.20230419202402-70aa0a560c0b h1:RkqSUvzSMj0aGkDhVMWuyhwAmFpIC6BD+O6Zd/hoEDA=
 github.com/openshift/machine-config-operator v0.0.1-0.20230419202402-70aa0a560c0b/go.mod h1:+caXSS3bNvgVz2QPNqrmx9FEE383t8uppvOeTroDIME=
-github.com/openshift/metallb-operator v0.0.0-20230123113337-fa1059e25fe1 h1:1SikszUiny7ufiaqcB49gWjHgd1JAM5CN1pB6+19hoU=
-github.com/openshift/metallb-operator v0.0.0-20230123113337-fa1059e25fe1/go.mod h1:e71AwgWr5MUCaFQoLOC3phqTevxP3LlhyepOqDu+mV0=
+github.com/openshift/metallb-operator v0.0.0-20230807120428-6267b32eaa61 h1:CSLpI6Wx5zL/nPFUgwIa2D7ojKqgfN9lAS0E4kxinTw=
+github.com/openshift/metallb-operator v0.0.0-20230807120428-6267b32eaa61/go.mod h1:7qn9ioVUKusd8KNY82TumiqMjrR3BXJH+qLfBGAuHD8=
 github.com/openshift/ptp-operator v0.0.0-20230206122400-e0231ea64d3a h1:63Q/VLx3oqKR0ZiLDK84Q+bOpVZ/VuJ2+EuQ5QdEMeE=
 github.com/openshift/ptp-operator v0.0.0-20230206122400-e0231ea64d3a/go.mod h1:xPR7lc/77WJmDgiBu5P9HAEvNTUVnNSH0TR1e2XSje4=
 github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f/go.mod h1:l9/qeKZuAmYUMl0yicJlbkPGDsIycGhwxOvOAWyaP0E=

--- a/vendor/github.com/Masterminds/semver/v3/.golangci.yml
+++ b/vendor/github.com/Masterminds/semver/v3/.golangci.yml
@@ -4,23 +4,27 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
-    - dupl
-    - errcheck
-    - gofmt
-    - goimports
-    - golint
-    - gosimple
-    - govet
-    - ineffassign
     - misspell
-    - nakedret
     - structcheck
-    - unused
+    - govet
+    - staticcheck
+    - deadcode
+    - errcheck
     - varcheck
+    - unparam
+    - ineffassign
+    - nakedret
+    - gocyclo
+    - dupl
+    - goimports
+    - revive
+    - gosec
+    - gosimple
+    - typecheck
+    - unused
 
 linters-settings:
   gofmt:
     simplify: true
   dupl:
-    threshold: 400
+    threshold: 600

--- a/vendor/github.com/Masterminds/semver/v3/CHANGELOG.md
+++ b/vendor/github.com/Masterminds/semver/v3/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 3.2.0 (2022-11-28)
+
+### Added
+
+- #190: Added text marshaling and unmarshaling
+- #167: Added JSON marshalling for constraints (thanks @SimonTheLeg)
+- #173: Implement encoding.TextMarshaler and encoding.TextUnmarshaler on Version (thanks @MarkRosemaker)
+- #179: Added New() version constructor (thanks @kazhuravlev)
+
+### Changed
+
+- #182/#183: Updated CI testing setup
+
+### Fixed
+
+- #186: Fixing issue where validation of constraint section gave false positives
+- #176: Fix constraints check with *-0 (thanks @mtt0)
+- #181: Fixed Caret operator (^) gives unexpected results when the minor version in constraint is 0 (thanks @arshchimni)
+- #161: Fixed godoc (thanks @afirth)
+
 ## 3.1.1 (2020-11-23)
 
 ### Fixed

--- a/vendor/github.com/Masterminds/semver/v3/constraints.go
+++ b/vendor/github.com/Masterminds/semver/v3/constraints.go
@@ -134,6 +134,23 @@ func (cs Constraints) String() string {
 	return strings.Join(buf, " || ")
 }
 
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (cs *Constraints) UnmarshalText(text []byte) error {
+	temp, err := NewConstraint(string(text))
+	if err != nil {
+		return err
+	}
+
+	*cs = *temp
+
+	return nil
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (cs Constraints) MarshalText() ([]byte, error) {
+	return []byte(cs.String()), nil
+}
+
 var constraintOps map[string]cfunc
 var constraintRegex *regexp.Regexp
 var constraintRangeRegex *regexp.Regexp
@@ -180,8 +197,13 @@ func init() {
 		ops,
 		cvRegex))
 
+	// The first time a constraint shows up will look slightly different from
+	// future times it shows up due to a leading space or comma in a given
+	// string.
 	validConstraintRegex = regexp.MustCompile(fmt.Sprintf(
-		`^(\s*(%s)\s*(%s)\s*\,?)+$`,
+		`^(\s*(%s)\s*(%s)\s*)((?:\s+|,\s*)(%s)\s*(%s)\s*)*$`,
+		ops,
+		cvRegex,
 		ops,
 		cvRegex))
 }
@@ -233,7 +255,7 @@ func parseConstraint(c string) (*constraint, error) {
 		patchDirty := false
 		dirty := false
 		if isX(m[3]) || m[3] == "" {
-			ver = "0.0.0"
+			ver = fmt.Sprintf("0.0.0%s", m[6])
 			dirty = true
 		} else if isX(strings.TrimPrefix(m[4], ".")) || m[4] == "" {
 			minorDirty = true
@@ -533,6 +555,10 @@ func constraintCaret(v *Version, c *constraint) (bool, error) {
 			return true, nil
 		}
 		return false, fmt.Errorf("%s does not have same minor version as %s. Expected minor versions to match when constraint major version is 0", v, c.orig)
+	}
+	// ^ when the minor is 0 and minor > 0 is =0.0.z
+	if c.con.Minor() == 0 && v.Minor() > 0 {
+		return false, fmt.Errorf("%s does not have same minor version as %s", v, c.orig)
 	}
 
 	// At this point the major is 0 and the minor is 0 and not dirty. The patch

--- a/vendor/github.com/Masterminds/semver/v3/doc.go
+++ b/vendor/github.com/Masterminds/semver/v3/doc.go
@@ -3,12 +3,12 @@ Package semver provides the ability to work with Semantic Versions (http://semve
 
 Specifically it provides the ability to:
 
-    * Parse semantic versions
-    * Sort semantic versions
-    * Check if a semantic version fits within a set of constraints
-    * Optionally work with a `v` prefix
+  - Parse semantic versions
+  - Sort semantic versions
+  - Check if a semantic version fits within a set of constraints
+  - Optionally work with a `v` prefix
 
-Parsing Semantic Versions
+# Parsing Semantic Versions
 
 There are two functions that can parse semantic versions. The `StrictNewVersion`
 function only parses valid version 2 semantic versions as outlined in the
@@ -21,48 +21,48 @@ that can be sorted, compared, and used in constraints.
 When parsing a version an optional error can be returned if there is an issue
 parsing the version. For example,
 
-    v, err := semver.NewVersion("1.2.3-beta.1+b345")
+	v, err := semver.NewVersion("1.2.3-beta.1+b345")
 
 The version object has methods to get the parts of the version, compare it to
 other versions, convert the version back into a string, and get the original
 string. For more details please see the documentation
 at https://godoc.org/github.com/Masterminds/semver.
 
-Sorting Semantic Versions
+# Sorting Semantic Versions
 
 A set of versions can be sorted using the `sort` package from the standard library.
 For example,
 
-    raw := []string{"1.2.3", "1.0", "1.3", "2", "0.4.2",}
-    vs := make([]*semver.Version, len(raw))
-	for i, r := range raw {
-		v, err := semver.NewVersion(r)
-		if err != nil {
-			t.Errorf("Error parsing version: %s", err)
+	    raw := []string{"1.2.3", "1.0", "1.3", "2", "0.4.2",}
+	    vs := make([]*semver.Version, len(raw))
+		for i, r := range raw {
+			v, err := semver.NewVersion(r)
+			if err != nil {
+				t.Errorf("Error parsing version: %s", err)
+			}
+
+			vs[i] = v
 		}
 
-		vs[i] = v
-	}
+		sort.Sort(semver.Collection(vs))
 
-	sort.Sort(semver.Collection(vs))
-
-Checking Version Constraints and Comparing Versions
+# Checking Version Constraints and Comparing Versions
 
 There are two methods for comparing versions. One uses comparison methods on
 `Version` instances and the other is using Constraints. There are some important
 differences to notes between these two methods of comparison.
 
-1. When two versions are compared using functions such as `Compare`, `LessThan`,
-   and others it will follow the specification and always include prereleases
-   within the comparison. It will provide an answer valid with the comparison
-   spec section at https://semver.org/#spec-item-11
-2. When constraint checking is used for checks or validation it will follow a
-   different set of rules that are common for ranges with tools like npm/js
-   and Rust/Cargo. This includes considering prereleases to be invalid if the
-   ranges does not include on. If you want to have it include pre-releases a
-   simple solution is to include `-0` in your range.
-3. Constraint ranges can have some complex rules including the shorthard use of
-   ~ and ^. For more details on those see the options below.
+ 1. When two versions are compared using functions such as `Compare`, `LessThan`,
+    and others it will follow the specification and always include prereleases
+    within the comparison. It will provide an answer valid with the comparison
+    spec section at https://semver.org/#spec-item-11
+ 2. When constraint checking is used for checks or validation it will follow a
+    different set of rules that are common for ranges with tools like npm/js
+    and Rust/Cargo. This includes considering prereleases to be invalid if the
+    ranges does not include on. If you want to have it include pre-releases a
+    simple solution is to include `-0` in your range.
+ 3. Constraint ranges can have some complex rules including the shorthard use of
+    ~ and ^. For more details on those see the options below.
 
 There are differences between the two methods or checking versions because the
 comparison methods on `Version` follow the specification while comparison ranges
@@ -76,19 +76,19 @@ patters with their versions.
 Checking a version against version constraints is one of the most featureful
 parts of the package.
 
-    c, err := semver.NewConstraint(">= 1.2.3")
-    if err != nil {
-        // Handle constraint not being parsable.
-    }
+	c, err := semver.NewConstraint(">= 1.2.3")
+	if err != nil {
+	    // Handle constraint not being parsable.
+	}
 
-    v, err := semver.NewVersion("1.3")
-    if err != nil {
-        // Handle version not being parsable.
-    }
-    // Check if the version meets the constraints. The a variable will be true.
-    a := c.Check(v)
+	v, err := semver.NewVersion("1.3")
+	if err != nil {
+	    // Handle version not being parsable.
+	}
+	// Check if the version meets the constraints. The a variable will be true.
+	a := c.Check(v)
 
-Basic Comparisons
+# Basic Comparisons
 
 There are two elements to the comparisons. First, a comparison string is a list
 of comma or space separated AND comparisons. These are then separated by || (OR)
@@ -99,31 +99,31 @@ greater than or equal to 4.2.3. This can also be written as
 
 The basic comparisons are:
 
-    * `=`: equal (aliased to no operator)
-    * `!=`: not equal
-    * `>`: greater than
-    * `<`: less than
-    * `>=`: greater than or equal to
-    * `<=`: less than or equal to
+  - `=`: equal (aliased to no operator)
+  - `!=`: not equal
+  - `>`: greater than
+  - `<`: less than
+  - `>=`: greater than or equal to
+  - `<=`: less than or equal to
 
-Hyphen Range Comparisons
+# Hyphen Range Comparisons
 
 There are multiple methods to handle ranges and the first is hyphens ranges.
 These look like:
 
-    * `1.2 - 1.4.5` which is equivalent to `>= 1.2, <= 1.4.5`
-    * `2.3.4 - 4.5` which is equivalent to `>= 2.3.4 <= 4.5`
+  - `1.2 - 1.4.5` which is equivalent to `>= 1.2, <= 1.4.5`
+  - `2.3.4 - 4.5` which is equivalent to `>= 2.3.4 <= 4.5`
 
-Wildcards In Comparisons
+# Wildcards In Comparisons
 
 The `x`, `X`, and `*` characters can be used as a wildcard character. This works
 for all comparison operators. When used on the `=` operator it falls
 back to the tilde operation. For example,
 
-    * `1.2.x` is equivalent to `>= 1.2.0 < 1.3.0`
-    * `>= 1.2.x` is equivalent to `>= 1.2.0`
-    * `<= 2.x` is equivalent to `<= 3`
-    * `*` is equivalent to `>= 0.0.0`
+  - `1.2.x` is equivalent to `>= 1.2.0 < 1.3.0`
+  - `>= 1.2.x` is equivalent to `>= 1.2.0`
+  - `<= 2.x` is equivalent to `<= 3`
+  - `*` is equivalent to `>= 0.0.0`
 
 Tilde Range Comparisons (Patch)
 
@@ -131,11 +131,11 @@ The tilde (`~`) comparison operator is for patch level ranges when a minor
 version is specified and major level changes when the minor number is missing.
 For example,
 
-    * `~1.2.3` is equivalent to `>= 1.2.3 < 1.3.0`
-    * `~1` is equivalent to `>= 1, < 2`
-    * `~2.3` is equivalent to `>= 2.3 < 2.4`
-    * `~1.2.x` is equivalent to `>= 1.2.0 < 1.3.0`
-    * `~1.x` is equivalent to `>= 1 < 2`
+  - `~1.2.3` is equivalent to `>= 1.2.3 < 1.3.0`
+  - `~1` is equivalent to `>= 1, < 2`
+  - `~2.3` is equivalent to `>= 2.3 < 2.4`
+  - `~1.2.x` is equivalent to `>= 1.2.0 < 1.3.0`
+  - `~1.x` is equivalent to `>= 1 < 2`
 
 Caret Range Comparisons (Major)
 
@@ -144,41 +144,41 @@ The caret (`^`) comparison operator is for major level changes once a stable
 as the API stability level. This is useful when comparisons of API versions as a
 major change is API breaking. For example,
 
-    * `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
-    * `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
-    * `^2.3` is equivalent to `>= 2.3, < 3`
-    * `^2.x` is equivalent to `>= 2.0.0, < 3`
-    * `^0.2.3` is equivalent to `>=0.2.3 <0.3.0`
-    * `^0.2` is equivalent to `>=0.2.0 <0.3.0`
-    * `^0.0.3` is equivalent to `>=0.0.3 <0.0.4`
-    * `^0.0` is equivalent to `>=0.0.0 <0.1.0`
-    * `^0` is equivalent to `>=0.0.0 <1.0.0`
+  - `^1.2.3` is equivalent to `>= 1.2.3, < 2.0.0`
+  - `^1.2.x` is equivalent to `>= 1.2.0, < 2.0.0`
+  - `^2.3` is equivalent to `>= 2.3, < 3`
+  - `^2.x` is equivalent to `>= 2.0.0, < 3`
+  - `^0.2.3` is equivalent to `>=0.2.3 <0.3.0`
+  - `^0.2` is equivalent to `>=0.2.0 <0.3.0`
+  - `^0.0.3` is equivalent to `>=0.0.3 <0.0.4`
+  - `^0.0` is equivalent to `>=0.0.0 <0.1.0`
+  - `^0` is equivalent to `>=0.0.0 <1.0.0`
 
-Validation
+# Validation
 
 In addition to testing a version against a constraint, a version can be validated
 against a constraint. When validation fails a slice of errors containing why a
 version didn't meet the constraint is returned. For example,
 
-    c, err := semver.NewConstraint("<= 1.2.3, >= 1.4")
-    if err != nil {
-        // Handle constraint not being parseable.
-    }
+	c, err := semver.NewConstraint("<= 1.2.3, >= 1.4")
+	if err != nil {
+	    // Handle constraint not being parseable.
+	}
 
-    v, _ := semver.NewVersion("1.3")
-    if err != nil {
-        // Handle version not being parseable.
-    }
+	v, _ := semver.NewVersion("1.3")
+	if err != nil {
+	    // Handle version not being parseable.
+	}
 
-    // Validate a version against a constraint.
-    a, msgs := c.Validate(v)
-    // a is false
-    for _, m := range msgs {
-        fmt.Println(m)
+	// Validate a version against a constraint.
+	a, msgs := c.Validate(v)
+	// a is false
+	for _, m := range msgs {
+	    fmt.Println(m)
 
-        // Loops over the errors which would read
-        // "1.3 is greater than 1.2.3"
-        // "1.3 is less than 1.4"
-    }
+	    // Loops over the errors which would read
+	    // "1.3 is greater than 1.2.3"
+	    // "1.3 is less than 1.4"
+	}
 */
 package semver

--- a/vendor/github.com/Masterminds/semver/v3/version.go
+++ b/vendor/github.com/Masterminds/semver/v3/version.go
@@ -55,14 +55,16 @@ func init() {
 	versionRegex = regexp.MustCompile("^" + semVerRegex + "$")
 }
 
-const num string = "0123456789"
-const allowed string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-" + num
+const (
+	num     string = "0123456789"
+	allowed string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-" + num
+)
 
 // StrictNewVersion parses a given version and returns an instance of Version or
 // an error if unable to parse the version. Only parses valid semantic versions.
 // Performs checking that can find errors within the version.
-// If you want to coerce a version, such as 1 or 1.2, and perse that as the 1.x
-// releases of semver provided use the NewSemver() function.
+// If you want to coerce a version such as 1 or 1.2 and parse it as the 1.x
+// releases of semver did, use the NewVersion() function.
 func StrictNewVersion(v string) (*Version, error) {
 	// Parsing here does not use RegEx in order to increase performance and reduce
 	// allocations.
@@ -207,6 +209,23 @@ func NewVersion(v string) (*Version, error) {
 	return sv, nil
 }
 
+// New creates a new instance of Version with each of the parts passed in as
+// arguments instead of parsing a version string.
+func New(major, minor, patch uint64, pre, metadata string) *Version {
+	v := Version{
+		major:    major,
+		minor:    minor,
+		patch:    patch,
+		pre:      pre,
+		metadata: metadata,
+		original: "",
+	}
+
+	v.original = v.String()
+
+	return &v
+}
+
 // MustParse parses a given version and panics on error.
 func MustParse(v string) *Version {
 	sv, err := NewVersion(v)
@@ -267,7 +286,6 @@ func (v Version) Metadata() string {
 
 // originalVPrefix returns the original 'v' prefix if any.
 func (v Version) originalVPrefix() string {
-
 	// Note, only lowercase v is supported as a prefix by the parser.
 	if v.original != "" && v.original[:1] == "v" {
 		return v.original[:1]
@@ -436,6 +454,23 @@ func (v Version) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.String())
 }
 
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (v *Version) UnmarshalText(text []byte) error {
+	temp, err := NewVersion(string(text))
+	if err != nil {
+		return err
+	}
+
+	*v = *temp
+
+	return nil
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (v Version) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
 // Scan implements the SQL.Scanner interface.
 func (v *Version) Scan(value interface{}) error {
 	var s string
@@ -470,7 +505,6 @@ func compareSegment(v, o uint64) int {
 }
 
 func comparePrerelease(v, o string) int {
-
 	// split the prelease versions by their part. The separator, per the spec,
 	// is a .
 	sparts := strings.Split(v, ".")
@@ -562,7 +596,6 @@ func comparePrePart(s, o string) int {
 		return 1
 	}
 	return -1
-
 }
 
 // Like strings.ContainsAny but does an only instead of any.

--- a/vendor/github.com/Masterminds/sprig/v3/CHANGELOG.md
+++ b/vendor/github.com/Masterminds/sprig/v3/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Changelog
 
+## Release 3.2.3 (2022-11-29)
+
+### Changed
+
+- Updated docs (thanks @book987 @aJetHorn @neelayu @pellizzetti @apricote @SaigyoujiYuyuko233 @AlekSi)
+- #348: Updated huandu/xstrings which fixed a snake case bug (thanks @yxxhero)
+- #353: Updated masterminds/semver which included bug fixes
+- #354: Updated golang.org/x/crypto which included bug fixes
+
+## Release 3.2.2 (2021-02-04)
+
+This is a re-release of 3.2.1 to satisfy something with the Go module system.
+
 ## Release 3.2.1 (2021-02-04)
 
-### Changed 
+### Changed
 
 - Upgraded `Masterminds/goutils` to `v1.1.1`. see the [Security Advisory](https://github.com/Masterminds/goutils/security/advisories/GHSA-xg2h-wx96-xgxr)
 

--- a/vendor/github.com/Masterminds/sprig/v3/README.md
+++ b/vendor/github.com/Masterminds/sprig/v3/README.md
@@ -17,10 +17,9 @@ JavaScript libraries, such as [underscore.js](http://underscorejs.org/).
 ## IMPORTANT NOTES
 
 Sprig leverages [mergo](https://github.com/imdario/mergo) to handle merges. In
-its v0.3.9 release there was a behavior change that impacts merging template
-functions in sprig. It is currently recommended to use v0.3.8 of that package.
-Using v0.3.9 will cause sprig tests to fail. The issue in mergo is tracked at
-https://github.com/imdario/mergo/issues/139.
+its v0.3.9 release, there was a behavior change that impacts merging template
+functions in sprig. It is currently recommended to use v0.3.10 or later of that package.
+Using v0.3.9 will cause sprig tests to fail.
 
 ## Package Versions
 
@@ -51,7 +50,7 @@ To load the Sprig `FuncMap`:
 ```go
 
 import (
-  "github.com/Masterminds/sprig"
+  "github.com/Masterminds/sprig/v3"
   "html/template"
 )
 

--- a/vendor/github.com/metallb/metallb-operator/pkg/status/status.go
+++ b/vendor/github.com/metallb/metallb-operator/pkg/status/status.go
@@ -101,7 +101,7 @@ func IsMetalLBAvailable(ctx context.Context, client k8sclient.Client, namespace 
 	if err != nil {
 		return err
 	}
-	if ds.Status.DesiredNumberScheduled != ds.Status.CurrentNumberScheduled {
+	if ds.Status.DesiredNumberScheduled != ds.Status.CurrentNumberScheduled || ds.Status.DesiredNumberScheduled != ds.Status.NumberReady {
 		return MetalLBResourcesNotReadyError{Message: "MetalLB speaker daemonset not ready"}
 	}
 	deployment := &appsv1.Deployment{}

--- a/vendor/github.com/metallb/metallb-operator/test/e2e/metallb/metallb.go
+++ b/vendor/github.com/metallb/metallb-operator/test/e2e/metallb/metallb.go
@@ -36,6 +36,10 @@ func Delete(metallb *metallbv1beta1.MetalLB) {
 		return
 	}
 	Expect(err).ToNot(HaveOccurred())
+}
+
+func DeleteAndCheck(metallb *metallbv1beta1.MetalLB) {
+	Delete(metallb)
 
 	Eventually(func() bool {
 		err := testclient.Client.Get(context.Background(), goclient.ObjectKey{Namespace: metallb.Namespace, Name: metallb.Name}, metallb)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,10 +1,10 @@
 # github.com/Masterminds/goutils v1.1.1
 ## explicit
 github.com/Masterminds/goutils
-# github.com/Masterminds/semver/v3 v3.1.1
-## explicit; go 1.12
+# github.com/Masterminds/semver/v3 v3.2.0
+## explicit; go 1.18
 github.com/Masterminds/semver/v3
-# github.com/Masterminds/sprig/v3 v3.2.2
+# github.com/Masterminds/sprig/v3 v3.2.3
 ## explicit; go 1.13
 github.com/Masterminds/sprig/v3
 # github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083
@@ -257,8 +257,8 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.4
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/metallb/metallb-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/metallb-operator v0.0.0-20230123113337-fa1059e25fe1
-## explicit; go 1.18
+# github.com/metallb/metallb-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/metallb-operator v0.0.0-20230807120428-6267b32eaa61
+## explicit; go 1.19
 github.com/metallb/metallb-operator/api/v1beta1
 github.com/metallb/metallb-operator/pkg/apply
 github.com/metallb/metallb-operator/pkg/platform
@@ -1268,7 +1268,7 @@ sigs.k8s.io/yaml
 # github.com/test-network-function/l2discovery-lib => github.com/test-network-function/l2discovery-lib v0.0.5
 # github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230330150324-84715294edb9
 # github.com/k8stopologyawareschedwg/resource-topology-exporter => github.com/k8stopologyawareschedwg/resource-topology-exporter v0.8.0
-# github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230123113337-fa1059e25fe1
+# github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230807120428-6267b32eaa61
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b
 # github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc
 # github.com/openshift/cluster-node-tuning-operator => github.com/openshift/cluster-node-tuning-operator v0.0.0-20230711003646-5b4af42e9cfb


### PR DESCRIPTION
Bump metallb vendor to latest commit on release-4.13 
This is so we include a fix that extends a timeout for a flaky test case.