### PR TITLE
[Do Not Merge] [release-4.14] Allow filtering SR-IOV by environment variable in cnf-tests

### DIFF
--- a/cnf-tests/testsuites/pkg/machineconfigpool/machineconfigpool.go
+++ b/cnf-tests/testsuites/pkg/machineconfigpool/machineconfigpool.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/client"
 	testclient "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/client"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/nodes"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -12,7 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 )
@@ -318,6 +321,15 @@ func ApplyKubeletConfigToNode(node *corev1.Node, name string, spec *mcov1.Kubele
 
 		return WaitForAllMCPStable()
 	}, nil
+}
+
+// DeleteKubeleConfigIfPresent delete the KubeletConfig specified by `name`. If there is no object with such name, a nil error is returned.
+func DeleteKubeleConfigIfPresent(name string) error {
+	err := client.Client.KubeletConfigs().Delete(context.Background(), name, metav1.DeleteOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 func waitUntilKubeletConfigHasUpdatedTheMCP(name string) error {

--- a/go.mod
+++ b/go.mod
@@ -187,7 +187,7 @@ replace (
 
 // Test deps
 replace (
-	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230905125821-ddb03cef1ca7 // release-4.14
+	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/zeeke/sriov-network-operator v0.0.0-20230914163651-27d1c7408a9d // release-4.14
 	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230905121931-593c75393b88 // release-4.14
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10
 	github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc // release-4.9

--- a/go.sum
+++ b/go.sum
@@ -2902,8 +2902,6 @@ github.com/openshift/ptp-operator v0.0.0-20230831212656-4b8be2662cfe/go.mod h1:q
 github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f/go.mod h1:l9/qeKZuAmYUMl0yicJlbkPGDsIycGhwxOvOAWyaP0E=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b h1:NlOsWwZI4tYu6XbqG1/9jtg2I20+zs+8vy7d4X7ieZs=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b/go.mod h1:ESuS9sfrzo0EpEHaHNEvjo1oThseBnGU5s+RT1psTRA=
-github.com/openshift/sriov-network-operator v0.0.0-20230905125821-ddb03cef1ca7 h1:AR3rSUHDIt89+apc57lP2RiVv0yM1vusqBMuiatgD1c=
-github.com/openshift/sriov-network-operator v0.0.0-20230905125821-ddb03cef1ca7/go.mod h1:iTLcGUWhk85IySPerBAGZ/jjFSp3FHuWnOT347us6hA=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -3475,6 +3473,8 @@ github.com/zalando/go-keyring v0.1.1/go.mod h1:OIC+OZ28XbmwFxU/Rp9V7eKzZjamBJwRz
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/errs v1.2.2/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
+github.com/zeeke/sriov-network-operator v0.0.0-20230914163651-27d1c7408a9d h1:Iehq7HwLg8X4qRxfODH9f3PeFvN99J6Phi97Kh2PVPs=
+github.com/zeeke/sriov-network-operator v0.0.0-20230914163651-27d1c7408a9d/go.mod h1:iTLcGUWhk85IySPerBAGZ/jjFSp3FHuWnOT347us6hA=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster/cluster.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster/cluster.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -92,33 +94,48 @@ func DiscoverSriov(clients *testclient.ClientSet, operatorNamespace string) (*En
 
 // FindOneSriovDevice retrieves a valid sriov device for the given node.
 func (n *EnabledNodes) FindOneSriovDevice(node string) (*sriovv1.InterfaceExt, error) {
-	s, ok := n.States[node]
-	if !ok {
-		return nil, fmt.Errorf("node %s not found", node)
+	ret, err := n.FindSriovDevices(node)
+	if err != nil {
+		return nil, err
 	}
-	for _, itf := range s.Status.Interfaces {
-		if IsPFDriverSupported(itf.Driver) && sriovv1.IsSupportedDevice(itf.DeviceID) {
-			// Skip mlx interfaces if secure boot is enabled
-			// TODO: remove this when mlx support secure boot/lockdown mode
-			if itf.Vendor == mlxVendorID && n.IsSecureBootEnabled[node] {
-				continue
-			}
 
-			// if the sriov is not enable in the kernel for intel nic the totalVF will be 0 so we skip the device
-			// That is not the case for Mellanox devices that will report 0 until we configure the sriov interfaces
-			// with the mstconfig package
-			if itf.Vendor == intelVendorID && itf.TotalVfs == 0 {
-				continue
-			}
+	if len(ret) == 0 {
+		return nil, fmt.Errorf("unable to find sriov devices in node %s", node)
+	}
 
-			return &itf, nil
+	return ret[0], nil
+}
+
+// FindSriovDevices retrieves all valid sriov devices for the given node, filtered by `SRIOV_DEVICE_NAME_FILTER` environment variable.
+func (n *EnabledNodes) FindSriovDevices(node string) ([]*sriovv1.InterfaceExt, error) {
+	devices, err := n.FindSriovDevicesIgnoreFilters(node)
+	if err != nil {
+		return nil, err
+	}
+
+	sriovDeviceNameFilter, ok := os.LookupEnv("SRIOV_DEVICE_NAME_FILTER")
+	if !ok {
+		return devices, nil
+	}
+
+	filteredDevices := []*sriovv1.InterfaceExt{}
+	for _, device := range devices {
+
+		match, err := regexp.MatchString(sriovDeviceNameFilter, device.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		if match {
+			filteredDevices = append(filteredDevices, device)
 		}
 	}
-	return nil, fmt.Errorf("unable to find sriov devices in node %s", node)
+
+	return filteredDevices, nil
 }
 
 // FindSriovDevices retrieves all valid sriov devices for the given node.
-func (n *EnabledNodes) FindSriovDevices(node string) ([]*sriovv1.InterfaceExt, error) {
+func (n *EnabledNodes) FindSriovDevicesIgnoreFilters(node string) ([]*sriovv1.InterfaceExt, error) {
 	devices := []*sriovv1.InterfaceExt{}
 	s, ok := n.States[node]
 	if !ok {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -225,7 +225,7 @@ github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/client/clientset/version
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1
-# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20230905125821-ddb03cef1ca7
+# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/zeeke/sriov-network-operator v0.0.0-20230914163651-27d1c7408a9d
 ## explicit; go 1.20
 github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
 github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/scheme
@@ -1270,7 +1270,7 @@ sigs.k8s.io/yaml
 # github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.46.0
 # github.com/test-network-function/l2discovery-lib => github.com/test-network-function/l2discovery-lib v0.0.5
 # sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.15.2
-# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230905125821-ddb03cef1ca7
+# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/zeeke/sriov-network-operator v0.0.0-20230914163651-27d1c7408a9d
 # github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230905121931-593c75393b88
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b
 # github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc


### PR DESCRIPTION
This PR is for testing only, as it includes a bump to a non official for of sriov-network-operator.
 
Changes allows to select SR-IOV devices used by cnf-tests by setting the environment variable `SRIOV_DEVICE_NAME_FILTER`.


