### PR TITLE
OCPBUGS-24242: [4.12] Modify deprecated `go get` to `go install`

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -28,9 +28,9 @@ RUN mkdir ~/bin && \
     eval "$(gimme $GOVERSION)" && \
     cat $GIMME_ENV >> $HOME/.bashrc && \
     # get required golang tools and OC client
-    go get github.com/onsi/ginkgo/ginkgo@v1.16.5 && \
-    go get github.com/onsi/gomega/...@v1.17.0 && \
-    go get -u golang.org/x/lint/golint && \
+    go install github.com/onsi/ginkgo/ginkgo@v1.16.5 && \
+    go install github.com/onsi/gomega/...@v1.17.0 && \
+    go install golang.org/x/lint/golint@v0.0.0-20210508222113-6edffad5e616 && \
     go install github.com/lack/mcmaker@v0.0.5 && \
     export latest_oc_client_version=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ 2>/dev/null | grep -o \"openshift-client-linux-4.*tar.gz\" | tr -d \") && \
     curl -JL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${latest_oc_client_version} -o oc.tar.gz && \


### PR DESCRIPTION
In the context of upgrading cnf-tests from Go 1.17 to 1.19: Modify the `Dockerfile.tools` to use the `go install` command instead of the deprecated `go get` that can not longer be used to build packages see more details here: https://go.dev/doc/go-get-install-deprecation