### PR TITLE
cnf-tests: `multinetworkpolicy` WaitStable

### DIFF
--- a/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go
@@ -86,6 +86,9 @@ var _ = Describe("[multinetworkpolicy] MultiNetworkPolicy SR-IOV integration", f
 		Expect(namespaces.Create(nsY, client.Client)).ToNot(HaveOccurred())
 		Expect(namespaces.Create(nsZ, client.Client)).ToNot(HaveOccurred())
 
+		// Wait for SR-IOV operator to be stable (each SriovNetworkNodeState.Status == Succeeded), as there can be a leftover of other test cases.
+		networks.WaitStable(sriovclient)
+
 		sriovInfos, err := sriovcluster.DiscoverSriov(sriovclient, namespaces.SRIOVOperator)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sriovInfos).ToNot(BeNil())


### PR DESCRIPTION
At the beggining of the feature suite, check for the cluster to be in a stable state for SR-IOV  before proceeding with the device discovery and configuration.
This is important because other test cases may left some active configuration on the cluster.