### PR TITLE
cnf-tests: Add fsGroup for rootless dpdk pod

### DIFF
--- a/cnf-tests/testsuites/pkg/pods/pods.go
+++ b/cnf-tests/testsuites/pkg/pods/pods.go
@@ -129,6 +129,7 @@ func RedefineWithPodAffinityOnLabel(pod *corev1.Pod, key, value string) *corev1.
 func RedefineWithRestrictedPrivileges(pod *corev1.Pod) *corev1.Pod {
 	pod.Spec.SecurityContext = &corev1.PodSecurityContext{
 		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		FSGroup:        pointer.Int64Ptr(1001),
 	}
 	for i := range pod.Spec.Containers {
 		pod.Spec.Containers[i].SecurityContext.RunAsNonRoot = pointer.BoolPtr(true)

--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -67,8 +67,8 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 RUN setcap cap_sys_resource,cap_ipc_lock=+ep /usr/libexec/s2i/run
 
 # Allows non-root users to use dpdk-testpmd.
-RUN setcap cap_sys_resource,cap_ipc_lock,cap_net_raw+ep /usr/local/bin/dpdk-testpmd
-RUN setcap cap_sys_resource,cap_ipc_lock,cap_net_raw+ep /usr/local/bin/dpdk-test-bbdev
+RUN setcap cap_ipc_lock,cap_net_raw+ep /usr/local/bin/dpdk-testpmd
+RUN setcap cap_ipc_lock,cap_net_raw+ep /usr/local/bin/dpdk-test-bbdev
 
 # Add supplementary group 801 to user 1001 in order to use the VFIO device in a non-privileged pod.
 RUN groupadd -g 801 hugetlbfs


### PR DESCRIPTION
The directory /mnt/huge couldn't be accessed by the 1001 user. fsGroup mounts the volume with 1001 group permissions.