### PR TITLE
ztp: OCPBUGS-21740: fix sync-time-once / chronyd contention

### DIFF
--- a/ztp/extra-manifests-builder/99-sync-time-once/build.sh
+++ b/ztp/extra-manifests-builder/99-sync-time-once/build.sh
@@ -23,6 +23,7 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=${SYNC_ATTEMPT_TIMEOUT_SEC}
+            ExecCondition=/bin/bash -c 'sleep 30 && systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]

--- a/ztp/source-crs/extra-manifest/99-sync-time-once-master.yaml
+++ b/ztp/source-crs/extra-manifest/99-sync-time-once-master.yaml
@@ -19,6 +19,7 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=300
+            ExecCondition=/bin/bash -c 'sleep 30 && systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]

--- a/ztp/source-crs/extra-manifest/99-sync-time-once-worker.yaml
+++ b/ztp/source-crs/extra-manifest/99-sync-time-once-worker.yaml
@@ -19,6 +19,7 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=300
+            ExecCondition=/bin/bash -c 'sleep 30 && systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]


### PR DESCRIPTION
This PR fixes a contention between chronyd sync-time-once services on boot. The latter service is needed for systems with PTP enabled, so it should only run on hosts with chronyd.service disabled. This fix adds an execution condition for sync-time-once, so it will only start when chronyd is disabled.

/cc @lack @sabbir-47 @imiller0 