### PR TITLE
ztp: Add cpuPartitioningMode to site-config-crd

### DIFF
--- a/ztp/ran-crd/site-config-crd.yaml
+++ b/ztp/ran-crd/site-config-crd.yaml
@@ -787,6 +787,19 @@ spec:
                             items:
                               type: string
                             type: array   
+                      cpuPartitioningMode:
+                        type: string
+                        default: None
+                        description: CPUPartitioning determines if a cluster should be setup for
+                          CPU workload partitioning at install time. When this field is set the
+                          cluster will be flagged for CPU Partitioning allowing users to segregate
+                          workloads to specific CPU Sets. This does not make any decisions on
+                          workloads it only configures the nodes to allow CPU Partitioning. The
+                          "AllNodes" value will setup all nodes for CPU Partitioning, the default
+                          is "None".
+                        enum:
+                          - None
+                          - AllNodes
                       diskEncryption:
                         description: Optional disk encryption parameters
                         type: object


### PR DESCRIPTION
Adds `cpuPartitioningMode` description to the siteConfig CRD, allowing users looking to write their siteconfigs to know the supported field name and the possible values that can be specified.