### PR TITLE
cnf-tests: Avoid passing nil to `GetStringEventsForPodFn`

### DIFF
--- a/cnf-tests/testsuites/e2esuite/sctp/sctp.go
+++ b/cnf-tests/testsuites/e2esuite/sctp/sctp.go
@@ -310,7 +310,7 @@ func startServerPod(node, namespace string, networks ...string) *k8sv1.Pod {
 		res, err = client.Client.Pods(namespace).Get(context.Background(), serverPod.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return res.Status.Phase
-	}, waitForPodRunningTimeout*time.Minute, 1*time.Second).Should(Equal(k8sv1.PodRunning), pods.GetStringEventsForPodFn(client.Client, res))
+	}, waitForPodRunningTimeout*time.Minute, 1*time.Second).Should(Equal(k8sv1.PodRunning), pods.GetStringEventsForPodFn(client.Client, serverPod))
 	return res
 }
 
@@ -344,7 +344,6 @@ func checkForSctpReady(cs *client.ClientSet) {
 }
 
 func testClientServerConnection(cs *client.ClientSet, namespace string, destIP string, port int32, clientNode string, serverPodName string, shouldSucceed bool, networks ...string) {
-	var pod *k8sv1.Pod
 
 	By("Connecting a client to the server")
 	clientArgs := []string{"-ip", destIP, "-port",
@@ -354,7 +353,7 @@ func testClientServerConnection(cs *client.ClientSet, namespace string, destIP s
 		clientPod.Annotations = map[string]string{"k8s.v1.cni.cncf.io/networks": strings.Join(networks, ",")}
 	}
 
-	_, err := cs.Pods(namespace).Create(context.Background(), clientPod, metav1.CreateOptions{})
+	pod, err := cs.Pods(namespace).Create(context.Background(), clientPod, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
 	if !shouldSucceed {

--- a/cnf-tests/testsuites/e2esuite/vrf/vrf.go
+++ b/cnf-tests/testsuites/e2esuite/vrf/vrf.go
@@ -113,27 +113,27 @@ func addVRFNad(cs *client.ClientSet, NadName string, vrfName string) netattdefv1
 }
 
 func getOverlapIP(cs *client.ClientSet, namespace string, nodeName string, podNamePrefix string) string {
-	var tempPod *k8sv1.Pod
 	tempPodDefinition := redefineAsNetRawWithNamePrefix(pods.DefinePodOnNode(namespace, nodeName), podNamePrefix)
 	err := cs.Create(context.Background(), tempPodDefinition)
 	Expect(err).ToNot(HaveOccurred())
 	Eventually(func() k8sv1.PodPhase {
-		tempPod, _ = cs.Pods(namespace).Get(context.Background(), tempPodDefinition.Name, metav1.GetOptions{})
+		tempPod, err := cs.Pods(namespace).Get(context.Background(), tempPodDefinition.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
 		return tempPod.Status.Phase
-	}, podWaitingTime, time.Second).Should(Equal(k8sv1.PodRunning), pods.GetStringEventsForPodFn(cs, tempPod))
+	}, podWaitingTime, time.Second).Should(Equal(k8sv1.PodRunning), pods.GetStringEventsForPodFn(cs, tempPodDefinition))
 	pod, err := cs.Pods(namespace).Get(context.Background(), tempPodDefinition.Name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	return pod.Status.PodIP
 }
 
 func waitUntilPodCreatedAndRunning(cs *client.ClientSet, podStruct *k8sv1.Pod) {
-	var tempPod *k8sv1.Pod
 	err := cs.Create(context.Background(), podStruct)
 	Expect(err).ToNot(HaveOccurred())
 	Eventually(func() k8sv1.PodPhase {
-		tempPod, _ = cs.Pods(podStruct.Namespace).Get(context.Background(), podStruct.Name, metav1.GetOptions{})
+		tempPod, err := cs.Pods(podStruct.Namespace).Get(context.Background(), podStruct.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
 		return tempPod.Status.Phase
-	}, podWaitingTime, time.Second).Should(Equal(k8sv1.PodRunning), pods.GetStringEventsForPodFn(cs, tempPod))
+	}, podWaitingTime, time.Second).Should(Equal(k8sv1.PodRunning), pods.GetStringEventsForPodFn(cs, podStruct))
 }
 
 func podHasCorrectVRFConfig(cs *client.ClientSet, pod *k8sv1.Pod, vrfMapsConfig []map[string]string) {

--- a/cnf-tests/testsuites/pkg/pods/pods.go
+++ b/cnf-tests/testsuites/pkg/pods/pods.go
@@ -470,11 +470,16 @@ func DetectDefaultRouteInterface(cs *testclient.ClientSet, pod corev1.Pod) (stri
 }
 
 func getStringEventsForPod(cs corev1client.EventsGetter, pod *corev1.Pod) string {
-	var res string
+	if pod == nil {
+		return "can't retrieve events for nil pod"
+	}
+
 	events, err := cs.Events(pod.Namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pod.Name), TypeMeta: metav1.TypeMeta{Kind: "Pod"}})
 	if err != nil {
-		return err.Error()
+		return fmt.Sprintf("can't retrieve events for pod %s/%s: %s", pod.Namespace, pod.Name, err.Error())
 	}
+
+	var res string
 	for _, item := range events.Items {
 		eventStr := fmt.Sprintf("%s: %s", item.LastTimestamp, item.Message)
 		res = res + fmt.Sprintf("%s\n", eventStr)


### PR DESCRIPTION
When the `Eventually(...)` call fails, the variables inside its block can be nil and they should not be passed to
`pods.GetStringEventsForPodFn()`, as they would cause a `nil pointer dereference` error.

Improve the information returned by `GetStringEventsForPodFn` when the pod retrieval raises errors.

Sample errors in:
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.13-e2e-telco5g-cnftests/1709932352127373312/artifacts/e2e-telco5g-cnftests/telco5g-cnf-tests/artifacts/saved-cnf-tests-run.log

cc @liornoy 


```
[0m[vrf] [38;5;243m [0mIntegration: NAD, IPAM: static, Interfaces: 1, Scheme: 2 Pods 2 VRFs OCP Primary network overlap [38;5;13m[1m[It] {"IPStack":"ipv4"}[0m
[38;5;243m/tmp/cnf-NdBry/cnf-features-deploy/cnf-tests/testsuites/e2esuite/vrf/vrf.go:82[0m

  [38;5;13m[PANICKED] Test Panicked[0m
  [38;5;13mIn [1m[It][0m[38;5;13m at: [1m/usr/local/go/src/runtime/panic.go:260[0m [38;5;243m@ 10/05/23 15:32:18.096[0m

  [38;5;13mruntime error: invalid memory address or nil pointer dereference[0m

  [38;5;13mFull Stack Trace[0m
    github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/pods.getStringEventsForPod({0x24d65a0?, 0xc0002e0dd0?}, 0x0)
    	/tmp/cnf-NdBry/cnf-features-deploy/cnf-tests/testsuites/pkg/pods/pods.go:475 +0x45
    github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/vrf.getOverlapIP.func2()
    	/tmp/cnf-NdBry/cnf-features-deploy/cnf-tests/testsuites/pkg/pods/pods.go:489 +0x28
    github.com/onsi/gomega/internal.(*AsyncAssertion).buildDescription(0xc0017f5110?, {0xc00102cae0?, 0xc000740670?, 0xc001954000?})
    	/tmp/cnf-NdBry/cnf-features-deploy/vendor/github.com/onsi/gomega/internal/async_assertion.go:160 +0x44
    github.com/onsi/gomega/internal.(*AsyncAssertion).match.func2()
    	/tmp/cnf-NdBry/cnf-features-deploy/vendor/github.com/onsi/gomega/internal/async_assertion.go:464 +0x599
    github.com/onsi/gomega/internal.(*AsyncAssertion).match.func3({0x2159a66, 0x9})
    	/tmp/cnf-NdBry/cnf-features-deploy/vendor/github.com/onsi/gomega/internal/async_assertion.go:470 +0x94
    github.com/onsi/gomega/internal.(*AsyncAssertion).match(0xc00090cf50, {0x24e3d18?, 0xc00102cac0}, 0x1, {0xc00102cae0, 0x1, 0x1})
    	/tmp/cnf-NdBry/cnf-features-deploy/vendor/github.com/onsi/gomega/internal/async_assertion.go:552 +0xec4
    github.com/onsi/gomega/internal.(*AsyncAssertion).Should(0xc00090cf50, {0x24e3d18, 0xc00102cac0}, {0xc00102cae0, 0x1, 0x1})
    	/tmp/cnf-NdBry/cnf-features-deploy/vendor/github.com/onsi/gomega/internal/async_assertion.go:145 +0x8d
    github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/vrf.getOverlapIP(0xc0002e0dd0, {0x215e966, 0xb}, {0xc0015d7900, 0x6}, {0x216a9a2, 0x11})
    	/tmp/cnf-NdBry/cnf-features-deploy/cnf-tests/testsuites/e2esuite/vrf/vrf.go:123 +0x4be
    github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/vrf.testVRFScenario(0xc0002e0dd0, {0x215e966, 0xb}, {0xc0015d7900, 0x6}, {0xc002710a38, 0x12}, {0xc00213aa08, 0x11}, {0x2152199, ...})
    	/tmp/cnf-NdBry/cnf-features-deploy/cnf-tests/testsuites/e2esuite/vrf/vrf.go:191 +0xc5
    github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/e2esuite/vrf.glob..func1.4.1({0x2152199?, 0x46ccf9?})
    	/tmp/cnf-NdBry/cnf-features-deploy/cnf-tests/testsuites/e2esuite/vrf/vrf.go:80 +0x71
    reflect.Value.call({0x1d4cbc0?, 0xc001f81080?, 0x7fed6d6c3108?}, {0x2151bb9, 0x4}, {0xc00142edf8, 0x1, 0x478dd7?})
    	/usr/local/go/src/reflect/value.go:584 +0x8c5
    reflect.Value.Call({0x1d4cbc0?, 0xc001f81080?, 0x250f608?}, {0xc00142edf8?, 0xc0006ba1d8?, 0x0?})
    	/usr/local/go/src/reflect/value.go:368 +0xbc

  There were [1m[38;5;9madditional failures[0m detected.  To view them in detail run [1mginkgo -vv
```