### PR TITLE
ztp: Make PG examples more general consistent

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-ranGen.yaml
@@ -227,8 +227,8 @@ policies:
       - spec:
           cpu:
             # These must be tailored for the specific hardware platform
-            isolated: "2-19,22-39"
-            reserved: "0-1,20-21"
+            isolated: "2-31,34-63"
+            reserved: "0-1,52-53"
           hugepages:
             defaultHugepagesSize: 1G
             pages:
@@ -285,7 +285,7 @@ policies:
 #              files:
 #                - contents:
                    # crio cpuset config goes below. This value needs to updated and matched PerformanceProfile. Check the link for more info on the content.
-#                    source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSwyLTMiIH0=
+#                    source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSw1Mi01MyIgfQo=
 #                  mode: 420
 #                  overwrite: true
 #                  path: /etc/crio/crio.conf.d/01-workload-partitioning

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-3node-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-3node-ranGen-templated.yaml
@@ -1,6 +1,6 @@
 # For this PGT, we've considered a 3 node managed cluster with the following labels:
 #   group-du-3nc-zone: zone-1
-#   hardware-type: dell-poweredge-xr12
+#   hardware-type: hw-type-platform-1
 # ConfigMaps used:
 #   group-hardware-types-configmap.yaml: group-hardware-types-configmap
 apiVersion: policy.open-cluster-management.io/v1
@@ -18,7 +18,7 @@ policyDefaults:
   placement:
     labelSelector:
       group-du-3nc-zone: "zone-1"
-      hardware-type: "dell-poweredge-xr12"
+      hardware-type: "hw-type-platform-1"
   remediationAction: inform
   severity: low
   # standards: []

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
@@ -1,6 +1,6 @@
 # For this PGT, we've considered an SNO managed cluster with the following labels:
 #   group-du-sno-zone: zone-1 
-#   hardware-type: dell-poweredge-xr12
+#   hardware-type: hw-type-platform-1
 # ConfigMaps used:
 #   group-hardware-types-configmap.yaml: group-hardware-types-configmap
 #   group-zones-configmap.yaml:          group-zones-configmap
@@ -20,7 +20,7 @@ policyDefaults:
   placement:
     labelSelector:
       group-du-sno-zone: "zone-1"
-      hardware-type: "dell-poweredge-xr12"
+      hardware-type: "hw-type-platform-1"
   remediationAction: inform
   severity: low
   # standards: []

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-standard-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-standard-ranGen-templated.yaml
@@ -1,6 +1,6 @@
 # For this PolicyGenerator, we've considered a standard managed cluster with the following labels:
 #   group-du-standard-zone: zone-1
-#   hardware-type: dell-poweredge-xr12
+#   hardware-type: hw-type-platform-1
 # ConfigMaps used:
 #   group-hardware-types-configmap.yaml: group-hardware-types-configmap
 apiVersion: policy.open-cluster-management.io/v1
@@ -18,7 +18,7 @@ policyDefaults:
   placement:
     labelSelector:
       group-du-standard-zone: "zone-1"
-      hardware-type: "dell-poweredge-xr12"
+      hardware-type: "hw-type-platform-1"
   remediationAction: inform
   severity: low
   # standards: []

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/configMaps/group-hardware-types-configmap.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/configMaps/group-hardware-types-configmap.yaml
@@ -6,23 +6,23 @@ metadata:
   namespace: ztp-group
 data:
   # SriovFecClusterConfig.yaml
-  dell-poweredge-xr12-sriov-fec-pfDriver: "pci-pf-stub"
-  dell-poweredge-xr12-fec-vfDriver: "vfio-pci"
-  dell-poweredge-xr12-fec-pciAddress: 0000:51:00.0
+  hw-type-platform-1-sriov-fec-pfDriver: "pci-pf-stub"
+  hw-type-platform-1-fec-vfDriver: "vfio-pci"
+  hw-type-platform-1-fec-pciAddress: 0000:51:00.0
   # SriovNetworkNodePolicy.yaml - general
-  dell-poweredge-xr12-sriov-node-policy-pfNames-1: "[\"ens5f0\"]"
-  dell-poweredge-xr12-sriov-node-policy-pfNames-2: "[\"ens7f0\"]"
+  hw-type-platform-1-sriov-node-policy-pfNames-1: "[\"ens5f0\"]"
+  hw-type-platform-1-sriov-node-policy-pfNames-2: "[\"ens7f0\"]"
   # PerformanceProfile.yaml
-  dell-poweredge-xr12-cpu-isolated: "2-31,34-63"
-  dell-poweredge-xr12-cpu-reserved: "0-1,32-33"
-  dell-poweredge-xr12-hugepages-default: "1G"
-  dell-poweredge-xr12-hugepages-size: "1G"
-  dell-poweredge-xr12-hugepages-count: "32"
+  hw-type-platform-1-cpu-isolated: "2-31,34-63"
+  hw-type-platform-1-cpu-reserved: "0-1,52-53"
+  hw-type-platform-1-hugepages-default: "1G"
+  hw-type-platform-1-hugepages-size: "1G"
+  hw-type-platform-1-hugepages-count: "32"
   # PtpConfigSlave.yaml
-  dell-poweredge-xr12-ptpcfgslave-profile-interface: "ens5f0"
+  hw-type-platform-1-ptpcfgslave-profile-interface: "ens5f0"
   # StorageLV.yaml
-  dell-poweredge-xr12-storagelv-devicepaths-1: "[\"/dev/disk/by-path/pci-0000:05:00.0-nvme-1\", \"pci-0000:18:00.0-scsi-0:1:0:0\"]"
-  dell-poweredge-xr12-storagelv-devicepaths-2: "[\"/dev/disk/by-path/pci-0001:05:00.0-nvme-1\", \"pci-0000:18:00.0-scsi-0:2:0:0\"]"
+  hw-type-platform-1-storagelv-devicepaths-1: "[\"/dev/disk/by-path/pci-0000:05:00.0-nvme-1\", \"pci-0000:18:00.0-scsi-0:1:0:0\"]"
+  hw-type-platform-1-storagelv-devicepaths-2: "[\"/dev/disk/by-path/pci-0001:05:00.0-nvme-1\", \"pci-0000:18:00.0-scsi-0:2:0:0\"]"
   # MachineConfigGeneric.yaml
-  dell-poweredge-xr12-machine-config-storage-source-1: "data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSwyLTMiIH0="
-  dell-poweredge-xr12-machine-config-storage-source-2: "data:text/plain;charset=utf-8;base64,ewogICJtYW5hZ2VtZW50IjogewogICAgImNwdXNldCI6ICIwLTEsNTItNTMiCiAgfQp9Cg=="
+  hw-type-platform-1-machine-config-storage-source-1: "data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSw1Mi01MyIgfQo="
+  hw-type-platform-1-machine-config-storage-source-2: "data:text/plain;charset=utf-8;base64,ewogICJtYW5hZ2VtZW50IjogewogICAgImNwdXNldCI6ICIwLTEsNTItNTMiCiAgfQp9Cg=="

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-sno-ranGen.yaml
@@ -95,8 +95,8 @@ spec:
       spec:
         cpu:
           # These must be tailored for the specific hardware platform
-          isolated: "2-19,22-39"
-          reserved: "0-1,20-21"
+          isolated: "2-31,34-63"
+          reserved: "0-1,52-53"
         hugepages:
           defaultHugepagesSize: 1G
           pages:
@@ -169,7 +169,7 @@ spec:
 #            files:
 #              - contents:
 #                  # crio cpuset config goes below. This value needs to updated and matched PerformanceProfile. Check the link for more info on the content.
-#                  source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSwyLTMiIH0=
+#                  source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSw1Mi01MyIgfQo=
 #                mode: 420
 #                overwrite: true
 #                path: /etc/crio/crio.conf.d/01-workload-partitioning

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/configMaps/group-hardware-types-configmap.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/configMaps/group-hardware-types-configmap.yaml
@@ -6,23 +6,23 @@ metadata:
   namespace: ztp-group
 data:
   # SriovFecClusterConfig.yaml
-  dell-poweredge-xr12-sriov-fec-pfDriver: "pci-pf-stub"
-  dell-poweredge-xr12-fec-vfDriver: "vfio-pci"
-  dell-poweredge-xr12-fec-pciAddress: 0000:51:00.0
+  hw-type-platform-1-sriov-fec-pfDriver: "pci-pf-stub"
+  hw-type-platform-1-fec-vfDriver: "vfio-pci"
+  hw-type-platform-1-fec-pciAddress: 0000:51:00.0
   # SriovNetworkNodePolicy.yaml - general
-  dell-poweredge-xr12-sriov-node-policy-pfNames-1: "[\"ens5f0\"]"
-  dell-poweredge-xr12-sriov-node-policy-pfNames-2: "[\"ens7f0\"]"
+  hw-type-platform-1-sriov-node-policy-pfNames-1: "[\"ens5f0\"]"
+  hw-type-platform-1-sriov-node-policy-pfNames-2: "[\"ens7f0\"]"
   # PerformanceProfile.yaml
-  dell-poweredge-xr12-cpu-isolated: "2-31,34-63"
-  dell-poweredge-xr12-cpu-reserved: "0-1,32-33"
-  dell-poweredge-xr12-hugepages-default: "1G"
-  dell-poweredge-xr12-hugepages-size: "1G"
-  dell-poweredge-xr12-hugepages-count: "32"
+  hw-type-platform-1-cpu-isolated: "2-31,34-63"
+  hw-type-platform-1-cpu-reserved: "0-1,52-53"
+  hw-type-platform-1-hugepages-default: "1G"
+  hw-type-platform-1-hugepages-size: "1G"
+  hw-type-platform-1-hugepages-count: "32"
   # PtpConfigSlave.yaml
-  dell-poweredge-xr12-ptpcfgslave-profile-interface: "ens5f0"
+  hw-type-platform-1-ptpcfgslave-profile-interface: "ens5f0"
   # StorageLV.yaml
-  dell-poweredge-xr12-storagelv-devicepaths-1: "[\"/dev/disk/by-path/pci-0000:05:00.0-nvme-1\", \"pci-0000:18:00.0-scsi-0:1:0:0\"]"
-  dell-poweredge-xr12-storagelv-devicepaths-2: "[\"/dev/disk/by-path/pci-0001:05:00.0-nvme-1\", \"pci-0000:18:00.0-scsi-0:2:0:0\"]"
+  hw-type-platform-1-storagelv-devicepaths-1: "[\"/dev/disk/by-path/pci-0000:05:00.0-nvme-1\", \"pci-0000:18:00.0-scsi-0:1:0:0\"]"
+  hw-type-platform-1-storagelv-devicepaths-2: "[\"/dev/disk/by-path/pci-0001:05:00.0-nvme-1\", \"pci-0000:18:00.0-scsi-0:2:0:0\"]"
   # MachineConfigGeneric.yaml
-  dell-poweredge-xr12-machine-config-storage-source-1: "data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSwyLTMiIH0="
-  dell-poweredge-xr12-machine-config-storage-source-2: "data:text/plain;charset=utf-8;base64,ewogICJtYW5hZ2VtZW50IjogewogICAgImNwdXNldCI6ICIwLTEsNTItNTMiCiAgfQp9Cg=="
+  hw-type-platform-1-machine-config-storage-source-1: "data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSw1Mi01MyIgfQo="
+  hw-type-platform-1-machine-config-storage-source-2: "data:text/plain;charset=utf-8;base64,ewogICJtYW5hZ2VtZW50IjogewogICAgImNwdXNldCI6ICIwLTEsNTItNTMiCiAgfQp9Cg=="

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-3node-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-3node-ranGen-templated.yaml
@@ -1,6 +1,6 @@
 # For this PGT, we've considered a 3 node managed cluster with the following labels:
 #   group-du-3nc-zone: zone-1
-#   hardware-type: dell-poweredge-xr12
+#   hardware-type: hw-type-platform-1
 # ConfigMaps used:
 #   group-hardware-types-configmap.yaml: group-hardware-types-configmap
 ---
@@ -13,7 +13,7 @@ spec:
   bindingRules:
     # These policies will correspond to all clusters with this label:
     group-du-3nc-zone: "zone-1"
-    hardware-type: "dell-poweredge-xr12"
+    hardware-type: "hw-type-platform-1"
   # Because 3-node clusters are both workers and masters, and the MCP pool for master binds more strongly than that for worker,
   # the Performance Profile needs to be set up to apply to the master MCP:
   mcp: "master"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
@@ -1,6 +1,6 @@
 # For this PGT, we've considered an SNO managed cluster with the following labels:
 #   group-du-sno-zone: zone-1 
-#   hardware-type: dell-poweredge-xr12
+#   hardware-type: hw-type-platform-1
 # ConfigMaps used:
 #   group-hardware-types-configmap.yaml: group-hardware-types-configmap
 #   group-zones-configmap.yaml:          group-zones-configmap
@@ -16,7 +16,7 @@ spec:
   bindingRules:
     # These policies will correspond to all clusters with these labels
     group-du-sno-zone: "zone-1"
-    hardware-type: "dell-poweredge-xr12"
+    hardware-type: "hw-type-platform-1"
   mcp: "master"
   sourceFiles:
     ##############################

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-standard-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-standard-ranGen-templated.yaml
@@ -1,6 +1,6 @@
 # For this PGT, we've considered a standard managed cluster with the following labels:
 #   group-du-standard-zone: zone-1
-#   hardware-type: dell-poweredge-xr12
+#   hardware-type: hw-type-platform-1
 # ConfigMap used
 #   group-hardware-types-configmap.yaml: group-hardware-types-configmap
 ---
@@ -13,7 +13,7 @@ spec:
   bindingRules:
     # These policies will correspond to all clusters with the labels below.
     group-du-standard-zone: "zone-1"
-    hardware-type: "dell-poweredge-xr12"
+    hardware-type: "hw-type-platform-1"
   mcp: "worker"
   sourceFiles:
     ############################


### PR DESCRIPTION
Description:
- make the hardware type platform agnostic
- update the MachineConfig examples to match their own CPU values and those under PerformanceProfile
/cc @imiller0 @serngawy 