### PR TITLE
ztp: CNF-9622: Create IBU platform OADP backup and restore CRs

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/README.md
+++ b/ztp/gitops-subscriptions/argocd/example/README.md
@@ -2,6 +2,9 @@ The directories in here contain examples for:
 * SiteConfig
 * the ACM PolicyGenerator
 * the ZTP PolicyGenTemplate
+* Image based upgrades
 
 The ```policygentemplates``` and ```acmpolicygenerator``` contain untemplated examples for all cluster configuration.
 Under each of the two directories there is also a ```hub-side-templating``` directory which contains examples for how to use hub templates for declaring the policies.
+
+The ```image-based-upgrades``` contain examples pertaining to image based upgrades.

--- a/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/README.md
+++ b/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/README.md
@@ -1,0 +1,91 @@
+## Image-Based Upgrades (IBU)
+This directory contains examples of generating resources required for Image Based Upgrades (IBU) utilizing the [Life Cycle Agent operator](https://github.com/openshift-kni/lifecycle-agent). These examples define policies to automate image-based upgrades, ensuring seamless deployment across managed clusters through Gitops.
+
+
+### Prerequisites
+
+Before using the IBU examples, ensure that the following namespaces have been created:
+
+- `ztp-common`: The root policy will be created in this namespace. If you use another name for the `common` namespace, please remember to update the `example-oadp-policy.yaml` policy.
+- `openshift-adp`: The ConfigMap containing the related OpenShift API for Data Protection (OADP) Custom Resources (CRs) will be copied to this namespace on the applicable spoke cluster(s).
+
+### Setup ArgoCD Application
+
+To deploy the IBU examples, you can use the existing [policies-app](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/gitops-subscriptions/argocd/deployment/policies-app.yaml), which is also used for deploying DU profile policy examples. Refer to the [ReadMe](https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/gitops-subscriptions/argocd/README.md) section "Preparation of Hub cluster for ZTP" for detailed instructions on setting up the ArgoCD policies application.
+
+Ensure that your Git repository, which will be used with the ArgoCD policies application, contains a directory structured as follows:
+
+```plaintext
+├── source-crs/
+│   ├── ibu/
+│   │    ├── PlatformBackupRestore.yaml
+├── ...
+├── custom-oadp-workload-crs.yaml
+├── example-oadp-policy.yaml
+├── kustomization.yaml
+```
+
+Note that [`source-crs/ibu/PlatformBackupRestore.yaml`](https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/source-crs/ibu/PlatformBackupRestore.yaml) is provided in the ZTP image, however, it is important to ensure that the `kustomization.yaml` file is located in the same directory structure shown above in order to reference the `PlatformBackupRestore.yaml` manifest.
+
+### Generating the ConfigMap and Policy
+
+Use the [`configMapGenerator`](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#configmapgenerator) provided by the Kustomize tool to generate a ConfigMap encapsulating the OADP CRs for IBU. The OpenShift platform-related CRs are available [here](https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/source-crs/ibu/PlatformBackupRestore.yaml).
+
+Additional workload OADP CRs may be included in the ConfigMap generation process as shown in the example below:
+
+```yaml
+configMapGenerator:
+- files:
+  - source-crs/ibu/PlatformBackupRestore.yaml
+  - custom-oadp-workload-crs.yaml
+  name: oadp-cm
+  namespace: ztp-common
+
+generatorOptions:
+  disableNameSuffixHash: true
+```
+
+Ensure that the `custom-oadp-workload-crs.yaml` file includes a one-to-one mapping of OADP backup and restore CRs. It's important to note that these CRs can be stored either in separate YAML manifests or consolidated within a single YAML file (as shown below), with each CR section separated by the `---` directive.
+
+```yaml
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  labels:
+    velero.io/storage-location: default
+  name: foobar-app
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+  - foobar
+  includedNamespaceScopedResources:
+  - secrets
+  - deployments
+  - statefulsets
+  excludedClusterScopedResources:
+  - persistentVolumes
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: foobar-app
+  namespace: openshift-adp
+  labels:
+    velero.io/storage-location: default
+  annotations:
+    lca.openshift.io/apply-wave: "3"
+spec:
+  backupName:
+    foobar-app
+```
+
+> [!IMPORTANT]
+> Don't forget to create and include the policy [example-oadp-policy.yaml](./example-oadp-policy.yaml) under the `resources` object in the `kustomization.yaml` file.
+> The policy uses hub-side templating and requires Advanced Cluster Management (ACM) 2.8 and later versions for the `copyConfigMapData` function. However, it is important to note that 2.9.2 will be the minimum supported ACM version for IBU.
+
+
+### Enforcing the Policy
+
+To enforce the policy and distribute the ConfigMap to the applicable managed clusters, create a ClusterGroupUpgrade (CGU) CR referencing the aforementioned policy. This should be done prior to setting the IBU stage to `Prep`.
+
+For more detailed information on using the Life Cycle Agent (LCA) operator, refer to the [docs](https://github.com/openshift-kni/lifecycle-agent/tree/main/docs).

--- a/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/example-oadp-policy.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/example-oadp-policy.yaml
@@ -1,0 +1,71 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: ztp-common-mcsb
+  namespace: ztp-common
+spec:
+  clusterSet: global
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: oadp-cm-policy-placement
+  namespace: ztp-common
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: common
+              operator: In
+              values:
+                - 'true'
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: oadp-cm-policy-placement-binding
+  namespace: ztp-common
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
+  name: oadp-cm-policy-placement
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: oadp-cm-common-policies
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: oadp-cm-common-policies
+  namespace: ztp-common
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: oadp-cm-policy
+        spec:
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - 'openshift-adp'
+          remediationAction: inform
+          severity: medium
+          object-templates:
+          - complianceType: mustonlyhave
+            objectDefinition:
+              kind: ConfigMap
+              apiVersion: v1
+              metadata:
+                name: oadp-cm
+                namespace: openshift-adp
+              data: '{{hub copyConfigMapData "ztp-common" "oadp-cm" hub}}'

--- a/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/kustomization.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+- files:
+  - source-crs/ibu/PlatformBackupRestore.yaml
+  # - <add-workload-oadp-crs-here>
+  name: oadp-cm
+  namespace: ztp-common
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+resources:
+- example-oadp-policy.yaml

--- a/ztp/source-crs/ibu/PlatformBackupRestore.yaml
+++ b/ztp/source-crs/ibu/PlatformBackupRestore.yaml
@@ -1,0 +1,63 @@
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: acm-klusterlet
+  annotations:
+    lca.openshift.io/apply-label: "rbac.authorization.k8s.io/v1/clusterroles/klusterlet,apps/v1/deployments/open-cluster-management-agent/klusterlet,v1/secrets/open-cluster-management-agent/bootstrap-hub-kubeconfig,rbac.authorization.k8s.io/v1/clusterroles/klusterlet,v1/serviceaccounts/open-cluster-management-agent/klusterlet,rbac.authorization.k8s.io/v1/clusterroles/open-cluster-management:klusterlet-admin-aggregate-clusterrole,rbac.authorization.k8s.io/v1/clusterrolebindings/klusterlet,operator.open-cluster-management.io/v1/klusterlets/klusterlet,apiextensions.k8s.io/v1/customresourcedefinitions/klusterlets.operator.open-cluster-management.io,v1/secrets/open-cluster-management-agent/open-cluster-management-image-pull-credentials"
+  labels:
+    velero.io/storage-location: default
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+  - open-cluster-management-agent
+  includedClusterScopedResources:
+  - klusterlets.operator.open-cluster-management.io
+  - klusterlet
+  - clusterrole
+  - clusterrolebinding
+  includedNamespaceScopedResources:
+  - deployments
+  - serviceaccounts
+  - secrets
+  excludedNamespaceScopedResources: []
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  labels:
+    velero.io/storage-location: default
+  name: localvolume
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+  - openshift-local-storage
+  includedNamespaceScopedResources:
+  - localvolumes
+  excludedClusterScopedResources:
+  - Namespace
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: acm-klusterlet
+  namespace: openshift-adp
+  labels:
+    velero.io/storage-location: default
+  annotations:
+    lca.openshift.io/apply-wave: "1"
+spec:
+  backupName:
+    acm-klusterlet
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: localvolume
+  namespace: openshift-adp
+  labels:
+    velero.io/storage-location: default
+  annotations:
+    lca.openshift.io/apply-wave: "2"
+spec:
+  backupName:
+    localvolume


### PR DESCRIPTION
The required OpenShift platform-related OADP backup and restore CRs for performing image based upgrades (IBU) is added under the `source-crs` directory. Specifically, a new `ibu` sub-directory is created to house all IBU related content.

The example directory is also updated to provide reference deployment samples to the user.