### PR TITLE
Separate ZTP and CNF-Tests CI Jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ verify-commits:
 	hack/verify-commits.sh
 
 ci-job: verify-commits gofmt golint govet cnftests-unit
+	
+ztp-ci-job:
 	$(MAKE) -C ztp ci-job
 
 feature-deploy:


### PR DESCRIPTION
This commit modifies the Makefile, creating a distinct Makefile target for the ZTP CI job. This adjustment aims to prevent conflicts in case of issues on the ZTP side, effectively blocking merges for the CNF-Tests component.

Alongside this commit, we will introduce a new Prow job in the openshift/release repository. This job will activate the new target but exclude it for changes exclusive to CNF-Tests.

For the release repo part see: https://github.com/openshift/release/pull/47936
