### PR TITLE
cnf-tests: Bump origin-oc-rpms version

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN make test-bin
 RUN git rev-list -1 HEAD > ./cnf-tests/bin/cnftests-sha.txt
 
-FROM quay.io/openshift/origin-oc-rpms:4.13 AS oc
+FROM quay.io/openshift/origin-oc-rpms:4.14 AS oc
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder-stresser
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -12,7 +12,7 @@ WORKDIR $PKG_PATH
 RUN make test-bin
 RUN git rev-list -1 HEAD > ./cnf-tests/bin/cnftests-sha.txt
 
-FROM quay.io/openshift/origin-oc-rpms:4.13 as oc
+FROM quay.io/openshift/origin-oc-rpms:4.14 as oc
 
 # This dockerfile is specific to building the OpenShift CNF stresser image
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 as builder-stresser


### PR DESCRIPTION
This commit bumps the image version of origin-oc-rpms that we use as part of the cnf-tests container Dockerfile.