### PR TITLE
cnf-tests: Fix flaky tuningcni tests

### DIFF
--- a/cnf-tests/testsuites/e2esuite/security/tuning.go
+++ b/cnf-tests/testsuites/e2esuite/security/tuning.go
@@ -78,6 +78,7 @@ var _ = Describe("[tuningcni]", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			podDefinition := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s", namespaces.TuningTest, nad1Name)})
+			podDefinition = pods.RedefineWithLabel(podDefinition, "app", "tuningcni")
 			pod, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			err = pods.WaitForPhase(client.Client, pod, corev1.PodRunning, 1*time.Minute)
@@ -86,7 +87,7 @@ var _ = Describe("[tuningcni]", func() {
 			podDefinition2 := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s", namespaces.TuningTest, nad2Name)})
 			podDefinition2 = pods.RedefineWithCommand(podDefinition2, []string{"/bin/bash", "-c", fmt.Sprintf("ping -c 1 %s", ip1)}, nil)
 			podDefinition2 = pods.RedefineWithRestartPolicy(podDefinition2, corev1.RestartPolicyNever)
-			podDefinition2.Spec.NodeName = pod.Spec.NodeName
+			podDefinition2 = pods.RedefineWithPodAffinityOnLabel(podDefinition2, "app", "tuningcni")
 			pod2, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition2, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			err = pods.WaitForPhase(client.Client, pod2, corev1.PodSucceeded, 1*time.Minute)
@@ -121,6 +122,7 @@ var _ = Describe("[tuningcni]", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				podDefinition1 := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s, %s/%s, %s/%s", namespaces.TuningTest, macvlanNadName, namespaces.TuningTest, macvlanNadName, namespaces.TuningTest, bondNadName1)})
+				podDefinition1 = pods.RedefineWithLabel(podDefinition1, "app", "tuningcni")
 				pod1, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition1, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				err = pods.WaitForPhase(client.Client, pod1, corev1.PodRunning, 1*time.Minute)
@@ -129,7 +131,7 @@ var _ = Describe("[tuningcni]", func() {
 				podDefinition2 := pods.DefineWithNetworks(namespaces.TuningTest, []string{fmt.Sprintf("%s/%s, %s/%s, %s/%s", namespaces.TuningTest, macvlanNadName, namespaces.TuningTest, macvlanNadName, namespaces.TuningTest, bondNadName2)})
 				podDefinition2 = pods.RedefineWithCommand(podDefinition2, []string{"/bin/bash", "-c", fmt.Sprintf("ping -c 1 %s", ip1)}, nil)
 				podDefinition2 = pods.RedefineWithRestartPolicy(podDefinition2, corev1.RestartPolicyNever)
-				podDefinition2.Spec.NodeName = pod1.Spec.NodeName
+				podDefinition2 = pods.RedefineWithPodAffinityOnLabel(podDefinition2, "app", "tuningcni")
 				pod2, err := client.Client.Pods(namespaces.TuningTest).Create(context.Background(), podDefinition2, metav1.CreateOptions{})
 
 				Expect(err).ToNot(HaveOccurred())

--- a/cnf-tests/testsuites/pkg/pods/pods.go
+++ b/cnf-tests/testsuites/pkg/pods/pods.go
@@ -104,6 +104,27 @@ func RedefineWithLabel(pod *corev1.Pod, key, value string) *corev1.Pod {
 	return pod
 }
 
+// RedefineWithPodAfinityOnLabel sets the spec.podAffinity field using the given label key and value.
+// It can be use to ensure a pod is scheduled on the same node as another, selecting the reference pod by a label.
+func RedefineWithPodAffinityOnLabel(pod *corev1.Pod, key, value string) *corev1.Pod {
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &corev1.Affinity{}
+	}
+
+	if pod.Spec.Affinity.PodAffinity == nil {
+		pod.Spec.Affinity.PodAffinity = &corev1.PodAffinity{}
+	}
+
+	pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = []corev1.PodAffinityTerm{{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{key: value},
+		},
+		TopologyKey: "kubernetes.io/hostname",
+	}}
+
+	return pod
+}
+
 // RedefineWithRestrictedPrivileges enforces restricted privileges on the pod.
 func RedefineWithRestrictedPrivileges(pod *corev1.Pod) *corev1.Pod {
 	pod.Spec.SecurityContext = &corev1.PodSecurityContext{


### PR DESCRIPTION
Tuning CNI test cases leverage multus macvlan networks, so
pods must be located in the same host to ping each other.

Previuous way to ensure pods are co-located was not good, as the field
`pod.Spec.NodeName` is not populated when the pod is created.

Use `pod.Spec.Affinity.podAffinity` using pod labels to ensure
client and server pods run on the same host.

cc @liornoy 
thanks to [1] I could identify the flake:

```go
podDefinition2.Spec.NodeName = pod.Spec.NodeName
```

- [1] https://github.com/openshift-kni/cnf-features-deploy/pull/1617

Fixes
```
[FAIL] [tuningcni] tuningcni over macvlan [It] pods with sysctl's over macvlan should be able to ping each other
  /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/security/tuning.go:93
[FAIL] [tuningcni] tuningcni over bond [It] pods with sysctls over bond should be able to ping each other
  /go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/security/tuning.go:137
```
