### PR TITLE
cnf-tests: Pass command line arguments to latency-e2e.test

### DIFF
--- a/cnf-tests/entrypoint/test-run.sh
+++ b/cnf-tests/entrypoint/test-run.sh
@@ -8,4 +8,4 @@ if [ "$IMAGE_REGISTRY" != "" ] && [[ "$IMAGE_REGISTRY" != */ ]]; then
 fi
 
 echo running "/usr/bin/latency-e2e.test"
-DISCOVERY_MODE="$DISCOVERY_MODE" LATENCY_TEST_RUN="$LATENCY_TEST_RUN" "/usr/bin/latency-e2e.test"
+DISCOVERY_MODE="$DISCOVERY_MODE" LATENCY_TEST_RUN="$LATENCY_TEST_RUN" "/usr/bin/latency-e2e.test" "$@"


### PR DESCRIPTION
Flags that passed to shell script, are now drilled down to latency-e2e.test executable. This resolves an issue when running latency tests by using cnf tests container with command line arguments had no effect and these arguments were ignored.

More info here:
https://issues.redhat.com/browse/OCPBUGS-27158