### PR TITLE
cnf-tests: Increase `ginkgo.timeout`

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -6,7 +6,7 @@ set -e
 export PATH=$PATH:$GOPATH/bin
 export failed=false
 export failures=()
-export GINKGO_PARAMS=${GINKGO_PARAMS:-'-vv --show-node-events'}
+export GINKGO_PARAMS=${GINKGO_PARAMS:-'-vv --show-node-events -timeout 6h'}
 
 #env variables needed for the containerized version
 export TEST_POD_IMAGES_REGISTRY="${TEST_POD_IMAGES_REGISTRY:-quay.io/openshift-kni/}"


### PR DESCRIPTION
Ginkgo V2 decreased the default suite timeout from `24h` to `1h`. This commit sets the default value to 6h, as cnf-tests suite is likely to run for more than 1h.

https://onsi.github.io/ginkgo/MIGRATING_TO_V2#timeout-behavior

cc @evgenLevin, @gregkopels 