### PR TITLE
OCPBUGS-13313: fix: error in messaging for cpu partitioning

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
@@ -201,9 +201,9 @@ func (scbuilder *SiteConfigBuilder) getClusterCRs(clusterId int, siteConfigTemp 
 		return clusterCRs, err
 	}
 
-	deprecationWarnings := getDeprecationWarnings(cluster)
+	annotationWarnings := getAnnotationWarnings(cluster)
 
-	return addZTPAnnotationToCRs(clusterCRs, deprecationWarnings)
+	return addZTPAnnotationToCRs(clusterCRs, annotationWarnings)
 }
 
 func (scbuilder *SiteConfigBuilder) instantiateCR(target string, originalTemplate map[string]interface{}, overrideSearch func(kind string) (string, bool), applyTemplate func(map[string]interface{}) (map[string]interface{}, error)) (map[string]interface{}, error) {

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -1421,13 +1421,15 @@ spec:
 		{
 			name:         "regular flow should work when node contains a cpuset",
 			configString: fmt.Sprintf(siteConfig, "", `cpuset: "0-1"`),
-			want:         "testdata/siteConfigCPUPartitioningDeprecatedTestOutput.yaml",
-			expectedDiff: noDiff,
+			want:         "testdata/siteConfigCPUPartitioningWarningTestOutput.yaml",
+			expectedDiff: func(s string) bool {
+				return strings.Contains(s, `ran.openshift.io/ztp-warning-techpreview-cpuPartitioningMode:`)
+			},
 		},
 		{
 			name:         "when both are specified should only add the install config override",
 			configString: fmt.Sprintf(siteConfig, `cpuPartitioningMode: "AllNodes"`, `cpuset: "0-1"`),
-			want:         "testdata/siteConfigCPUPartitioningDeprecatedTestOutput.yaml",
+			want:         "testdata/siteConfigCPUPartitioningWarningTestOutput.yaml",
 			expectedDiff: func(s string) bool { return strings.Contains(s, `"cpuPartitioningMode":"AllNodes"`) },
 		},
 	}

--- a/ztp/siteconfig-generator/siteConfig/siteConfigHelper.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigHelper.go
@@ -366,24 +366,18 @@ func applyWorkloadPinningInstallConfigOverrides(clusterSpec *Clusters) (result s
 	return clusterSpec.InstallConfigOverrides, nil
 }
 
-// getDeprecationWarnings is a helper function, currently it only adds deprecation warning for CPU Partitioning.
+// getAnnotationWarnings is a helper function, currently it only adds warning for CPU Partitioning.
 // Note: should be expanded if more annotations are needed.
-func getDeprecationWarnings(clusterSpec Clusters) *annotationWarning {
-	deprecationWarnings := NewAnnotationWarning(ZtpDeprecationWarningAnnotationPostfix)
+func getAnnotationWarnings(clusterSpec Clusters) *annotationWarning {
+	annotationWarnings := NewAnnotationWarning("techpreview")
 	const (
-		deprecationCR      = "AgentClusterInstall"
-		deprecationField   = "cpuset"
-		deprecationMessage = "cpuset will be deprecated after OCP 4.15, please use cpuPartitioningMode for OCP versions >= 4.13"
+		warningCR      = "AgentClusterInstall"
+		warningField   = "cpuPartitioningMode"
+		warningMessage = "feature is currently in TechPreview, this field will replace cpuset in future versions"
 	)
 
-	for _, node := range clusterSpec.Nodes {
-		// If a CPUSet exists on any of the nodes, the whole cluster, regardless if SNO or not, must be setup
-		// for partitioning.
-		if node.Cpuset != "" {
-			// If Node has CPUSet add deprecation warning
-			deprecationWarnings.Add(deprecationCR, deprecationField, deprecationMessage)
-			break
-		}
+	if clusterSpec.CPUPartitioning != "" {
+		annotationWarnings.Add(warningCR, warningField, warningMessage)
 	}
-	return deprecationWarnings
+	return annotationWarnings
 }

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningNewTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningNewTestOutput.yaml
@@ -16,6 +16,7 @@ metadata:
         agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType":"OVNKubernetes"},"cpuPartitioningMode":"AllNodes"}'
         argocd.argoproj.io/sync-wave: "1"
         ran.openshift.io/ztp-gitops-generated: '{}'
+        ran.openshift.io/ztp-warning-techpreview-cpuPartitioningMode: feature is currently in TechPreview, this field will replace cpuset in future versions
     name: cluster1
     namespace: cluster1
 spec:

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningWarningTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningWarningTestOutput.yaml
@@ -16,7 +16,7 @@ metadata:
         agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType":"OVNKubernetes"}}'
         argocd.argoproj.io/sync-wave: "1"
         ran.openshift.io/ztp-gitops-generated: '{}'
-        ran.openshift.io/ztp-warning-field-deprecation-cpuset: cpuset will be deprecated after OCP 4.15, please use cpuPartitioningMode for OCP versions >= 4.13
+        ran.openshift.io/ztp-warning-techpreview-cpuPartitioningMode: feature is currently in TechPreview, this field will replace cpuset in future versions
     name: cluster1
     namespace: cluster1
 spec:

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
@@ -16,7 +16,6 @@ metadata:
         agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType":"OVNKubernetes"},"controlPlane":{"hyperthreading":"Disabled"}}'
         argocd.argoproj.io/sync-wave: "1"
         ran.openshift.io/ztp-gitops-generated: '{}'
-        ran.openshift.io/ztp-warning-field-deprecation-cpuset: cpuset will be deprecated after OCP 4.15, please use cpuPartitioningMode for OCP versions >= 4.13
     name: cluster1
     namespace: cluster1
 spec:


### PR DESCRIPTION
We incorrectly merged in messaging that stated this feature was available in 4.13, this is a 4.14 feature. Updated logic to allow users to use it as a TechPreview flag in 4.13 as originally intended but with correct wording

/assign @imiller0 