### PR TITLE
cnf-tests: Add new .snyk file. Previous file fails to parse in "snyk code test" command that is used in the security workflow.

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,4 @@
 exclude:
   global:
-    - vendor/github.com/onsi/ginkgo/v2/internal/suite.go:
-      reason: Temporarily ignoring until a fix is ready.
-      expires: 2024-03-01
-      created: 2024-01-01
-    - vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go:
-      reason: Ignoring as the issue in the code is expected.
-      created: 2024-01-01
+    - "vendor/github.com/onsi/ginkgo/v2/internal/suite.go"
+    - "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"


### PR DESCRIPTION
Currently the SAST job fails due to the following error:

 Could not parse ignore rules to glob { path: '/go/src/github.com/openshift-kni/cnf-features-deploy/.snyk' }
Please make sure ignore file follows correct syntax 

I managed to reproduce the error locally and by changing the file content to the new version, the parsing of the file is successful and so is the security scanning.