### PR TITLE
CNF-23434: ztp: Remove GO111MODULE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,6 @@ TOOLS_DIR="$(CACHE_DIR)/tools"
 
 $(shell mkdir -p $(TOOLS_DIR))
 
-# Export GO111MODULE=on to enable project to be built from within GOPATH/src
-export GO111MODULE=on
-
 deps-update:
 	go mod tidy && \
 	go mod vendor

--- a/ztp/tools/policy-object-template-diff/Makefile
+++ b/ztp/tools/policy-object-template-diff/Makefile
@@ -5,7 +5,7 @@ ZTP_PATH?=""
 
 build:
 	mkdir -p out/bin
-	GO111MODULE=on $(GOCMD) build -mod vendor -o out/bin/$(BINARY_NAME) .
+	$(GOCMD) build -mod vendor -o out/bin/$(BINARY_NAME) .
 
 clean:
 	rm -fr ./bin


### PR DESCRIPTION
`GO111MODULE=on` is the default behavior as of Go 1.16.  Not needed anymore.