### PR TITLE
ztp: remove chrony sync ExecCondition sleep

### DIFF
--- a/ztp/extra-manifests-builder/99-sync-time-once/build.sh
+++ b/ztp/extra-manifests-builder/99-sync-time-once/build.sh
@@ -23,7 +23,7 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=${SYNC_ATTEMPT_TIMEOUT_SEC}
-            ExecCondition=/bin/bash -c 'sleep 30 && systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
+            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]

--- a/ztp/source-crs/extra-manifest/99-sync-time-once-master.yaml
+++ b/ztp/source-crs/extra-manifest/99-sync-time-once-master.yaml
@@ -19,7 +19,7 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=300
-            ExecCondition=/bin/bash -c 'sleep 30 && systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
+            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]

--- a/ztp/source-crs/extra-manifest/99-sync-time-once-worker.yaml
+++ b/ztp/source-crs/extra-manifest/99-sync-time-once-worker.yaml
@@ -19,7 +19,7 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=300
-            ExecCondition=/bin/bash -c 'sleep 30 && systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
+            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]


### PR DESCRIPTION
The `sleep 30` in ExecCondition was left by mistake