### PR TITLE
cnf-tests: Fixes snyk file content

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,4 @@
 exclude:
   global:
-    - vendor/github.com/onsi/ginkgo/v2/internal/suite.go:
-      reason: Temporarily ignoring until a fix is ready.
-      expires: 2024-03-01
-      created: 2024-01-01
-    - vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go:
-      reason: Ignoring as the issue in the code is expected.
-      created: 2024-01-01
+    - "vendor/github.com/onsi/ginkgo/v2/internal/suite.go"
+    - "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"


### PR DESCRIPTION
Currently the SAST workflow that we are adding to cnf-features-deploy repo fails for the following reason: Could not parse ignore rules to glob { path: '/go/src/github.com/openshift-kni/cnf-features-deploy/.snyk' } Please make sure ignore file follows correct syntax The failure occurs in "snyk code test" command that is used in the security workflow. By changing the current .snyk file content to a new one the parsing of the file is successful and so is the security scanning.