### PR TITLE
OCPBUGS-27031: Don't skip a NMStateConfig over-ride

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfig.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig.go
@@ -486,8 +486,11 @@ func (node *Nodes) CrAnnotationSearch(kind string, action string, cluster *Clust
 }
 
 // Return true if the NodeNetwork content is empty or not defined
-func (node *Nodes) nodeNetworkIsEmpty() bool {
-	if len(node.NodeNetwork.Config) == 0 && len(node.NodeNetwork.Interfaces) == 0 {
+func (node *Nodes) nodeNetworkIsEmpty(cluster *Clusters, site *Spec) bool {
+	// Check if we have an NMStateConfig as a crTemplate over-ride. If we do,
+	// we want to use the NodeNetwork details from there.
+	_, ok := node.CrTemplateSearch("NMStateConfig", cluster, site)
+	if len(node.NodeNetwork.Config) == 0 && len(node.NodeNetwork.Interfaces) == 0 && !ok {
 		return true
 	}
 	return false

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
@@ -184,7 +184,7 @@ func (scbuilder *SiteConfigBuilder) getClusterCRs(clusterId int, siteConfigTemp 
 
 				// BZ 2028510 -- Empty NMStateConfig causes issues and
 				// should simply be left out.
-				if kind == "NMStateConfig" && node.nodeNetworkIsEmpty() {
+				if kind == "NMStateConfig" && node.nodeNetworkIsEmpty(&cluster, &siteConfigTemp.Spec) {
 					// noop, leave the empty NMStateConfig CR out of the generated set
 				} else if kind == "HostFirmwareSettings" {
 					if filePath := node.BiosFileSearch(&cluster, &siteConfigTemp.Spec); filePath != "" {

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -1773,6 +1773,36 @@ spec:
 	result, err = scBuilder.Build(sc)
 	nmState, err = getKind(result["test-site/cluster1"], "NMStateConfig")
 	assert.Nil(t, nmState, nil)
+
+	noNetworkWithNMStateOverRide := `
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "test-site"
+  namespace: "test-site"
+spec:
+  baseDomain: "example.com"
+  clusterImageSetNameRef: "openshift-v4.8.0"
+  sshPublicKey:
+  clusters:
+  - clusterName: "cluster1"
+    clusterLabels:
+      group-du-sno: ""
+      common: true
+      sites : "test-site"
+    nodes:
+      - hostName: "node1"
+        crTemplates:
+          NMStateConfig: "testdata/nmstateconfig.yaml"
+`
+
+	// Set empty case with a NMStateConfig over-ride.  Make sure we do get an
+	// NMStateConfig
+	err = yaml.Unmarshal([]byte(noNetworkWithNMStateOverRide), &sc)
+	assert.Equal(t, err, nil)
+	result, err = scBuilder.Build(sc)
+	nmState, err = getKind(result["test-site/cluster1/node1"], "NMStateConfig")
+	assert.NotEqual(t, nmState, nil)
 }
 
 func Test_filterExtraManifests(t *testing.T) {

--- a/ztp/siteconfig-generator/siteConfig/testdata/nmstateconfig.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/nmstateconfig.yaml
@@ -1,0 +1,37 @@
+apiVersion: agent-install.openshift.io/v1beta1 
+kind: NMStateConfig
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  name: "test-site"
+  namespace: "test-site"
+  labels:
+    nmstate-label: "test-site"
+spec:   
+  interfaces:
+    - name: eno5
+      macAddress: 00:00:00:00:00:18
+  config:
+    interfaces:
+      - name: bond0
+        type: bond
+        state: up
+        mtu: 6000
+        ipv4:
+          enabled: false
+        ipv6:
+          enabled: false
+        link-aggregation:
+          mode: 802.3ad
+          options:
+            miimon: 100
+            lacp_rate: slow
+          port:
+            - ens1f0
+            - ens1f1
+    dns-resolver:
+      config:
+        server:
+          - 10.10.11.10
+          - 10.10.11.11
+


### PR DESCRIPTION
If the user ommits the NodeNetwork details from the siteConfig but includes it in an crTemplate over-ride of NMStateConfig, we end up not generating the NMStateConfig because we think the network is empty. Check if the user did not include an over-ride before skiping the NMStateConfig generation.