### PR TITLE
ztp: Remove redundant overlay content

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-3node-ranGen.yaml
@@ -181,21 +181,6 @@ policies:
     - path: source-crs/TunedPerformancePatch.yaml
       patches:
       - spec:
-          profile:
-          - name: performance-patch
-          # The cmdline_crash CPU set must match the 'isolated' set in the PerformanceProfile above
-            data: |
-              [main]
-              summary=Configuration changes profile inherited from performance created tuned
-              include=openshift-node-performance-openshift-node-performance-profile
-              [sysctl]
-              kernel.timer_migration=1
-              [scheduler]
-              group.ice-ptp=0:f:10:*:ice-ptp.*
-              group.ice-gnss=0:f:10:*:ice-gnss.*
-              [service]
-              service.stalld=start,enable
-              service.chronyd=stop,disable
           recommend:
           - machineConfigLabels:
               machineconfiguration.openshift.io/role: "master"

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
@@ -241,21 +241,6 @@ policies:
     - path: source-crs/TunedPerformancePatch.yaml
       patches:
       - spec:
-          profile:
-          - name: performance-patch
-          # The cmdline_crash CPU set must match the 'isolated' set in the PerformanceProfile above
-            data: |
-              [main]
-              summary=Configuration changes profile inherited from performance created tuned
-              include=openshift-node-performance-openshift-node-performance-profile
-              [sysctl]
-              kernel.timer_migration=1
-              [scheduler]
-              group.ice-ptp=0:f:10:*:ice-ptp.*
-              group.ice-gnss=0:f:10:*:ice-gnss.*
-              [service]
-              service.stalld=start,enable
-              service.chronyd=stop,disable
           recommend:
           - machineConfigLabels:
               machineconfiguration.openshift.io/role: "master"

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-standard-ranGen.yaml
@@ -186,21 +186,6 @@ policies:
     - path: source-crs/TunedPerformancePatch.yaml
       patches:
       - spec:
-          profile:
-          - name: performance-patch
-          # The cmdline_crash CPU set must match the 'isolated' set in the PerformanceProfile above
-            data: |
-              [main]
-              summary=Configuration changes profile inherited from performance created tuned
-              include=openshift-node-performance-openshift-node-performance-profile
-              [sysctl]
-              kernel.timer_migration=1
-              [scheduler]
-              group.ice-ptp=0:f:10:*:ice-ptp.*
-              group.ice-gnss=0:f:10:*:ice-gnss.*
-              [service]
-              service.stalld=start,enable
-              service.chronyd=stop,disable
           recommend:
           - machineConfigLabels:
               machineconfiguration.openshift.io/role: "worker"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-3node-ranGen.yaml
@@ -40,21 +40,6 @@ spec:
               count: 32
     - fileName: TunedPerformancePatch.yaml
       policyName: "config-policy"
-      spec:
-        profile:
-          - name: performance-patch
-            data: |
-              [main]
-              summary=Configuration changes profile inherited from performance created tuned
-              include=openshift-node-performance-openshift-node-performance-profile
-              [sysctl]
-              kernel.timer_migration=1
-              [scheduler]
-              group.ice-ptp=0:f:10:*:ice-ptp.*
-              group.ice-gnss=0:f:10:*:ice-gnss.*
-              [service]
-              service.stalld=start,enable
-              service.chronyd=stop,disable
     #
     # These CRs are to enable crun on master and worker nodes for 4.13+ only
     #

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -104,21 +104,6 @@ spec:
               count: 32
     - fileName: TunedPerformancePatch.yaml
       policyName: "config-policy"
-      spec:
-        profile:
-          - name: performance-patch
-            data: |
-              [main]
-              summary=Configuration changes profile inherited from performance created tuned
-              include=openshift-node-performance-openshift-node-performance-profile
-              [sysctl]
-              kernel.timer_migration=1
-              [scheduler]
-              group.ice-ptp=0:f:10:*:ice-ptp.*
-              group.ice-gnss=0:f:10:*:ice-gnss.*
-              [service]
-              service.stalld=start,enable
-              service.chronyd=stop,disable
     #
     # These CRs are to enable crun on master and worker nodes for 4.13+ only
     #

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
@@ -40,21 +40,6 @@ spec:
               count: 32
     - fileName: TunedPerformancePatch.yaml
       policyName: "config-policy"
-      spec:
-        profile:
-          - name: performance-patch
-            data: |
-              [main]
-              summary=Configuration changes profile inherited from performance created tuned
-              include=openshift-node-performance-openshift-node-performance-profile
-              [sysctl]
-              kernel.timer_migration=1
-              [scheduler]
-              group.ice-ptp=0:f:10:*:ice-ptp.*
-              group.ice-gnss=0:f:10:*:ice-gnss.*
-              [service]
-              service.stalld=start,enable
-              service.chronyd=stop,disable
     #
     # These CRs are to enable crun on master and worker nodes for 4.13+ only
     #


### PR DESCRIPTION
The overlay content for the tuned patch in the group profile is identical to the content in the base source-cr. There is no need to maintain (or recommend to the user) the overlay content.