### PR TITLE
[release-4.11] Bump metallb vendor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -195,7 +195,7 @@ replace (
 // Test deps
 replace (
 	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20221207151212-4d0309e6f226 // release-4.11
-	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c //release-4.11
+	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230807125124-f28dd04473bf //release-4.11
 	github.com/openshift-kni/numaresources-operator => github.com/openshift-kni/numaresources-operator v0.4.10-3.2022042201
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10
 	github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc // release-4.9

--- a/go.sum
+++ b/go.sum
@@ -1222,8 +1222,8 @@ github.com/openshift/custom-resource-status v0.0.0-20210221154447-420d9ecf2a00/g
 github.com/openshift/library-go v0.0.0-20210706120254-6f1208ffd780/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
 github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a h1:3YvNi1U+SrL1gBfL7aDT0jHkwvk6+N/xPIqSKXYFRJo=
 github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a/go.mod h1:LC0tawtxYlQ94QiIMOZ68Q+B3xEO8Vq3FIn+srfm4mE=
-github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c h1:WIQB22MuvRQ1tIGBRzQfgbD7BygnigKeKfh6jV6QJRM=
-github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c/go.mod h1:vKlmFjwJPcZxKySg6Y2HF4w+5cB4luH/2W3TmUAXGvg=
+github.com/openshift/metallb-operator v0.0.0-20230807125124-f28dd04473bf h1:kQve+7DQ+Ki52Lgzj0xSg/kwXYxWgiQpfZ8p0u2paEA=
+github.com/openshift/metallb-operator v0.0.0-20230807125124-f28dd04473bf/go.mod h1:vKlmFjwJPcZxKySg6Y2HF4w+5cB4luH/2W3TmUAXGvg=
 github.com/openshift/ptp-operator v0.0.0-20211201021143-27df2443c98f h1:jTS15R8E8fFmLx27w1dNih+owFXM9uWUyV8lu0SJakE=
 github.com/openshift/ptp-operator v0.0.0-20211201021143-27df2443c98f/go.mod h1:ZZqGY2xKHSxu2Ov7F9X5OE8vPhwaGowoGkLxsWYUaBc=
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912/go.mod h1:0OXNy7VoqFexkxKqyQbHJLPwn1MFp1/CxRJAgKHM+/o=

--- a/vendor/github.com/metallb/metallb-operator/pkg/status/status.go
+++ b/vendor/github.com/metallb/metallb-operator/pkg/status/status.go
@@ -101,7 +101,7 @@ func IsMetalLBAvailable(ctx context.Context, client k8sclient.Client, namespace 
 	if err != nil {
 		return err
 	}
-	if ds.Status.DesiredNumberScheduled != ds.Status.CurrentNumberScheduled {
+	if ds.Status.DesiredNumberScheduled != ds.Status.CurrentNumberScheduled || ds.Status.DesiredNumberScheduled != ds.Status.NumberReady {
 		return MetalLBResourcesNotReadyError{Message: "MetalLB speaker daemonset not ready"}
 	}
 	deployment := &appsv1.Deployment{}

--- a/vendor/github.com/metallb/metallb-operator/test/e2e/functional/tests/e2e.go
+++ b/vendor/github.com/metallb/metallb-operator/test/e2e/functional/tests/e2e.go
@@ -12,6 +12,7 @@ import (
 	"github.com/metallb/metallb-operator/pkg/status"
 	"github.com/metallb/metallb-operator/test/consts"
 	testclient "github.com/metallb/metallb-operator/test/e2e/client"
+	"github.com/metallb/metallb-operator/test/e2e/metallb"
 	metallbutils "github.com/metallb/metallb-operator/test/e2e/metallb"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -64,7 +65,7 @@ var _ = Describe("metallb", func() {
 				Expect(daemonset.OwnerReferences).ToNot(BeNil())
 				Expect(daemonset.OwnerReferences[0].Kind).To(Equal("MetalLB"))
 
-				metallbutils.Delete(metallb)
+				metallbutils.DeleteAndCheck(metallb)
 			}
 		})
 
@@ -195,7 +196,7 @@ var _ = Describe("metallb", func() {
 
 			AfterEach(func() {
 				metallbutils.Delete(incorrect_metallb)
-				metallbutils.Delete(correct_metallb)
+				metallbutils.DeleteAndCheck(correct_metallb)
 			})
 			It("should have correct statuses", func() {
 				By("checking MetalLB resource status", func() {
@@ -211,7 +212,7 @@ var _ = Describe("metallb", func() {
 						err := testclient.Client.Get(context.TODO(), goclient.ObjectKey{Namespace: correct_metallb.Namespace, Name: correct_metallb.Name}, instance)
 						Expect(err).ToNot(HaveOccurred())
 						return metallbutils.CheckConditionStatus(instance) == status.ConditionAvailable
-					}, 30*time.Second, 5*time.Second).Should(BeTrue())
+					}, metallb.DeployTimeout, 5*time.Second).Should(BeTrue())
 
 					// Delete incorrectly named resource
 					err := testclient.Client.Delete(context.Background(), incorrect_metallb)

--- a/vendor/github.com/metallb/metallb-operator/test/e2e/metallb/metallb.go
+++ b/vendor/github.com/metallb/metallb-operator/test/e2e/metallb/metallb.go
@@ -33,6 +33,10 @@ func Delete(metallb *metallbv1beta1.MetalLB) {
 		return
 	}
 	Expect(err).ToNot(HaveOccurred())
+}
+
+func DeleteAndCheck(metallb *metallbv1beta1.MetalLB) {
+	Delete(metallb)
 
 	Eventually(func() bool {
 		err := testclient.Client.Get(context.Background(), goclient.ObjectKey{Namespace: metallb.Namespace, Name: metallb.Name}, metallb)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -293,7 +293,7 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/metallb/metallb-operator v0.0.0-20211202081249-1b0df396f552 => github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c
+# github.com/metallb/metallb-operator v0.0.0-20211202081249-1b0df396f552 => github.com/openshift/metallb-operator v0.0.0-20230807125124-f28dd04473bf
 ## explicit; go 1.17
 github.com/metallb/metallb-operator/api/v1beta1
 github.com/metallb/metallb-operator/pkg/apply
@@ -1284,7 +1284,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20210701174259-29813c845a4a
 # sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.0
 # github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20221207151212-4d0309e6f226
-# github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20220514043651-18c1afd8484c
+# github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230807125124-f28dd04473bf
 # github.com/openshift-kni/numaresources-operator => github.com/openshift-kni/numaresources-operator v0.4.10-3.2022042201
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b
 # github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc


### PR DESCRIPTION
Bump metallb vendor to latest commit on release-4.11
This is so we include a fix that extends a timeout for a flaky test case.