### PR TITLE
cnf-tests: Deprecate ioutil

### DIFF
--- a/cnf-tests/mirror/mirror.go
+++ b/cnf-tests/mirror/mirror.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 )
 
@@ -26,7 +26,7 @@ func main() {
 		log.Fatal("Missing mandatory fields")
 	}
 
-	bytes, err := ioutil.ReadFile(*imagesFile)
+	bytes, err := os.ReadFile(*imagesFile)
 	if err != nil {
 		log.Fatalf("Failed to read %s - %v", *imagesFile, err)
 	}

--- a/cnf-tests/pod-utils/pkg/node/node.go
+++ b/cnf-tests/pod-utils/pkg/node/node.go
@@ -2,7 +2,7 @@ package node
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -31,7 +31,7 @@ func GetSelfCPUs() (*cpuset.CPUSet, error) {
 
 // PrintInformation prints debug information
 func PrintInformation() error {
-	out, err := ioutil.ReadFile("/proc/cmdline")
+	out, err := os.ReadFile("/proc/cmdline")
 	if err != nil {
 		klog.Errorf("failed to read file /proc/cmdline")
 		return err
@@ -50,7 +50,7 @@ func PrintInformation() error {
 // GetCPUSiblings returns the IDs of the CPU siblings
 func GetCPUSiblings(cpu int) ([]int, error) {
 	siblingThreadFile := fmt.Sprintf("/sys/devices/system/cpu/cpu%d/topology/thread_siblings_list", cpu)
-	out, err := ioutil.ReadFile(siblingThreadFile)
+	out, err := os.ReadFile(siblingThreadFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: err: %v", siblingThreadFile, err)
 	}

--- a/cnf-tests/pod-utils/stresser/main.go
+++ b/cnf-tests/pod-utils/stresser/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -47,7 +46,7 @@ func consumeCpus(howMany int) error {
 	for i := 0; i < howMany; i++ {
 		log.Print("Spawning a go routine to consume CPU")
 		go func() {
-			_, err := io.Copy(ioutil.Discard, src)
+			_, err := io.Copy(io.Discard, src)
 			if err != nil {
 				panic(err)
 			}

--- a/cnf-tests/testsuites/e2esuite/sctp/sctp.go
+++ b/cnf-tests/testsuites/e2esuite/sctp/sctp.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -243,7 +242,7 @@ var _ = Describe("[sctp]", func() {
 
 func loadMC() *mcfgv1.MachineConfig {
 	decode := mcfgScheme.Codecs.UniversalDeserializer().Decode
-	mcoyaml, err := ioutil.ReadFile(mcYaml)
+	mcoyaml, err := os.ReadFile(mcYaml)
 	Expect(err).ToNot(HaveOccurred())
 
 	obj, _, err := decode([]byte(mcoyaml), nil, nil)

--- a/ztp/policygenerator/testSource/TestAssertions.go
+++ b/ztp/policygenerator/testSource/TestAssertions.go
@@ -1,11 +1,12 @@
 package testSource
 
 import (
-	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func ACMResourceDefinitionAssertions(t *testing.T) {
@@ -61,7 +62,7 @@ func checkIfSourceYamlEqualsACMObjectDefinition(generatedFilePath string, t *tes
 }
 
 func checkDirectoryExists(parentDirPath string, childDir string) bool {
-	var dirFs, err = ioutil.ReadDir(parentDirPath)
+	var dirFs, err = os.ReadDir(parentDirPath)
 	if err == nil {
 		for i := range dirFs {
 			if dirFs[i].IsDir() && dirFs[i].Name() == childDir {
@@ -73,7 +74,7 @@ func checkDirectoryExists(parentDirPath string, childDir string) bool {
 }
 
 func checkFileExists(parentDirPath string, fileName string) bool {
-	var dirFs, err = ioutil.ReadDir(parentDirPath)
+	var dirFs, err = os.ReadDir(parentDirPath)
 	if err == nil {
 		for i := range dirFs {
 			if !dirFs[i].IsDir() && dirFs[i].Name() == fileName {

--- a/ztp/policygenerator/testSource/TestGetters.go
+++ b/ztp/policygenerator/testSource/TestGetters.go
@@ -1,13 +1,13 @@
 package testSource
 
 import (
-	"github.com/openshift-kni/cnf-features-deploy/ztp/policygenerator/utils"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/openshift-kni/cnf-features-deploy/ztp/policygenerator/utils"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func GetOutPath(t *testing.T) string {
@@ -38,7 +38,7 @@ func GetTestCRDFileName(t *testing.T) string {
 func ReadFileToTemplateObject(t *testing.T) utils.PolicyGenTemplate {
 	filePath := path.Join(GetTemplatePath(t), GetTestCRDFileName(t))
 	fileData := utils.PolicyGenTemplate{}
-	file1, err := ioutil.ReadFile(filePath)
+	file1, err := os.ReadFile(filePath)
 
 	if err != nil {
 		assert.Fail(t, err.Error())
@@ -122,7 +122,7 @@ func getSourcePolicyWithSubstitutions(t *testing.T) map[string]interface{} {
 func getPolicyTemplateObject(t *testing.T) utils.PolicyGenTemplate {
 	filePath := path.Join(GetTemplatePath(t), GetTestCRDFileName(t))
 	fileData := utils.PolicyGenTemplate{}
-	file1, err := ioutil.ReadFile(filePath)
+	file1, err := os.ReadFile(filePath)
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}

--- a/ztp/policygenerator/testSource/TestHelpers.go
+++ b/ztp/policygenerator/testSource/TestHelpers.go
@@ -1,16 +1,17 @@
 package testSource
 
 import (
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func readFileToMap(filePath string, t *testing.T) map[string]interface{} {
 	fileData := make(map[string]interface{})
-	file1, err := ioutil.ReadFile(filePath)
+	file1, err := os.ReadFile(filePath)
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}

--- a/ztp/siteconfig-generator/siteConfig/filesHandler.go
+++ b/ztp/siteconfig-generator/siteConfig/filesHandler.go
@@ -1,7 +1,6 @@
 package siteConfig
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,14 +26,29 @@ func GetFiles(path string) ([]os.FileInfo, error) {
 	}
 
 	if fileInfo.IsDir() {
-		return ioutil.ReadDir(path)
+		var files []os.FileInfo
+		results, err := os.ReadDir(path)
+		if err != nil {
+			return nil, err
+		}
+
+		// Translate []fs.DirEntry to []os.FileInfo
+		for _, result := range results {
+			resultsInfo, err := result.Info()
+			if err != nil {
+				return nil, err
+			}
+			files = append(files, resultsInfo)
+		}
+
+		return files, nil
 	}
 
 	return []os.FileInfo{fileInfo}, nil
 }
 
 func ReadFile(filePath string) ([]byte, error) {
-	return ioutil.ReadFile(filePath)
+	return os.ReadFile(filePath)
 }
 
 func WriteFile(filePath string, outDir string, content []byte) error {
@@ -42,7 +56,7 @@ func WriteFile(filePath string, outDir string, content []byte) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		os.MkdirAll(path, 0775)
 	}
-	err := ioutil.WriteFile(outDir+"/"+filePath, content, 0644)
+	err := os.WriteFile(outDir+"/"+filePath, content, 0644)
 
 	return err
 }

--- a/ztp/tools/policy-object-template-diff/main.go
+++ b/ztp/tools/policy-object-template-diff/main.go
@@ -2,6 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+
 	"github.com/google/go-cmp/cmp"
 	sriov "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	performanceprofile "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v1"
@@ -13,14 +19,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"log"
 	configurationPolicyv1 "open-cluster-management.io/config-policy-controller/api/v1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
-	"os"
-	"path"
-	"runtime"
 	"sigs.k8s.io/yaml"
-	"strings"
 )
 
 var (


### PR DESCRIPTION
`ioutil` was deprecated back in [Go 1.16](https://go.dev/doc/go1.16).