### PR TITLE
cnf-tests: add git submodule dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ custom-rpms:
 	@echo "Installing rpms"
 	RPMS_SRC="$(RPMS_SRC)" hack/custom_rpms.sh
 
-test-bin:
+test-bin: init-git-submodules
 	@echo "Making test binary"
 	cnf-tests/hack/build-test-bin.sh
 


### PR DESCRIPTION
The Makefile target 'test-bin' needs to have the Git submodules initiated. Here, we add 'init-git-submodule' as a dependency for the 'test-bin' target.