### PR TITLE
cnf-tests: Fix fec secure boot test case

### DIFF
--- a/cnf-tests/testsuites/e2esuite/fec/fec.go
+++ b/cnf-tests/testsuites/e2esuite/fec/fec.go
@@ -3,12 +3,13 @@ package fec
 import (
 	"context"
 	"fmt"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Adding dynamic secureBoot verification.
If secure boot enabled SriovFecClusterConfig resources gets updated with the correct pfDriver configuration vfio-pci