### PR TITLE
ztp: correct examples using InstallerArgs

### DIFF
--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-du.yaml
@@ -53,7 +53,7 @@ spec:
         userData:
           bootKey: value1
         cpuset: "2-19,22-39"
-        installerArgs: '{"args": ["--append-karg", "nameserver=8.8.8.8", "-n"]}'
+        installerArgs: '["--append-karg", "nameserver=8.8.8.8", "-n"]'
         ignitionConfigOverride: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/containers/registries.conf", "overwrite": true, "contents": {"source": "data:text/plain;base64,aGVsbG8gZnJvbSB6dHAgcG9saWN5IGdlbmVyYXRvcg=="}}]}}'
         nodeNetwork:
           interfaces:

--- a/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-expansion.yaml
+++ b/ztp/siteconfig-generator-kustomize-plugin/testSiteConfig/site1-sno-expansion.yaml
@@ -53,7 +53,7 @@ spec:
         userData:
           bootKey: value1
         cpuset: "2-19,22-39"
-        installerArgs: '{"args": ["--append-karg", "nameserver=8.8.8.8", "-n"]}'
+        installerArgs: '["--append-karg", "nameserver=8.8.8.8", "-n"]'
         ignitionConfigOverride: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/containers/registries.conf", "overwrite": true, "contents": {"source": "data:text/plain;base64,aGVsbG8gZnJvbSB6dHAgcG9saWN5IGdlbmVyYXRvcg=="}}]}}'
         nodeNetwork:
           interfaces:
@@ -130,7 +130,7 @@ spec:
         userData:
           bootKey: value1
         cpuset: "2-19,22-39"
-        installerArgs: '{"args": ["--append-karg", "nameserver=8.8.8.8", "-n"]}'
+        installerArgs: '["--append-karg", "nameserver=8.8.8.8", "-n"]'
         ignitionConfigOverride: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/containers/registries.conf", "overwrite": true, "contents": {"source": "data:text/plain;base64,aGVsbG8gZnJvbSB6dHAgcG9saWN5IGdlbmVyYXRvcg=="}}]}}'
         nodeNetwork:
           interfaces:


### PR DESCRIPTION
The current examples about using InstallerArgs, to
interact with the AI Service, seems not been
working correctly.

Using: {"args": ["--append-karg", "nameserver=8.8.8.8", "-n"]} makes the AI agent to fail to unmarshall

```
  - lastTransitionTime: "2023-09-08T07:58:00Z"
    message: 'The Spec could not be synced due to an input error: Fail to unmarshal
      installer args for host 00000000-0000-0000-0000-000000000008 in infraEnv 0e7b3463-b7a5-4fc7-ae68-e249d52760e3:
      json: cannot unmarshal object into Go value of type []string'
    reason: InputError
    status: "False"
    type: SpecSynced
```

Just using:  ["--append-karg", "nameserver=8.8.8.8", "-n"] seems to be working.