### PR TITLE
Fix cnf-tests container build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,9 @@ custom-rpms:
 	@echo "Installing rpms"
 	RPMS_SRC="$(RPMS_SRC)" hack/custom_rpms.sh
 
-test-bin: init-git-submodules
+test-bin:
 	@echo "Making test binary"
+	git submodule update --init --force
 	cnf-tests/hack/build-test-bin.sh
 
 cnf-tests-local:


### PR DESCRIPTION
Currently, the "test-bin" target invokes the "init-git-submodules".
This is, in his turn, invoke "fetch -all" which creates connection
to the public github repo. However, in Red Hat's mid-stream container
image builder, we are creating the image in a disconnected environment.

So here we remove the call to the "init-git-submodules" target,
and instead only invoke "git submodule update --init --force".
Also because we only care about the latest commit of the NTO.
