### PR TITLE
ztp: Revert ZTP CI seperation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,6 @@ verify-commits:
 	hack/verify-commits.sh
 
 ci-job: verify-commits gofmt golint govet cnftests-unit
-	
-ztp-ci-job:
 	$(MAKE) -C ztp ci-job
 
 feature-deploy:


### PR DESCRIPTION
Because of delays merging the openshift/release PR to invoke the new ztp-ci lane,
this PR reverts the separation, so we won't miss breaking changes in ztp.

https://github.com/openshift/release/pull/47936