### PR TITLE
cnf-tests: Dump correct code line on failure

### DIFF
--- a/cnf-tests/testsuites/configsuite/test_suite_test.go
+++ b/cnf-tests/testsuites/configsuite/test_suite_test.go
@@ -43,6 +43,12 @@ func TestTest(t *testing.T) {
 			if reporter != nil {
 				reporter.Dump(testutils.LogsExtractDuration, CurrentSpecReport().LeafNodeText)
 			}
+
+			// Ensure failing line location is not affected by this wrapper
+			for i := range callerSkip {
+				callerSkip[i]++
+			}
+
 			Fail(message, callerSkip...)
 		})
 

--- a/cnf-tests/testsuites/e2esuite/test_suite_test.go
+++ b/cnf-tests/testsuites/e2esuite/test_suite_test.go
@@ -83,6 +83,12 @@ func TestTest(t *testing.T) {
 			if reporter != nil {
 				reporter.Dump(testutils.LogsExtractDuration, CurrentSpecReport().LeafNodeText)
 			}
+
+			// Ensure failing line location is not affected by this wrapper
+			for i := range callerSkip {
+				callerSkip[i]++
+			}
+
 			Fail(message, callerSkip...)
 		})
 

--- a/cnf-tests/testsuites/validationsuite/test_suite_test.go
+++ b/cnf-tests/testsuites/validationsuite/test_suite_test.go
@@ -41,6 +41,12 @@ func TestTest(t *testing.T) {
 			if reporter != nil {
 				reporter.Dump(testutils.LogsExtractDuration, CurrentSpecReport().LeafNodeText)
 			}
+
+			// Ensure failing line location is not affected by this wrapper
+			for i := range callerSkip {
+				callerSkip[i]++
+			}
+
 			Fail(message, callerSkip...)
 		})
 


### PR DESCRIPTION
Custom ginkgo FailHanlder adds an item in the call stack when handling a failure and ginkgo uses `panic(...)` to get the stacktrace and to infer the user code location of the failing assertion.

This commit ensure the `callerSkip ...int` parameter is incremented.

Prior to this commit, failing messages appeared as

```
In [It] at: /tmp/cnf-jc658/cnf-features-deploy/vendor/github.com/onsi/gomega/internal/assertion.go:62 @ 09/11/23 20:31:50.623
```

(the failing line is always inside `vendor/github.com/onsi/gomega/internal/...`)

Example [here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-telco5g-cnftests/1701302792343261184/artifacts/e2e-telco5g-cnftests/telco5g-cnf-tests/artifacts/test_results.html)

Ref:
- https://github.com/openshift-kni/cnf-features-deploy/pull/1617

cc @liornoy , @AlinaSecret
