### PR TITLE
cnf-tests: Set DISCOVERY_MODE to true by default

### DIFF
--- a/cnf-tests/entrypoint/test-run.sh
+++ b/cnf-tests/entrypoint/test-run.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 LATENCY_TEST_RUN="${LATENCY_TEST_RUN:-true}"
+DISCOVERY_MODE="${DISCOVERY_MODE:-true}"
 
 if [ "$IMAGE_REGISTRY" != "" ] && [[ "$IMAGE_REGISTRY" != */ ]]; then
     export IMAGE_REGISTRY="$IMAGE_REGISTRY/"
 fi
 
 echo running "/usr/bin/latency-e2e.test"
-LATENCY_TEST_RUN="$LATENCY_TEST_RUN" "/usr/bin/latency-e2e.test"
+DISCOVERY_MODE="$DISCOVERY_MODE" LATENCY_TEST_RUN="$LATENCY_TEST_RUN" "/usr/bin/latency-e2e.test"


### PR DESCRIPTION
Modify the 'test-run.sh' script, which serves as the entry point for the latency tests, and set the DISCOVERY_MODE variable to true. This adjustment eliminates the need for users to set it manually. However, users still have the option to override the variable and set it to 'false' if desired.