### PR TITLE
cnf-tests: `sriov/numa` clean configuration

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/numa_node_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/numa_node_sriov.go
@@ -111,6 +111,10 @@ var _ = Describe("[sriov] NUMA node alignment", Ordered, ContinueOnFailure, func
 			"test-numa-1-nic1-exclude-topology-true-", testingNode.Name,
 			"testNuma1NIC1ExcludeTopoplogyTrue", ipam, true)
 
+		DeferCleanup(func() {
+			networks.CleanSriov(sriovclient)
+		})
+
 		By("Waiting for SRIOV devices to get configured")
 		networks.WaitStable(sriovclient)
 


### PR DESCRIPTION
Add a step to clean the configuration after the `sriov/NUMA` test suite has been finished.
This is important because other test suites could expect to find a clean and stable cluster state.