### PR TITLE
cnf-tests: Remove NTO's 4_latency test suite

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -39,8 +39,7 @@ declare -A TESTS_PATHS=\
  ["cnftests integration"]="cnf-tests/testsuites/e2esuite"\
  ["cnftests metallb"]="cnf-tests/submodules/metallb-operator/test/e2e/functional"\
  ["cnftests sriov"]="cnf-tests/submodules/sriov-network-operator/test/conformance"\
- ["cnftests nto-performance"]="cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance"\
- ["cnftests nto-latency"]="cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/4_latency")
+ ["cnftests nto-performance"]="cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance")
 export TESTS_PATHS
 
 get_current_commit() {


### PR DESCRIPTION
Remove the NTO's 4_latency test suite from the `TESTS_PATHS` variable, to prevent the functests from running this test suite.

We need that because we want to remove the "LATENCY_TEST_RUN" variable, which always skipped this suite during the conformance tests.

For clarity - the "LATENCY_TEST_RUN" was necessary when we compiled all of the suites together in the cnf-tests container image, but now it's redundant.