### PR TITLE
ztp: CNF-10131 remove deprecated grafana field from reduce footprint CR

### DIFF
--- a/ztp/source-crs/ReduceMonitoringFootprint.yaml
+++ b/ztp/source-crs/ReduceMonitoringFootprint.yaml
@@ -7,8 +7,6 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "1"
 data:
   config.yaml: |
-    grafana:
-      enabled: false
     alertmanagerMain:
       enabled: false
     telemeterClient:


### PR DESCRIPTION
- Grafana field is deprecated since version 4.11
- This change must be backported till 4.11

/assign @imiller0 @serngawy 