### PR TITLE
ztp: 'node-role.kubernetes.io/master' is deprecated; use 'node-role.kubernetes.io/control-plane'

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/clusterCRsV1.go
+++ b/ztp/siteconfig-generator/siteConfig/clusterCRsV1.go
@@ -38,7 +38,7 @@ spec:
     machineNetwork: "{{ .Cluster.MachineNetwork }}"
     serviceNetwork: "{{ .Cluster.ServiceNetwork }}"
   provisionRequirements:
-    controlPlaneAgents: "{{ .Cluster.NumMasters }}"
+    controlPlaneAgents: "{{ .Cluster.NumControlPlanes }}"
     workerAgents: "{{ .Cluster.NumWorkers }}"
   proxy: "{{ .Cluster.Proxy }}"
   sshPublicKey: "{{ .Site.SshPublicKey }}"

--- a/ztp/siteconfig-generator/siteConfig/clusterCRsV2.go
+++ b/ztp/siteconfig-generator/siteConfig/clusterCRsV2.go
@@ -37,7 +37,7 @@ spec:
     machineNetwork: "{{ .Cluster.MachineNetwork }}"
     serviceNetwork: "{{ .Cluster.ServiceNetwork }}"
   provisionRequirements:
-    controlPlaneAgents: "{{ .Cluster.NumMasters }}"
+    controlPlaneAgents: "{{ .Cluster.NumControlPlanes }}"
     workerAgents: "{{ .Cluster.NumWorkers }}"
   proxy: "{{ .Cluster.Proxy }}"
   sshPublicKey: "{{ .Site.SshPublicKey }}"

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -33,7 +33,7 @@ spec:
   clusters:
   - clusterName: "cluster1"
     clusterType: sno
-    numMasters: 1
+    numControlPlanes: 1
     networkType: "OVNKubernetes"
     installConfigOverrides: "{\"controlPlane\":{\"hyperthreading\":\"Disabled\"}}"
     clusterLabels:
@@ -102,7 +102,7 @@ spec:
   clusters:
   - clusterName: "cluster1"
     clusterType: sno
-    numMasters: 1
+    numControlPlanes: 1
     networkType: "OVNKubernetes"
     installConfigOverrides: "{\"controlPlane\":{\"hyperthreading\":\"Disabled\"}}"
     clusterLabels:
@@ -176,7 +176,7 @@ spec:
   clusters:
   - clusterName: "cluster1"
     clusterType: sno
-    numMasters: 1
+    numControlPlanes: 1
     installConfigOverrides: "{\"controlPlane\":{\"hyperthreading\":\"Disabled\"}}"
     clusterLabels:
       group-du-sno: ""

--- a/ztp/siteconfig-generator/siteConfig/siteConfig_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig_test.go
@@ -142,7 +142,7 @@ kind: SiteConfig
 spec:
   clusters:
   - clusterName: "ignore-user-supplied-values"
-    numMasters: 5
+    numControlPlanes: 5
     numWorkers: 22
     clusterType: "any value"
     nodes:
@@ -176,11 +176,11 @@ spec:
 	err := yaml.Unmarshal([]byte(input), &siteConfig)
 	assert.NoError(t, err)
 
-	// Validate NumMasters
-	assert.Equal(t, siteConfig.Spec.Clusters[0].NumMasters, uint8(1))
-	assert.Equal(t, siteConfig.Spec.Clusters[1].NumMasters, uint8(1))
-	assert.Equal(t, siteConfig.Spec.Clusters[2].NumMasters, uint8(3))
-	assert.Equal(t, siteConfig.Spec.Clusters[3].NumMasters, uint8(3))
+	// Validate NumControlPlanes
+	assert.Equal(t, siteConfig.Spec.Clusters[0].NumControlPlanes, uint8(1))
+	assert.Equal(t, siteConfig.Spec.Clusters[1].NumControlPlanes, uint8(1))
+	assert.Equal(t, siteConfig.Spec.Clusters[2].NumControlPlanes, uint8(3))
+	assert.Equal(t, siteConfig.Spec.Clusters[3].NumControlPlanes, uint8(3))
 
 	// Validate NumWorkers
 	assert.Equal(t, siteConfig.Spec.Clusters[0].NumWorkers, uint8(0))
@@ -204,8 +204,8 @@ spec:
     nodes:
 `
 	err = yaml.Unmarshal([]byte(badInput), &siteConfig)
-	assert.Error(t, err, "Expected an error with 0 masters defined")
-	assert.True(t, strings.Contains(err.Error(), "must be 1 or more"), "Expecting counted masters to match %d:", 0, err.Error())
+	assert.Error(t, err, "Expected an error with 0 control-planes defined")
+	assert.True(t, strings.Contains(err.Error(), "must be 1 or more"), "Expecting counted control-planes to match %d:", 0, err.Error())
 }
 
 func TestGetSiteConfigFieldValue(t *testing.T) {


### PR DESCRIPTION
In Kubernetes 1.24 (released in 2022), the label `node-role.kubernetes.io/master` was deprecated in favor of `node-role.kubernetes.io/control-plane`.

https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/#api-removals-deprecations-and-other-changes-for-kubernetes-1-24

I'm still keeping the check for `master` around for backwards compatibility, and also adding the check for `control-plane`.