### PR TITLE
cnf-tests: Deprecate k8s.io/utils pointer function

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
@@ -585,7 +585,7 @@ sleep INF
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
 
-				err = client.Client.Pods(namespaces.DpdkTest).Delete(context.Background(), pod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64Ptr(0)})
+				err = client.Client.Pods(namespaces.DpdkTest).Delete(context.Background(), pod.Name, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)})
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() error {

--- a/cnf-tests/testsuites/e2esuite/vrf/vrf.go
+++ b/cnf-tests/testsuites/e2esuite/vrf/vrf.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/pods"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -242,7 +242,7 @@ func testVRFScenario(apiclient *client.ClientSet, namespace string, nodeName str
 	By("Run client/server ICMP connectivity tests")
 	assertIPIsReachableViaVRF(apiclient, podClient, VRFBlueName, podServerFirstVRFNetworkIPAddress)
 
-	err := apiclient.Pods(namespace).Delete(context.Background(), podServer.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64Ptr(0)})
+	err := apiclient.Pods(namespace).Delete(context.Background(), podServer.Name, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)})
 	Expect(err).ToNot(HaveOccurred())
 	Eventually(func() error {
 		_, err := apiclient.Pods(namespace).Get(context.Background(), podServer.Name, metav1.GetOptions{})

--- a/cnf-tests/testsuites/pkg/namespaces/namespaces.go
+++ b/cnf-tests/testsuites/pkg/namespaces/namespaces.go
@@ -13,7 +13,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	testclient "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/client"
 )
@@ -175,7 +175,7 @@ func Clean(namespace string, prefix string, cs *testclient.ClientSet) error {
 	for _, p := range policies.Items {
 		if strings.HasPrefix(p.Name, prefix) {
 			err = cs.NetworkPolicies(namespace).Delete(context.Background(), p.Name, metav1.DeleteOptions{
-				GracePeriodSeconds: pointer.Int64Ptr(0),
+				GracePeriodSeconds: ptr.To[int64](0),
 			})
 			if err != nil && !k8serrors.IsNotFound(err) {
 				return err
@@ -190,7 +190,7 @@ func Clean(namespace string, prefix string, cs *testclient.ClientSet) error {
 	for _, pod := range pods.Items {
 		if strings.HasPrefix(pod.Name, prefix) {
 			err = cs.Pods(namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{
-				GracePeriodSeconds: pointer.Int64Ptr(0),
+				GracePeriodSeconds: ptr.To[int64](0),
 			})
 			if err != nil && !k8serrors.IsNotFound(err) {
 				return err
@@ -207,7 +207,7 @@ func Clean(namespace string, prefix string, cs *testclient.ClientSet) error {
 		if strings.HasPrefix(s.Name, prefix) {
 
 			err = cs.Services(namespace).Delete(context.Background(), s.Name, metav1.DeleteOptions{
-				GracePeriodSeconds: pointer.Int64Ptr(0)})
+				GracePeriodSeconds: ptr.To[int64](0)})
 			if err != nil && k8serrors.IsNotFound(err) {
 				continue
 			}
@@ -236,7 +236,7 @@ func CleanPods(namespace string, cs NamespacesAndPods) {
 		return
 	}
 	err := cs.Pods(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{
-		GracePeriodSeconds: pointer.Int64Ptr(0),
+		GracePeriodSeconds: ptr.To[int64](0),
 	}, metav1.ListOptions{})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/cnf-tests/testsuites/pkg/pods/pods.go
+++ b/cnf-tests/testsuites/pkg/pods/pods.go
@@ -26,6 +26,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func getDefinition(namespace string) *corev1.Pod {
@@ -34,7 +35,7 @@ func getDefinition(namespace string) *corev1.Pod {
 			GenerateName: "testpod-",
 			Namespace:    namespace},
 		Spec: corev1.PodSpec{
-			TerminationGracePeriodSeconds: pointer.Int64Ptr(0),
+			TerminationGracePeriodSeconds: ptr.To[int64](0),
 			Containers: []corev1.Container{{Name: "test",
 				Image:   images.For(images.TestUtils),
 				Command: []string{"/bin/bash", "-c", "sleep INF"}}}}}
@@ -129,12 +130,12 @@ func RedefineWithPodAffinityOnLabel(pod *corev1.Pod, key, value string) *corev1.
 func RedefineWithRestrictedPrivileges(pod *corev1.Pod) *corev1.Pod {
 	pod.Spec.SecurityContext = &corev1.PodSecurityContext{
 		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-		FSGroup:        pointer.Int64Ptr(1001),
+		FSGroup:        ptr.To[int64](1001),
 	}
 	for i := range pod.Spec.Containers {
 		pod.Spec.Containers[i].SecurityContext.RunAsNonRoot = pointer.BoolPtr(true)
-		pod.Spec.Containers[i].SecurityContext.RunAsUser = pointer.Int64Ptr(1001)
-		pod.Spec.Containers[i].SecurityContext.RunAsGroup = pointer.Int64Ptr(1001)
+		pod.Spec.Containers[i].SecurityContext.RunAsUser = ptr.To[int64](1001)
+		pod.Spec.Containers[i].SecurityContext.RunAsGroup = ptr.To[int64](1001)
 		pod.Spec.Containers[i].SecurityContext.Privileged = pointer.BoolPtr(false)
 		pod.Spec.Containers[i].SecurityContext.Capabilities.Drop = []corev1.Capability{"ALL"}
 
@@ -213,7 +214,7 @@ sleep INF`}, []string{},
 	pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: "hugepages", MountPath: "/dev/hugepages"}}
 
 	// Security context capabilities
-	pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{RunAsUser: pointer.Int64Ptr(0),
+	pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{RunAsUser: ptr.To[int64](0),
 		Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"IPC_LOCK"}}}
 
 	// Hugepages volume
@@ -249,7 +250,7 @@ func DefineDPDKWorkload(nodeSelector map[string]string, command string, image st
 			command,
 		},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: pointer.Int64Ptr(0),
+			RunAsUser: ptr.To[int64](0),
 			Capabilities: &corev1.Capabilities{
 				Add: capabilities,
 			},


### PR DESCRIPTION
Doc: https://pkg.go.dev/k8s.io/utils@v0.0.0-20240102154912-e7106e64919e/pointer

`k8s.io/utils/pointer` has been deprecated and replaced with `k8s.io/utils/ptr`.

Bonus: `ztp/tools/policy-object-template-diff/main.go` was adjusted by `go fmt`.