### PR TITLE
ztp: remove marketplace operator

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-common-ranGen.yaml
@@ -31,7 +31,6 @@ policies:
     ran.openshift.io/ztp-deploy-wave: "1"
   manifests:
     - path: source-crs/ReduceMonitoringFootprint.yaml
-    - path: source-crs/OperatorHub.yaml
     - path: source-crs/DefaultCatsrc.yaml
       patches:
       - metadata:

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
@@ -60,14 +60,13 @@ spec:
     #
     # These CRs are in support of installation from a disconnected registry
     #
-    - fileName: OperatorHub.yaml
-      policyName: "config-policy"
     - fileName: DefaultCatsrc.yaml
       policyName: "config-policy"
-      # The Subscriptions all point to redhat-operators-disconnected. The OperatorHub CR
-      # disables the defaults and this CR replaces redhat-operators-disconnected with a
-      # CatalogSource pointing to the disconnected registry. Including both of
-      # these in the same policy orders their application to the cluster.
+      # The Subscriptions all point to redhat-operators-disconnected. We remove
+      # the marketplace operator which disables the defaults and this CR
+      # replaces redhat-operators-disconnected with a CatalogSource pointing to
+      # the disconnected registry. Including both of these in the same policy
+      # orders their application to the cluster.
       # Tip: for RH sources `image: registry.redhat.io/redhat/redhat-operator-index:v4.xx`
       metadata:
         name: redhat-operators-disconnected

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -22,7 +22,7 @@ spec:
     # Notes:
     # - OperatorLifecycleManager is needed for 4.15 and later
     # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
-    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"OperatorLifecycleManager\", \"marketplace\", \"NodeTuning\" ] }}"
+    installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"OperatorLifecycleManager\", \"NodeTuning\" ] }}"
     # It is strongly recommended to include crun manifests as part of the additional install-time manifests for 4.13+.
     # The crun manifests can be obtained from source-crs/optional-extra-manifest/ and added to the git repo ie.sno-extra-manifest.
     # extraManifestPath: sno-extra-manifest

--- a/ztp/source-crs/OperatorHub.yaml
+++ b/ztp/source-crs/OperatorHub.yaml
@@ -1,9 +1,0 @@
-apiVersion: config.openshift.io/v1
-kind: OperatorHub
-metadata:
-    name: cluster
-    annotations:
-        ran.openshift.io/ztp-deploy-wave: "1"
-spec:
-    disableAllDefaultSources: true
-

--- a/ztp/source-crs/extra-manifest/09-openshift-marketplace-ns.yaml
+++ b/ztp/source-crs/extra-manifest/09-openshift-marketplace-ns.yaml
@@ -1,0 +1,17 @@
+# Taken from https://github.com/operator-framework/operator-marketplace/blob/53c124a3f0edfd151652e1f23c87dd39ed7646bb/manifests/01_namespace.yaml
+# Update it as the source evolves.
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: v1.25
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: v1.25
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn-version: v1.25
+  name: "openshift-marketplace"


### PR DESCRIPTION
CNF-10348

The marketplace operator is not needed if one is managing their own catalog sources and do not need the default Redhat catalog sources (certified-operators, community-operators, redhat-marketplace, redhat-operators)

If we are to remove the marketplace operator using the "capabilities" field in siteConfig, we also have to remove disabling all the default catalag sources through the OperatorHub CR as that CR will not be present because it is installed by the marketplace operator

We also need to add the openshift-marketplace namespace.