### PR TITLE
[WIP] cnf-tests: Move the k8sreporter to the FailHandler

### DIFF
--- a/cnf-tests/testsuites/configsuite/test_suite_test.go
+++ b/cnf-tests/testsuites/configsuite/test_suite_test.go
@@ -38,7 +38,13 @@ func init() {
 }
 
 func TestTest(t *testing.T) {
-	RegisterFailHandler(Fail)
+	RegisterFailHandler(
+		func(message string, callerSkip ...int) {
+			if reporter != nil {
+				reporter.Dump(testutils.LogsExtractDuration, CurrentSpecReport().LeafNodeText)
+			}
+			Fail(message, callerSkip...)
+		})
 
 	if *reportPath != "" {
 		reportFile := path.Join(*reportPath, "setup_failure_report.log")
@@ -71,15 +77,5 @@ var _ = ReportAfterSuite("setup", func(report types.Report) {
 
 	if qe_reporters.Polarion.Run {
 		reporters.ReportViaDeprecatedReporter(&qe_reporters.Polarion, report)
-	}
-})
-
-var _ = ReportAfterEach(func(specReport types.SpecReport) {
-	if specReport.Failed() == false {
-		return
-	}
-
-	if *reportPath != "" {
-		reporter.Dump(testutils.LogsExtractDuration, specReport.LeafNodeText)
 	}
 })

--- a/cnf-tests/testsuites/e2esuite/test_suite_test.go
+++ b/cnf-tests/testsuites/e2esuite/test_suite_test.go
@@ -81,7 +81,13 @@ func init() {
 }
 
 func TestTest(t *testing.T) {
-	RegisterFailHandler(Fail)
+	RegisterFailHandler(
+		func(message string, callerSkip ...int) {
+			if reporter != nil {
+				reporter.Dump(testutils.LogsExtractDuration, CurrentSpecReport().LeafNodeText)
+			}
+			Fail(message, callerSkip...)
+		})
 
 	if *reportPath != "" {
 		reportFile := path.Join(*reportPath, "cnftests_failure_report.log")
@@ -122,15 +128,5 @@ var _ = ReportAfterSuite("cnftests", func(report types.Report) {
 	}
 	if qe_reporters.Polarion.Run {
 		reporters.ReportViaDeprecatedReporter(&qe_reporters.Polarion, report)
-	}
-})
-
-var _ = ReportAfterEach(func(specReport types.SpecReport) {
-	if specReport.Failed() == false {
-		return
-	}
-
-	if *reportPath != "" {
-		reporter.Dump(testutils.LogsExtractDuration, specReport.LeafNodeText)
 	}
 })

--- a/cnf-tests/testsuites/validationsuite/test_suite_test.go
+++ b/cnf-tests/testsuites/validationsuite/test_suite_test.go
@@ -36,7 +36,13 @@ func init() {
 }
 
 func TestTest(t *testing.T) {
-	RegisterFailHandler(Fail)
+	RegisterFailHandler(
+		func(message string, callerSkip ...int) {
+			if reporter != nil {
+				reporter.Dump(testutils.LogsExtractDuration, CurrentSpecReport().LeafNodeText)
+			}
+			Fail(message, callerSkip...)
+		})
 
 	if *reportPath != "" {
 		reportFile := path.Join(*reportPath, "validation_failure_report.log")
@@ -68,15 +74,5 @@ var _ = ReportAfterSuite("validation", func(report types.Report) {
 	}
 	if qe_reporters.Polarion.Run {
 		reporters.ReportViaDeprecatedReporter(&qe_reporters.Polarion, report)
-	}
-})
-
-var _ = ReportAfterEach(func(specReport types.SpecReport) {
-	if specReport.Failed() == false {
-		return
-	}
-
-	if *reportPath != "" {
-		reporter.Dump(testutils.LogsExtractDuration, specReport.LeafNodeText)
 	}
 })


### PR DESCRIPTION
Moving the k8sreporter to the FailHandler in order to run the reporter.Dump
before the cleanup of AfterEach.