### PR TITLE
cnf-test: Fix `ncat` timeout error message

### DIFF
--- a/cnf-tests/testsuites/e2esuite/multinetworkpolicy/reachmatcher.go
+++ b/cnf-tests/testsuites/e2esuite/multinetworkpolicy/reachmatcher.go
@@ -255,14 +255,21 @@ func canSendTraffic(sourcePod, destinationPod *corev1.Pod, destinationPort strin
 }
 
 func doesErrorMeanNoConnectivity(commandOutput string, protocol corev1.Protocol) bool {
+	// Since v7.92, ncat timeout error message has changed.
+	// See https://github.com/nmap/nmap/commit/4824a5a0742a77f92c43eb5c9d9c420d56dbadcc
+	const NCAT_v7_70_TIMEOUT string = "Ncat: Connection timed out"
+	const NCAT_v7_92_TIMEOUT string = "Ncat: TIMEOUT"
+
 	switch protocol {
 	case corev1.ProtocolTCP:
-		if strings.Contains(commandOutput, "Ncat: Connection timed out") {
+		if strings.Contains(commandOutput, NCAT_v7_70_TIMEOUT) ||
+			strings.Contains(commandOutput, NCAT_v7_92_TIMEOUT) {
 			// Timeout error is symptom of no connection
 			return true
 		}
 	case corev1.ProtocolSCTP:
-		if strings.Contains(commandOutput, "Ncat: Connection timed out") {
+		if strings.Contains(commandOutput, NCAT_v7_70_TIMEOUT) ||
+			strings.Contains(commandOutput, NCAT_v7_92_TIMEOUT) {
 			// Timeout error is symptom of no connection
 			return true
 		}


### PR DESCRIPTION
Since v7.92, ncat timeout error message has changed from
```
Ncat: Connection timed out
```
to
```
Ncat: TIMEOUT
```
See
https://github.com/nmap/nmap/commit/4824a5a0742a77f92c43eb5c9d9c420d56dbadcc

This commit makes the ReachMatcher, used by the
`[multinetworkpolicy]` suite, able to work with both version of ncat.

This problem first appeared in `v4.12.7-2`:

```
docker run registry-proxy.engineering.redhat.com/rh-osbs/openshift4-cnf-tests:v4.12.7-1 ncat -version -w 1 192.168.2.2 
Ncat: Version 7.70 ( https://nmap.org/ncat )
Ncat: Connection timed out.

docker run registry-proxy.engineering.redhat.com/rh-osbs/openshift4-cnf-tests:v4.12.7-2 ncat -version -w 1 192.168.2.2
Ncat: Version 7.92 ( https://nmap.org/ncat )
Ncat: TIMEOUT.
```

See brew builds [cnf-tests-container/v4.12.7/1/data/logs/x86_64.log](https://download.eng.bos.redhat.com/brewroot/packages/cnf-tests-container/v4.12.7/1/data/logs/x86_64.log) and [cnf-tests-container/v4.12.7/2/data/logs/x86_64.log
](https://download.eng.bos.redhat.com/brewroot/packages/cnf-tests-container/v4.12.7/2/data/logs/x86_64.log
)

cc @evgenLevin 
