### PR TITLE
Add .snyk file for static code analysis

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+exclude:
+  global:
+    - vendor/github.com/onsi/ginkgo/v2/internal/suite.go:
+      reason: Temporarily ignoring until a fix is ready.
+      expires: 2024-03-01
+      created: 2024-01-01
+    - vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go:
+      reason: Ignoring as the issue in the code is expected.
+      created: 2024-01-01


### PR DESCRIPTION
Add a '.snyk' file to exclude the vendor directory for
the snyk code analysis.
