### PR TITLE
OCPBUGS-15790, OCPBUGS-15791: cnf-tests: Use `lspcu --parse` to get NUMA  node

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/numa_node_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/numa_node_sriov.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/namespaces"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/networks"
 	utilnodes "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/nodes"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/numa"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/pods"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
@@ -405,7 +406,7 @@ func expectPodCPUsAreOnNUMANode(pod *corev1.Pod, expectedCPUsNUMA int) {
 	cpuList, err := getCpuSet(buff.String())
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-	numaNode, err := findNUMAForCPUs(pod, cpuList)
+	numaNode, err := numa.FindForCPUs(pod, cpuList)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	ExpectWithOffset(1, numaNode).To(Equal(expectedCPUsNUMA))

--- a/cnf-tests/testsuites/pkg/numa/numa.go
+++ b/cnf-tests/testsuites/pkg/numa/numa.go
@@ -1,0 +1,62 @@
+package numa
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/strings/slices"
+
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/client"
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/pods"
+)
+
+// FindNUMAForCPUs finds the NUMA node if all the CPUs in the list are in the same one and returns it.
+func FindForCPUs(pod *corev1.Pod, cpuList []string) (int, error) {
+	buff, err := pods.ExecCommand(client.Client, *pod, []string{"lscpu", "--parse=cpu,node"})
+	if err != nil {
+		return -1, fmt.Errorf("cannot issue lscpu on pod %s/%s: %w", pod.Namespace, pod.Name, err)
+
+	}
+
+	return findForCPUsParseOutput(buff.String(), cpuList)
+}
+
+func findForCPUsParseOutput(lscpuOutput string, cpuList []string) (int, error) {
+	foundNUMAnode := -1
+
+	for _, line := range strings.Split(lscpuOutput, "\r\n") {
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if !strings.Contains(line, ",") {
+			// Last line is empty
+			continue
+		}
+
+		splittedLine := strings.Split(line, ",")
+		if len(splittedLine) != 2 {
+			return -1, fmt.Errorf("bad line output for lscpu: %s", line)
+		}
+
+		cpu := splittedLine[0]
+		numa, err := strconv.Atoi(splittedLine[1])
+		if err != nil {
+			return -1, fmt.Errorf("can't convert NUMA node from line: %s. lscpu output: %s", line, lscpuOutput)
+		}
+
+		if slices.Contains(cpuList, cpu) {
+			if foundNUMAnode != -1 {
+				if foundNUMAnode != numa {
+					return -1, fmt.Errorf("not all the cpus are in the same numa node")
+				}
+			}
+
+			foundNUMAnode = numa
+		}
+	}
+
+	return foundNUMAnode, nil
+}

--- a/cnf-tests/testsuites/pkg/numa/numa_test.go
+++ b/cnf-tests/testsuites/pkg/numa/numa_test.go
@@ -1,0 +1,43 @@
+package numa
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var lsCpu2NUMA16CoresOutput string = strings.ReplaceAll(`# The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting from zero.
+# CPU,Node
+0,0
+1,1
+2,0
+3,1
+4,0
+5,1
+6,0
+7,1
+8,0
+9,1
+10,0
+11,1
+12,0
+13,1
+14,0
+15,1
+`, "\n", "\r\n")
+
+func TestFindNUMAForCPUsInLscpu(t *testing.T) {
+	result, err := findForCPUsParseOutput(lsCpu2NUMA16CoresOutput, []string{"0", "2", "4", "6"})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, result)
+
+	result, err = findForCPUsParseOutput(lsCpu2NUMA16CoresOutput, []string{"1", "3"})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, result)
+
+	_, err = findForCPUsParseOutput(lsCpu2NUMA16CoresOutput, []string{"0", "1"})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
If a node has many CPUs, `lscpu` command output may split over multiple lines, making it hard to get the list of CPUs per NUMA node.

Switching to `lscpu --parse=cpu,node` simplifies the parsing logic.

cc @SchSeba 