### PR TITLE
ztp: revert base image to RHEL8

### DIFF
--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 as builder
 ARG IMAGE_REF
 USER root
 ENV PKG_ROOT=cnf-features-deploy


### PR DESCRIPTION
Revert base image to rhel-8 in the ztp's Containerfile, due to failures building the new ztp image.