### PR TITLE
Allow to select each node MCP together with roles

### DIFF
--- a/ztp/ran-crd/site-config-crd.yaml
+++ b/ztp/ran-crd/site-config-crd.yaml
@@ -384,6 +384,9 @@ spec:
                               enum:
                                 - master
                                 - worker
+                            machineConfigPool:
+                              description: Select the MachineConfigPool that the node belongs to. For default roles master/worker this field is not needed. This field is useful to set the node into a different MCP than the default ones. In this case, the MCP needs to be created, placing the MCP resource into extra-manifest folder.
+                              type: string
                             cpuset:
                               description: cpuset required by workload partitioning manifest.
                               type: string
@@ -916,6 +919,9 @@ spec:
                               enum:
                                 - master
                                 - worker
+                            machineConfigPool:
+                              description: Select the MachineConfigPool that the node belongs to. For default roles master/worker this field is not needed. This field is useful to set the node into a different MCP than the default ones. In this case, the MCP needs to be created, placing the MCP resource into extra-manifest folder.
+                              type: string
                             cpuset:
                               description: cpuset required by workload partitioning manifest.
                               type: string

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 as builder
 ARG IMAGE_REF
 USER root
 ENV PKG_ROOT=cnf-features-deploy

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 as builder
 ARG IMAGE_REF
 USER root
 ENV PKG_ROOT=cnf-features-deploy

--- a/ztp/siteconfig-generator/siteConfig/clusterCRsV1.go
+++ b/ztp/siteconfig-generator/siteConfig/clusterCRsV1.go
@@ -115,6 +115,7 @@ metadata:
     bmac.agent-install.openshift.io/installer-args: "{{ .Node.InstallerArgs }}"
     bmac.agent-install.openshift.io/ignition-config-overrides: "{{ .Node.IgnitionConfigOverride }}"
     bmac.agent-install.openshift.io/role: "{{ .Node.Role }}"
+    bmac.agent-install.openshift.io/machine-config-pool: "{{ .Node.MachineConfigPool }}"
   labels:
     infraenvs.agent-install.openshift.io: "{{ .Cluster.ClusterName }}"
 spec:

--- a/ztp/siteconfig-generator/siteConfig/clusterCRsV2.go
+++ b/ztp/siteconfig-generator/siteConfig/clusterCRsV2.go
@@ -114,6 +114,7 @@ metadata:
     bmac.agent-install.openshift.io/installer-args: "{{ .Node.InstallerArgs }}"
     bmac.agent-install.openshift.io/ignition-config-overrides: "{{ .Node.IgnitionConfigOverride }}"
     bmac.agent-install.openshift.io/role: "{{ .Node.Role }}"
+    bmac.agent-install.openshift.io/machine-config-pool: "{{ .Node.MachineConfigPool }}"
   labels:
     infraenvs.agent-install.openshift.io: "{{ .Cluster.ClusterName }}"
 spec:

--- a/ztp/siteconfig-generator/siteConfig/siteConfig.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig.go
@@ -440,6 +440,7 @@ type Nodes struct {
 	InstallerArgs          string                 `yaml:"installerArgs"`
 	IgnitionConfigOverride string                 `yaml:"ignitionConfigOverride"`
 	Role                   string                 `yaml:"role"`
+	MachineConfigPool      string                 `yaml:"machineConfigPool"`
 	CrTemplates            map[string]string      `yaml:"crTemplates"`
 	CrAnnotations          CrAnnotations          `yaml:"crAnnotations"`
 	CrSuppression          []string               `yaml:"crSuppression"`

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -284,6 +284,68 @@ spec:
               macAddress: "00:00:00:01:20:70"
 `
 
+const siteConfigStandardClusterExtraRolesTest = `
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "test-standard"
+  namespace: "test-standard"
+spec:
+  baseDomain: "example.com"
+  pullSecretRef:
+    name: "pullSecretName"
+  clusterImageSetNameRef: "openshift-v4.9.0"
+  sshPublicKey: "ssh-rsa "
+  clusters:
+  - clusterName: "cluster1"
+    apiVIP: 10.16.231.2
+    ingressVIP: 10.16.231.3
+    clusterNetwork:
+      - cidr: 10.128.0.0/14
+        hostPrefix: 23
+    machineNetwork:
+      - cidr: 10.16.231.0/24
+    serviceNetwork:
+      - 172.30.0.0/16
+    mergeDefaultMachineConfigs: true
+    nodes:
+      - hostName: "node1"
+        role: "master"
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              macAddress: "00:00:00:01:20:30"
+      - hostName: "node2"
+        role: "master"
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              macAddress: "00:00:00:01:20:40"
+      - hostName: "node3"
+        role: "master"
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              macAddress: "00:00:00:01:20:50"
+      - hostName: "node4"
+        role: "worker"
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              macAddress: "00:00:00:01:20:60"
+        nodeLabels:
+          node-role.kubernetes.io/ht: ""
+      - hostName: "node5"
+        role: "worker"
+        nodeNetwork:
+          interfaces:
+            - name: eno1
+              macAddress: "00:00:00:01:20:70"
+        nodeLabels:
+          node-role.kubernetes.io/ht: ""
+        machineConfigPool: "ht"
+`
+
 const siteConfigV2StandardClusterTest = `
 apiVersion: ran.openshift.io/v2
 kind: SiteConfig
@@ -1043,6 +1105,16 @@ func Test_StandardClusterSiteConfigBuild(t *testing.T) {
 
 	outputStr := checkSiteConfigBuild(t, sc)
 	filesData, err := ReadFile("testdata/siteConfigStandardClusterTestOutput.yaml")
+	assert.Equal(t, string(filesData), outputStr)
+}
+
+func Test_StandardClusterSiteConfigExtraRolesBuild(t *testing.T) {
+	sc := SiteConfig{}
+	err := yaml.Unmarshal([]byte(siteConfigStandardClusterExtraRolesTest), &sc)
+	assert.NoError(t, err)
+
+	outputStr := checkSiteConfigBuild(t, sc)
+	filesData, err := ReadFile("testdata/siteConfigStandardClusterExtraRolesTestOutput.yaml")
 	assert.Equal(t, string(filesData), outputStr)
 }
 

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterExtraRolesTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterExtraRolesTestOutput.yaml
@@ -1,0 +1,366 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "0"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        name: cluster1
+    name: cluster1
+---
+apiVersion: extensions.hive.openshift.io/v1beta1
+kind: AgentClusterInstall
+metadata:
+    annotations:
+        agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType":"OVNKubernetes"}}'
+        argocd.argoproj.io/sync-wave: "1"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    name: cluster1
+    namespace: cluster1
+spec:
+    apiVIP: 10.16.231.2
+    clusterDeploymentRef:
+        name: cluster1
+    imageSetRef:
+        name: openshift-v4.9.0
+    ingressVIP: 10.16.231.3
+    manifestsConfigMapRef:
+        name: cluster1
+    networking:
+        clusterNetwork:
+            - cidr: 10.128.0.0/14
+              hostPrefix: 23
+        machineNetwork:
+            - cidr: 10.16.231.0/24
+        serviceNetwork:
+            - 172.30.0.0/16
+    provisionRequirements:
+        controlPlaneAgents: 3
+        workerAgents: 2
+    sshPublicKey: 'ssh-rsa '
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    name: cluster1
+    namespace: cluster1
+spec:
+    baseDomain: example.com
+    clusterInstallRef:
+        group: extensions.hive.openshift.io
+        kind: AgentClusterInstall
+        name: cluster1
+        version: v1beta1
+    clusterName: cluster1
+    platform:
+        agentBareMetal:
+            agentSelector:
+                matchLabels:
+                    cluster-name: cluster1
+    pullSecretRef:
+        name: pullSecretName
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: NMStateConfig
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        nmstate-label: cluster1
+    name: node1
+    namespace: cluster1
+spec:
+    interfaces:
+        - name: eno1
+          macAddress: "00:00:00:01:20:30"
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: NMStateConfig
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        nmstate-label: cluster1
+    name: node2
+    namespace: cluster1
+spec:
+    interfaces:
+        - name: eno1
+          macAddress: "00:00:00:01:20:40"
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: NMStateConfig
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        nmstate-label: cluster1
+    name: node3
+    namespace: cluster1
+spec:
+    interfaces:
+        - name: eno1
+          macAddress: "00:00:00:01:20:50"
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: NMStateConfig
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        nmstate-label: cluster1
+    name: node4
+    namespace: cluster1
+spec:
+    interfaces:
+        - name: eno1
+          macAddress: 00:00:00:01:20:60
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: NMStateConfig
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        nmstate-label: cluster1
+    name: node5
+    namespace: cluster1
+spec:
+    interfaces:
+        - name: eno1
+          macAddress: 00:00:00:01:20:70
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: InfraEnv
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    name: cluster1
+    namespace: cluster1
+spec:
+    clusterRef:
+        name: cluster1
+        namespace: cluster1
+    nmStateConfigLabelSelector:
+        matchLabels:
+            nmstate-label: cluster1
+    pullSecretRef:
+        name: pullSecretName
+    sshAuthorizedKey: 'ssh-rsa '
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        bmac.agent-install.openshift.io/hostname: node1
+        bmac.agent-install.openshift.io/role: master
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        infraenvs.agent-install.openshift.io: cluster1
+    name: node1
+    namespace: cluster1
+spec:
+    automatedCleaningMode: disabled
+    bmc:
+        disableCertificateVerification: true
+    bootMode: UEFI
+    online: true
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        bmac.agent-install.openshift.io/hostname: node2
+        bmac.agent-install.openshift.io/role: master
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        infraenvs.agent-install.openshift.io: cluster1
+    name: node2
+    namespace: cluster1
+spec:
+    automatedCleaningMode: disabled
+    bmc:
+        disableCertificateVerification: true
+    bootMode: UEFI
+    online: true
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        bmac.agent-install.openshift.io/hostname: node3
+        bmac.agent-install.openshift.io/role: master
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        infraenvs.agent-install.openshift.io: cluster1
+    name: node3
+    namespace: cluster1
+spec:
+    automatedCleaningMode: disabled
+    bmc:
+        disableCertificateVerification: true
+    bootMode: UEFI
+    online: true
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        bmac.agent-install.openshift.io.node-label.node-role.kubernetes.io/ht: ""
+        bmac.agent-install.openshift.io/hostname: node4
+        bmac.agent-install.openshift.io/role: worker
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        infraenvs.agent-install.openshift.io: cluster1
+    name: node4
+    namespace: cluster1
+spec:
+    automatedCleaningMode: disabled
+    bmc:
+        disableCertificateVerification: true
+    bootMode: UEFI
+    online: true
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        bmac.agent-install.openshift.io.node-label.node-role.kubernetes.io/ht: ""
+        bmac.agent-install.openshift.io/hostname: node5
+        bmac.agent-install.openshift.io/machine-config-pool: ht
+        bmac.agent-install.openshift.io/role: worker
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    labels:
+        infraenvs.agent-install.openshift.io: cluster1
+    name: node5
+    namespace: cluster1
+spec:
+    automatedCleaningMode: disabled
+    bmc:
+        disableCertificateVerification: true
+    bootMode: UEFI
+    online: true
+---
+apiVersion: v1
+data:
+    predefined-extra-manifests-master.yaml: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        metadata:
+            annotations:
+                ran.openshift.io/ztp-gitops-generated: '{}'
+            labels:
+                machineconfiguration.openshift.io/role: master
+            name: predefined-extra-manifests-master
+        spec:
+            config:
+                ignition:
+                    version: 3.2.0
+                storage:
+                    files:
+                        - contents:
+                            source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKZWNobyAiRm9vYmFyISIgPiBmb29iYXIuY29uZg==
+                          mode: 493
+                          overwrite: true
+                          path: /usr/local/bin/foobar.sh
+                systemd:
+                    units:
+                        - contents: |
+                            [Unit]
+                            Description=Runs a simple shell script for test purposes
+
+                            [Service]
+                            Type=simple
+                            ExecStart=/usr/local/bin/foobar.sh
+                          enabled: true
+                          name: foobar.service
+            kernelType: default
+    predefined-extra-manifests-worker.yaml: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        metadata:
+            annotations:
+                ran.openshift.io/ztp-gitops-generated: '{}'
+            labels:
+                machineconfiguration.openshift.io/role: worker
+            name: predefined-extra-manifests-worker
+        spec:
+            config:
+                ignition:
+                    version: 3.2.0
+                storage:
+                    files:
+                        - contents:
+                            source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKZWNobyAiRm9vYmFyISIgPiBmb29iYXIuY29uZg==
+                          mode: 493
+                          overwrite: true
+                          path: /usr/local/bin/foobar.sh
+                systemd:
+                    units:
+                        - contents: |
+                            [Unit]
+                            Description=Runs a simple shell script for test purposes
+
+                            [Service]
+                            Type=simple
+                            ExecStart=/usr/local/bin/foobar.sh
+                          enabled: true
+                          name: foobar.service
+            kernelType: default
+kind: ConfigMap
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    name: cluster1
+    namespace: cluster1
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "2"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    name: cluster1
+spec:
+    hubAcceptsClient: true
+---
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "2"
+        ran.openshift.io/ztp-gitops-generated: '{}'
+    name: cluster1
+    namespace: cluster1
+spec:
+    applicationManager:
+        enabled: false
+    certPolicyController:
+        enabled: false
+    clusterLabels:
+        cloud: auto-detect
+        vendor: auto-detect
+    clusterName: cluster1
+    clusterNamespace: cluster1
+    iamPolicyController:
+        enabled: false
+    policyController:
+        enabled: true
+    searchCollector:
+        enabled: false


### PR DESCRIPTION
Hi, 
this feature is an extra to the previously added feature for nodeLabels. These labels can be used to add roles to each node, apart from the worker/master. This was a feature already implemented in AI and ZTP. 

In case of the extra labels are used to add an new role to a node, we can combine it with an AI annotation (`bmac.agent-install.openshift.io/machine-config-pool`). This feature allows the node to download, from the very beginning, the ignition file of that MCP:

https://github.com/openshift/assisted-service/blob/513ec44ec649838a7d10b659254357cf012bc051/docs/hive-integration/README.md#bare-metal-operator-integration

The result is the same, the node is created under a different role. But it is using its proper MCP and you save one reboot.
