### PR TITLE
OCPBUGS-25794: cnf-tests: sriov-network-operator bump 4.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -187,7 +187,7 @@ replace (
 
 // Test deps
 replace (
-	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230905125821-ddb03cef1ca7 // release-4.14
+	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20231222003522-c6722c5beb44 // release-4.14
 	github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230905121931-593c75393b88 // release-4.14
 	github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b // release-4.10
 	github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc // release-4.9

--- a/go.sum
+++ b/go.sum
@@ -2902,8 +2902,8 @@ github.com/openshift/ptp-operator v0.0.0-20230831212656-4b8be2662cfe/go.mod h1:q
 github.com/openshift/runtime-utils v0.0.0-20220926190846-5c488b20a19f/go.mod h1:l9/qeKZuAmYUMl0yicJlbkPGDsIycGhwxOvOAWyaP0E=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b h1:NlOsWwZI4tYu6XbqG1/9jtg2I20+zs+8vy7d4X7ieZs=
 github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b/go.mod h1:ESuS9sfrzo0EpEHaHNEvjo1oThseBnGU5s+RT1psTRA=
-github.com/openshift/sriov-network-operator v0.0.0-20230905125821-ddb03cef1ca7 h1:AR3rSUHDIt89+apc57lP2RiVv0yM1vusqBMuiatgD1c=
-github.com/openshift/sriov-network-operator v0.0.0-20230905125821-ddb03cef1ca7/go.mod h1:iTLcGUWhk85IySPerBAGZ/jjFSp3FHuWnOT347us6hA=
+github.com/openshift/sriov-network-operator v0.0.0-20231222003522-c6722c5beb44 h1:XfAej12yDbOA7+SAC0zr8BO4ZVGQ3sABocWclrS0rp4=
+github.com/openshift/sriov-network-operator v0.0.0-20231222003522-c6722c5beb44/go.mod h1:el72tYP1ZWJKxdDrQ7JUdIX+ksoW5v2a9zXT7Cxzdvc=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster/cluster.go
+++ b/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster/cluster.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -33,6 +35,24 @@ var (
 	mlxVendorID        = "15b3"
 	intelVendorID      = "8086"
 )
+
+// Name of environment variable to filter which decives can be discovered by FindSriovDevices and FindOneSriovDevice.
+// The filter is a regexp matched against node names and device name in the form <node_name>:<device_name>
+//
+// For example, given the following devices in the cluster:
+//
+// worker-0:eno1
+// worker-0:eno2
+// worker-1:eno1
+// worker-1:eno2
+// worker-1:ens1f0
+// worker-1:ens1f1
+//
+// Values:
+// - `.*:eno1` matches `worker-0:eno1,worker-1:eno1`
+// - `worker-0:eno.*` matches `worker-0:eno1,worker-0:eno2`
+// - `worker-0:eno1|worker-1:eno2` matches `worker-0:eno1,worker-1:eno2`
+const NodeAndDeviceNameFilterEnvVar string = "SRIOV_NODE_AND_DEVICE_NAME_FILTER"
 
 // DiscoverSriov retrieves Sriov related information of a given cluster.
 func DiscoverSriov(clients *testclient.ClientSet, operatorNamespace string) (*EnabledNodes, error) {
@@ -90,35 +110,49 @@ func DiscoverSriov(clients *testclient.ClientSet, operatorNamespace string) (*En
 	return res, nil
 }
 
-// FindOneSriovDevice retrieves a valid sriov device for the given node.
+// FindOneSriovDevice retrieves a valid sriov device for the given node, filtered by `SRIOV_NODE_AND_DEVICE_NAME_FILTER` environment variable.
 func (n *EnabledNodes) FindOneSriovDevice(node string) (*sriovv1.InterfaceExt, error) {
-	s, ok := n.States[node]
-	if !ok {
-		return nil, fmt.Errorf("node %s not found", node)
+	ret, err := n.FindSriovDevices(node)
+	if err != nil {
+		return nil, err
 	}
-	for _, itf := range s.Status.Interfaces {
-		if IsPFDriverSupported(itf.Driver) && sriovv1.IsSupportedDevice(itf.DeviceID) {
-			// Skip mlx interfaces if secure boot is enabled
-			// TODO: remove this when mlx support secure boot/lockdown mode
-			if itf.Vendor == mlxVendorID && n.IsSecureBootEnabled[node] {
-				continue
-			}
 
-			// if the sriov is not enable in the kernel for intel nic the totalVF will be 0 so we skip the device
-			// That is not the case for Mellanox devices that will report 0 until we configure the sriov interfaces
-			// with the mstconfig package
-			if itf.Vendor == intelVendorID && itf.TotalVfs == 0 {
-				continue
-			}
-
-			return &itf, nil
-		}
+	if len(ret) == 0 {
+		return nil, fmt.Errorf("unable to find sriov devices in node %s", node)
 	}
-	return nil, fmt.Errorf("unable to find sriov devices in node %s", node)
+
+	return ret[0], nil
 }
 
-// FindSriovDevices retrieves all valid sriov devices for the given node.
+// FindSriovDevices retrieves all valid sriov devices for the given node, filtered by `SRIOV_NODE_AND_DEVICE_NAME_FILTER` environment variable.
 func (n *EnabledNodes) FindSriovDevices(node string) ([]*sriovv1.InterfaceExt, error) {
+	devices, err := n.FindSriovDevicesIgnoreFilters(node)
+	if err != nil {
+		return nil, err
+	}
+
+	sriovDeviceNameFilter, ok := os.LookupEnv(NodeAndDeviceNameFilterEnvVar)
+	if !ok {
+		return devices, nil
+	}
+
+	filteredDevices := []*sriovv1.InterfaceExt{}
+	for _, device := range devices {
+		match, err := regexp.MatchString(sriovDeviceNameFilter, node+":"+device.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		if match {
+			filteredDevices = append(filteredDevices, device)
+		}
+	}
+
+	return filteredDevices, nil
+}
+
+// FindSriovDevicesIgnoreFilters retrieves all valid sriov devices for the given node.
+func (n *EnabledNodes) FindSriovDevicesIgnoreFilters(node string) ([]*sriovv1.InterfaceExt, error) {
 	devices := []*sriovv1.InterfaceExt{}
 	s, ok := n.States[node]
 	if !ok {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -225,7 +225,7 @@ github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/client/clientset/version
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1
-# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20230905125821-ddb03cef1ca7
+# github.com/k8snetworkplumbingwg/sriov-network-operator v0.0.0-00010101000000-000000000000 => github.com/openshift/sriov-network-operator v0.0.0-20231222003522-c6722c5beb44
 ## explicit; go 1.20
 github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
 github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/scheme
@@ -1269,7 +1269,7 @@ sigs.k8s.io/yaml
 # github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.46.0
 # github.com/test-network-function/l2discovery-lib => github.com/test-network-function/l2discovery-lib v0.0.5
 # sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.15.2
-# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20230905125821-ddb03cef1ca7
+# github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20231222003522-c6722c5beb44
 # github.com/metallb/metallb-operator => github.com/openshift/metallb-operator v0.0.0-20230905121931-593c75393b88
 # github.com/openshift-psap/special-resource-operator => github.com/openshift/special-resource-operator v0.0.0-20211202035230-4c86f99c426b
 # github.com/openshift/cluster-nfd-operator => github.com/openshift/cluster-nfd-operator v0.0.0-20210727033955-e8e9697b5ffc


### PR DESCRIPTION
SR-IOV Network Operator dependency bumped with commands:

```
go mod download github.com/openshift/sriov-network-operator@release-4.14
go mod edit -replace \
github.com/k8snetworkplumbingwg/sriov-network-operator=\
github.com/openshift/sriov-network-operator@release-4.14
go mod tidy
go mod vendor
```