### PR TITLE
cnf-tests: Increase delay in WaitStable

### DIFF
--- a/cnf-tests/testsuites/pkg/networks/sriov.go
+++ b/cnf-tests/testsuites/pkg/networks/sriov.go
@@ -226,7 +226,7 @@ func WaitStable(sriovclient *sriovtestclient.ClientSet) {
 	// then stable. The issue is that if no configuration is applied, then
 	// the status won't never go to not stable and the test will fail.
 	// TODO: find a better way to handle this scenario
-	time.Sleep(5 * time.Second)
+	time.Sleep(15 * time.Second)
 	Eventually(func() bool {
 		res, _ := sriovcluster.SriovStable("openshift-sriov-network-operator", sriovclient)
 		// ignoring the error for the disconnected cluster scenario


### PR DESCRIPTION
When creating SriovNetworkNodePolicy, the delay before seeing an SriovNetworkNodeState going to `InProgress` can be a little longer than 5 seconds. e.g. `[multinetworkpolicy]` test suite showed falky failures in this sense [1]:

```
// sriov-network-operator
2023-10-23T21:04:41.069865775Z	INFO	SriovNetworkNodePolicy	Enqueuing sync for create event	{"resource": "test-policy-d2q2g"}
...
2023-10-23T21:04:42.080418658Z	INFO	syncAllSriovNetworkNodeStates	Sync SriovNetworkNodeState CR	{"name": "cnfdu3"}

// cnfdu3 sriov-config-daemon
I1023 21:04:42.113860  148878 daemon.go:536] nodeStateSyncHandler(): calling OnNodeStateChange for an updated node state
...
I1023 21:04:46.605306  148878 writer.go:170] setNodeStateStatus(): syncStatus: InProgress, lastSyncError:
```

[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-telco5g-cnftests/1716523123970412544