### PR TITLE
ztp: Align reference PGT with vector

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
@@ -35,28 +35,23 @@ policies:
       patches:
       - spec:
           outputs:
-          - type: "kafka"
-            name: kafka-open
-            # below url is an example
-            url: tcp://10.46.55.190:9092/test
+            - type: "kafka"
+              name: kafka-open
+              # below url is an example
+              url: tcp://10.46.55.190:9092/test
           pipelines:
-          - name: audit-logs
-            inputRefs:
-             - audit
+          - inputRefs:
+            - audit
+            - infrastructure
+            labels:
+              label1: test1
+              label2: test2
+              label3: test3
+              label4: test4
+            name: all-to-default
             outputRefs:
-             - kafka-open
-          - name: infrastructure-logs
-            inputRefs:
-             - infrastructure
-            outputRefs:
-             - kafka-open
+            - kafka-open
     - path: source-crs/ClusterLogging.yaml
-      patches:
-      - spec:
-          collection:
-            logs:
-              type: "fluentd"
-              fluentd: {}
     ## The setting below overrides the default "worker" selector predefined in
     ## the source-crs. The change is recommended on SNOs configured with PTP 
     ## event notification for forward compatibility with possible SNO expansion.

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -24,23 +24,19 @@ spec:
             # below url is an example
             url: tcp://10.46.55.190:9092/test
         pipelines:
-          - name: audit-logs
-            inputRefs:
-             - audit
-            outputRefs:
-             - kafka-open
-          - name: infrastructure-logs
-            inputRefs:
-             - infrastructure
-            outputRefs:
-             - kafka-open
+        - inputRefs:
+          - audit
+          - infrastructure
+          labels:
+            label1: test1
+            label2: test2
+            label3: test3
+            label4: test4
+          name: all-to-default
+          outputRefs:
+          - kafka-open
     - fileName: ClusterLogging.yaml
       policyName: "config-policy"
-      spec:
-        collection:
-          logs:
-            type: "fluentd"
-            fluentd: {}
     # The setting below overrides the default "worker" selector predefined in
     # the source-crs. The change is recommended on SNOs configured with PTP 
     # event notification for forward compatibility with possible SNO expansion.

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/group-du-sno-ranGen.yaml
@@ -32,11 +32,6 @@ spec:
              - kafka-open
     - fileName: ClusterLogging.yaml
       policyName: "log-policy"
-      spec:
-        collection:
-          logs:
-            type: "fluentd"
-            fluentd: {}
     - fileName: MachineConfigSctp.yaml
       policyName: "mc-sctp-policy"
       metadata:

--- a/ztp/policygenerator/README.md
+++ b/ztp/policygenerator/README.md
@@ -29,8 +29,8 @@ spec:
       spec:
         collection:
           logs:
-            type: "fluentd"
-            fluentd: {}
+            type: "favoriteCollector"
+            favoriteCollector: {}
 ```
 
 The generated policies will be:
@@ -111,8 +111,8 @@ spec:
             spec:
               collection:
                 logs:
-                  fluentd: {}
-                  type: fluentd
+                  favoriteCollector: {}
+                  type: favoriteCollector
               managementState: Managed
         remediationAction: inform
         severity: low


### PR DESCRIPTION
CNF-9132 Align the reference PolicyGenTemplates with use of vector for log collection. The PGT simply use the source CR to align with default collector. Update test code and README to align.