### PR TITLE
ztp: remove marketplace oeprator

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
@@ -60,8 +60,6 @@ spec:
     #
     # These CRs are in support of installation from a disconnected registry
     #
-    - fileName: OperatorHub.yaml
-      policyName: "config-policy"
     - fileName: DefaultCatsrc.yaml
       policyName: "config-policy"
       # The Subscriptions all point to redhat-operators-disconnected. The OperatorHub CR

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -22,7 +22,7 @@ spec:
     # Notes:
     # - OperatorLifecycleManager is needed for 4.15 and later
     # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
-    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"OperatorLifecycleManager\", \"marketplace\", \"NodeTuning\" ] }}"
+    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"OperatorLifecycleManager\", \"NodeTuning\" ] }}"
     # It is strongly recommended to include crun manifests as part of the additional install-time manifests for 4.13+.
     # The crun manifests can be obtained from source-crs/optional-extra-manifest/ and added to the git repo ie.sno-extra-manifest.
     # extraManifestPath: sno-extra-manifest


### PR DESCRIPTION
The marketplace operator is not needed if one is managing their own catalog sources and do not need the default Redhat catalog sources (certified-operators, community-operators, redhat-marketplace, redhat-operators)

If we are to remove the marketplace operator using the "capabilities" field in siteConfig, we also have to remove disabling all the default catalag sources through the OperatorHub CR as that CR will not be present because it is installed by the marketplace operator