### PR TITLE
ztp: Cleanup hub templating to better match non templated examples

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-3node-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-3node-ranGen-templated.yaml
@@ -12,7 +12,7 @@ policyDefaults:
   # categories: []
   # controls:
   #   - PR.DS-1 Data-at-rest
-  namespace: ztp-site
+  namespace: ztp-group
   # Use an existing placement rule so that placement bindings can be consolidated
   placement:
     labelSelector:

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
@@ -12,7 +12,7 @@ policyDefaults:
   #categories: []
   #controls:
   #  - PR.DS-1 Data-at-rest
-  namespace: ztp-site
+  namespace: ztp-group
   # Use an existing placement rule so that placement bindings can be consolidated.
   placement:
     labelSelector:
@@ -232,30 +232,30 @@ policies:
             profile: performance-patch
     - path: source-crs/optional-extra-manifest/enable-crun-master.yaml
     - path: source-crs/optional-extra-manifest/enable-crun-worker.yaml
-    - path: source-crs/AmqInstance.yaml
-    - path: source-crs/HardwareEvent.yaml
-      patches:
-      - spec:
-          nodeSelector: {}
-          transportHost: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-hwevent-transportHost" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
-          logLevel: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-hwevent-logLevel" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
-    - path: source-crs/StorageClass.yaml
-      patches:
-      - metadata:
-          name: image-registry-sc # FIXED
-    - path: source-crs/StoragePVC.yaml # wave 10
-      patches:
-      - metadata:
-          name: image-registry-pvc # FIXED
-          namespace: openshift-image-registry
-        spec:
-          accessModes:
-            - ReadWriteMany
-          resources:
-            requests:
-              storage: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-storagepvc-storage" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
-          storageClassName: image-registry-sc # FIXED
-          volumeMode: Filesystem # FIXED
+#    - path: source-crs/AmqInstance.yaml
+#    - path: source-crs/HardwareEvent.yaml
+#      patches:
+#      - spec:
+#          nodeSelector: {}
+#          transportHost: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-hwevent-transportHost" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
+#          logLevel: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-hwevent-logLevel" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
+#    - path: source-crs/StorageClass.yaml
+#      patches:
+#      - metadata:
+#          name: image-registry-sc # FIXED
+#    - path: source-crs/StoragePVC.yaml # wave 10
+#      patches:
+#      - metadata:
+#          name: image-registry-pvc # FIXED
+#          namespace: openshift-image-registry
+#        spec:
+#          accessModes:
+#            - ReadWriteMany
+#          resources:
+#            requests:
+#              storage: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-storagepvc-storage" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
+#          storageClassName: image-registry-sc # FIXED
+#          volumeMode: Filesystem # FIXED
 #    - path: source-crs/ImageRegistryPV.yaml
 #    - path: source-crs/ImageRegistryConfig.yaml
 #      patches:

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-standard-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-standard-ranGen-templated.yaml
@@ -12,7 +12,7 @@ policyDefaults:
   #categories: []
   #controls:
   #  - PR.DS-1 Data-at-rest
-  namespace: ztp-site
+  namespace: ztp-group
   # Use an existing placement rule so that placement bindings can be consolidated
   placement:
     labelSelector:

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/kustomization.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/kustomization.yaml
@@ -3,29 +3,29 @@ generators:
 - acm-common-ranGen.yaml
 # This group policy is for all single-node deployments. Use just one of the 2 below.
 - acm-group-du-sno-ranGen.yaml
-- hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
+#- hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
 # This group validator policy is for all single-node deployments:
 - acm-group-du-sno-validator-ranGen.yaml
 # This group policy is for all compressed 3-node cluster deployments. Use just one of the 2 below.
 - acm-group-du-3node-ranGen.yaml
-- hub-side-templating/acm-group-du-3node-ranGen-templated.yaml
+#- hub-side-templating/acm-group-du-3node-ranGen-templated.yaml
 # This group validator policy is for all compressed 3-node cluster deployments:
 - acm-group-du-3node-validator-ranGen.yaml
 # This group policy is for all standard cluster deployments. Use just one of the 2 below.
 - acm-group-du-standard-ranGen.yaml
-- hub-side-templating/acm-group-du-standard-ranGen-templated.yaml
+#- hub-side-templating/acm-group-du-standard-ranGen-templated.yaml
 # This group validator policy is for all standard cluster deployments:
 - acm-group-du-standard-validator-ranGen.yaml
 # These are examples that should be replicated for every individual site. Use just one for each cluster configuration.
 - acm-example-sno-site.yaml
-- hub-side-templating/acm-example-sno-site-templated.yaml
+#- hub-side-templating/acm-example-sno-site-templated.yaml
 - acm-example-multinode-site.yaml
-- hub-side-templating/acm-example-multinode-site-templated.yaml
+#- hub-side-templating/acm-example-multinode-site-templated.yaml
 
 resources:
 - ns.yaml
 # The resources from below are only needed if policies from hub-side-templating are used.
-- hub-side-templating/site-du-sno-configmap.yaml
-- hub-side-templating/site-du-3nc-configmap.yaml
-- hub-side-templating/site-du-standard-configmap.yaml
-- hub-side-templating/site-du-multinode-configmap.yaml
+#- hub-side-templating/site-du-sno-configmap.yaml
+#- hub-side-templating/site-du-3nc-configmap.yaml
+#- hub-side-templating/site-du-standard-configmap.yaml
+#- hub-side-templating/site-du-multinode-configmap.yaml

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-3node-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-3node-ranGen-templated.yaml
@@ -7,7 +7,7 @@ apiVersion: ran.openshift.io/v1
 kind: PolicyGenTemplate
 metadata:
   name: group-du-3nc-pgt
-  namespace: ztp-site
+  namespace: ztp-group
 spec:
   bindingRules:
     # These policies will correspond to all clusters with this label:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
@@ -8,7 +8,7 @@ kind: PolicyGenTemplate
 metadata:
   # The name will be used to generate the placementBinding and placementRule names as {name}-placementBinding and {name}-placementRule
   name: group-du-sno-pgt
-  namespace: ztp-site
+  namespace: ztp-group
 spec:
   bindingRules:
     # These policies will correspond to all clusters with these labels
@@ -107,38 +107,38 @@ spec:
     - fileName: optional-extra-manifest/enable-crun-worker.yaml
       policyName: "gr-du-sno-cfg-pc-templated"
     ###
-    # AmqInstance is required if PTP and BMER operators use AMQP transport
-    - fileName: AmqInstance.yaml # wave 100 - updated below to 10
-      policyName: "gr-du-sno-cfg-pc-templated"
-      metadata:
-        annotations:
-          ran.openshift.io/ztp-deploy-wave: "10"
-    ###
-    - fileName: HardwareEvent.yaml # wave 10
-      policyName: "gr-du-sno-cfg-pc-templated"
-      spec:
-        nodeSelector: {}
-        transportHost: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-hwevent-transportHost" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
-        logLevel: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-hwevent-logLevel" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
-    ###
-    # ---- START OF source CRs needed for image registry (check ImageRegistry.md for more details) ----
-    - fileName: StorageClass.yaml # wave 10
-      policyName: "gr-du-sno-cfg-pc-templated"
-      metadata:
-        name: image-registry-sc # FIXED
-    - fileName: StoragePVC.yaml # wave 10
-      policyName: "gr-du-sno-cfg-pc-templated"
-      metadata:
-        name: image-registry-pvc # FIXED
-        namespace: openshift-image-registry
-      spec:
-        accessModes:
-          - ReadWriteMany
-        resources:
-          requests:
-            storage: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-storagepvc-storage" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
-        storageClassName: image-registry-sc # FIXED
-        volumeMode: Filesystem # FIXED
+#    # AmqInstance is required if PTP and BMER operators use AMQP transport
+#    - fileName: AmqInstance.yaml # wave 100 - updated below to 10
+#      policyName: "gr-du-sno-cfg-pc-templated"
+#      metadata:
+#        annotations:
+#          ran.openshift.io/ztp-deploy-wave: "10"
+#   ###
+#    - fileName: HardwareEvent.yaml # wave 10
+#      policyName: "gr-du-sno-cfg-pc-templated"
+#      spec:
+#        nodeSelector: {}
+#        transportHost: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-hwevent-transportHost" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
+#        logLevel: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-hwevent-logLevel" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
+#    ###
+#    # ---- START OF source CRs needed for image registry (check ImageRegistry.md for more details) ----
+#    - fileName: StorageClass.yaml # wave 10
+#      policyName: "gr-du-sno-cfg-pc-templated"
+#      metadata:
+#        name: image-registry-sc # FIXED
+#    - fileName: StoragePVC.yaml # wave 10
+#      policyName: "gr-du-sno-cfg-pc-templated"
+#      metadata:
+#        name: image-registry-pvc # FIXED
+#        namespace: openshift-image-registry
+#      spec:
+#        accessModes:
+#          - ReadWriteMany
+#        resources:
+#          requests:
+#            storage: '{{hub fromConfigMap "" (printf "site-%s-configmap" .ManagedClusterName) (printf "%s-storagepvc-storage" (index .ManagedClusterLabels "group-du-sno-zone")) hub}}'
+#        storageClassName: image-registry-sc # FIXED
+#        volumeMode: Filesystem # FIXED
 #    #############
 #    # pv-policy #
 #    #############

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-standard-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-standard-ranGen-templated.yaml
@@ -7,7 +7,7 @@ apiVersion: ran.openshift.io/v1
 kind: PolicyGenTemplate
 metadata:
   name: group-du-standard-pgt
-  namespace: ztp-site
+  namespace: ztp-group
 spec:
   bindingRules:
     # These policies will correspond to all clusters with the labels below.

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/kustomization.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/kustomization.yaml
@@ -3,32 +3,32 @@ generators:
 - common-ranGen.yaml
 # This group policy is for all single-node deployments. Use just one of the 2 below.
 - group-du-sno-ranGen.yaml
-- hub-side-templating/group-du-sno-ranGen-templated.yaml
+#- hub-side-templating/group-du-sno-ranGen-templated.yaml
 # This group validator policy is for all single-node deployments.
 - group-du-sno-validator-ranGen.yaml
 # This group policy is for all compressed 3-node cluster deployments. Use just one of the 2 below.
 - group-du-3node-ranGen.yaml
-- hub-side-templating/group-du-3node-ranGen-templated.yaml
+#- hub-side-templating/group-du-3node-ranGen-templated.yaml
 # This group validator policy is for all compressed 3-node cluster deployments:
 - group-du-3node-validator-ranGen.yaml
 # This group policy is for all standard cluster deployments. Use just one of the 2 below.
 - group-du-standard-ranGen.yaml
-- hub-side-templating/group-du-standard-ranGen-templated.yaml
+#- hub-side-templating/group-du-standard-ranGen-templated.yaml
 # This group validator policy is for all standard cluster deployments:
 - group-du-standard-validator-ranGen.yaml
 # These are examples that should be replicated for every individual site. Use just one for each cluster configuration.
 - example-sno-site.yaml
-- hub-side-templating/example-sno-site-templated.yaml
+#- hub-side-templating/example-sno-site-templated.yaml
 - example-multinode-site.yaml
-- hub-side-templating/example-multinode-site-templated.yaml
+#- hub-side-templating/example-multinode-site-templated.yaml
 
 resources:
 - ns.yaml
 # The resources from below are only needed if policies from hub-side-templating are used.
-- hub-side-templating/site-du-sno-configmap.yaml
-- hub-side-templating/site-du-3nc-configmap.yaml
-- hub-side-templating/site-du-standard-configmap.yaml
-- hub-side-templating/site-du-multinode-configmap.yaml
+#- hub-side-templating/site-du-sno-configmap.yaml
+#- hub-side-templating/site-du-3nc-configmap.yaml
+#- hub-side-templating/site-du-standard-configmap.yaml
+#- hub-side-templating/site-du-multinode-configmap.yaml
 
 
 # Updates to the PerformanceProfile or MachineConfigurations may take a short period of time before 


### PR DESCRIPTION
- Create all the group policies in the ztp-group namespace
- Comment out all the source files that are also commented out in the non templated PG(T)s
- Comment out templated policies from the kustomization file, but leave comments about using either the templated or the non templated policies. This makes the examples usable as is without further action needed by users. If the hub templated policies are desired, they should be uncommented and the non templated policies should be commented out to avoid overlaps.