### PR TITLE
OCPBUGS-27158: Pass command line arguments to latency-e2e.test

### DIFF
--- a/cnf-tests/entrypoint/test-run.sh
+++ b/cnf-tests/entrypoint/test-run.sh
@@ -8,4 +8,4 @@ if [ "$IMAGE_REGISTRY" != "" ] && [[ "$IMAGE_REGISTRY" != */ ]]; then
 fi
 
 echo running "/usr/bin/latency-e2e.test"
-DISCOVERY_MODE="$DISCOVERY_MODE" LATENCY_TEST_RUN="$LATENCY_TEST_RUN" "/usr/bin/latency-e2e.test"
+DISCOVERY_MODE="$DISCOVERY_MODE" LATENCY_TEST_RUN="$LATENCY_TEST_RUN" "/usr/bin/latency-e2e.test" "$@"

--- a/cnf-tests/entrypoint/test-run.sh
+++ b/cnf-tests/entrypoint/test-run.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 LATENCY_TEST_RUN="${LATENCY_TEST_RUN:-true}"
+DISCOVERY_MODE="${DISCOVERY_MODE:-true}"
 
 if [ "$IMAGE_REGISTRY" != "" ] && [[ "$IMAGE_REGISTRY" != */ ]]; then
     export IMAGE_REGISTRY="$IMAGE_REGISTRY/"
 fi
 
 echo running "/usr/bin/latency-e2e.test"
-LATENCY_TEST_RUN="$LATENCY_TEST_RUN" "/usr/bin/latency-e2e.test"
+DISCOVERY_MODE="$DISCOVERY_MODE" LATENCY_TEST_RUN="$LATENCY_TEST_RUN" "/usr/bin/latency-e2e.test"


### PR DESCRIPTION
This PR cherry-picks both commits:

638c6c2: cnf-tests: Set DISCOVERY_MODE to true by default
and
ed12344: cnf-tests: Pass command line arguments to latency-e2e.test

Please note: the declared bug, is fixed by the second commit and the first one
is a fix we merged to latest and wasn't backported from some reason.
