### PR TITLE
infra: Reduce wget verbosity to unhide tests logs in Prow

### DIFF
--- a/hack/setup-build-index-image.sh
+++ b/hack/setup-build-index-image.sh
@@ -51,7 +51,7 @@ spec:
           set -xe
 
           yum install jq git wget -y
-          wget https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/linux-amd64-opm
+          wget -q https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/linux-amd64-opm
           mv linux-amd64-opm opm
           chmod +x ./opm
           set +x


### PR DESCRIPTION
When wget prints Github link there is an AWS key in the output, which make Prow to remove all build logs (because of removing everything that similar to AWS keys).
Make wget non-verbose to hide this info and prevent Prow to delete build logs.