### PR TITLE
vendor: bump nto deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -205,6 +205,6 @@ replace (
 	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230905121931-593c75393b88 // release-4.14
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10
 	github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc // release-4.9
-	github.com/openshift/cluster-node-tuning-operator => github.com/openshift/cluster-node-tuning-operator v0.0.0-20230906061509-32041b084a80 // release-4.14
+	github.com/openshift/cluster-node-tuning-operator => github.com/openshift/cluster-node-tuning-operator v0.0.0-20230910132107-883a3cf3a8a0 // release-4.14
 	github.com/openshift/ptp-operator => github.com/openshift/ptp-operator v0.0.0-20230831212656-4b8be2662cfe // release-4.14
 )

--- a/go.sum
+++ b/go.sum
@@ -2892,8 +2892,8 @@ github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc h1:5Ib/WLecCTw8Nd+Qu7BdXRByzrJdsJTnWYU2vaeB6P4=
 github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc/go.mod h1:yZIen7zOC5Heuq2TnL3Ec1APql+HnhZXeaOST8h2TeQ=
-github.com/openshift/cluster-node-tuning-operator v0.0.0-20230906061509-32041b084a80 h1:IIQp70D/PyeoUl2n4SPsxNhx9lYw480fKUDzGBksqxg=
-github.com/openshift/cluster-node-tuning-operator v0.0.0-20230906061509-32041b084a80/go.mod h1:WHTSlpJEglA/KrmlmW5r8j9aBRpAlTxr+9B7k1NW9Kg=
+github.com/openshift/cluster-node-tuning-operator v0.0.0-20230910132107-883a3cf3a8a0 h1:z8//brERUOkWwQ4T5+jpDBIUaSuRBxgtcndCqRRZ3pM=
+github.com/openshift/cluster-node-tuning-operator v0.0.0-20230910132107-883a3cf3a8a0/go.mod h1:WHTSlpJEglA/KrmlmW5r8j9aBRpAlTxr+9B7k1NW9Kg=
 github.com/openshift/custom-resource-status v0.0.0-20210221154447-420d9ecf2a00/go.mod h1:GDjWl0tX6FNIj82vIxeudWeSx2Ff6nDZ8uJn0ohUFvo=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 h1:cHyxR+Y8rAMT6m1jQCaYGRwikqahI0OjjUDhFNf3ySQ=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -406,7 +406,7 @@ github.com/openshift/client-go/operator/listers/operator/v1alpha1
 # github.com/openshift/cluster-nfd-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc
 ## explicit; go 1.16
 github.com/openshift/cluster-nfd-operator/api/v1
-# github.com/openshift/cluster-node-tuning-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/cluster-node-tuning-operator v0.0.0-20230906061509-32041b084a80
+# github.com/openshift/cluster-node-tuning-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/cluster-node-tuning-operator v0.0.0-20230910132107-883a3cf3a8a0
 ## explicit; go 1.19
 github.com/openshift/cluster-node-tuning-operator/assets/performanceprofile
 github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v1
@@ -1353,5 +1353,5 @@ sigs.k8s.io/yaml
 # github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230905121931-593c75393b88
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b
 # github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc
-# github.com/openshift/cluster-node-tuning-operator => github.com/openshift/cluster-node-tuning-operator v0.0.0-20230906061509-32041b084a80
+# github.com/openshift/cluster-node-tuning-operator => github.com/openshift/cluster-node-tuning-operator v0.0.0-20230910132107-883a3cf3a8a0
 # github.com/openshift/ptp-operator => github.com/openshift/ptp-operator v0.0.0-20230831212656-4b8be2662cfe


### PR DESCRIPTION
We improved the logging in the RPS test https://github.com/openshift/cluster-node-tuning-operator/pull/787 in order to find out why the test failed upstream.