### PR TITLE
ztp: pin policygenerator version to v1.12.4

### DIFF
--- a/ztp/gitops-subscriptions/Makefile
+++ b/ztp/gitops-subscriptions/Makefile
@@ -24,7 +24,7 @@ build:
 	@echo "ZTP: setup ACM policyGenerator kustomize plugin"
 	mkdir -p $(ACM_POLICYGEN_KUSTOMIZE_DIR)
 	cp -r $(SOURCE_CRS_DIR) $(ACM_POLICYGEN_EX_DIR)
-	GOBIN=$(ACM_POLICYGEN_KUSTOMIZE_DIR) go install open-cluster-management.io/policy-generator-plugin/cmd/PolicyGenerator@latest
+	GOBIN=$(ACM_POLICYGEN_KUSTOMIZE_DIR) go install open-cluster-management.io/policy-generator-plugin/cmd/PolicyGenerator@v1.12.4
 
 $(KUSTOMIZE_BIN):
 	@if [[ $(KUSTOMIZE) == $(KUSTOMIZE_BIN) ]] && [ ! -f $(KUSTOMIZE) ]; then \


### PR DESCRIPTION
Latest version of policygenerator breaks CI with the error message:

go: open-cluster-management.io/policy-generator-plugin/cmd/PolicyGenerator@latest (in open-cluster-management.io/policy-generator-plugin@v1.13.0):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
make: *** [Makefile:27: build] Error 1