### PR TITLE
cnf-tests: Remove `libhugetlbfs` RPM deps

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -65,7 +65,7 @@ FROM quay.io/openshift/origin-oc-rpms:4.16 AS oc
 FROM centos:7
 
 # python3 is needed for hwlatdetect
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs linuxptp iperf3 python3 nc iptables
+RUN yum install -y lksctp-tools iproute tmux ethtool ping numactl-libs linuxptp iperf3 python3 nc iptables
 
 RUN mkdir -p /usr/local/etc/cnf
 

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -71,7 +71,7 @@ FROM quay.io/openshift/origin-oc-rpms:4.16 AS oc
 FROM openshift/origin-base
 
 # python3 is needed for hwlatdetect
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3 python3 nc iptables
+RUN yum install -y lksctp-tools iproute tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3 python3 nc iptables
 
 RUN mkdir -p /usr/local/etc/cnf
 


### PR DESCRIPTION
RPM packages `libhugetlbfs` and ``libhugetlbfs-utils` are not available in RHEL9. This PR removes them from `cnf-tests/Dockerfile`

From `quay.io/openshift-kni/cnf-tests` [build](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-kni-cnf-features-deploy-master-images/1742642261163773952):

```
[7/7] STEP 3/22: RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3 python3 nc iptables
...
No match for argument: libhugetlbfs-utils
No match for argument: libhugetlbfs
...
Error: Unable to find a match: libhugetlbfs-utils libhugetlbfs
```


refs:
- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/package_manifest/index
- https://github.com/openshift-kni/cnf-features-deploy/pull/1736
- https://github.com/openshift/release/pull/47209

cc @liornoy 
cc @ffromani 