### PR TITLE
ztp: Bump ignition testdata version from `3.2.0` to `3.4.0`

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -738,7 +738,7 @@ func Test_ExtraManifestSearchPath(t *testing.T) {
 
 	// check for the user extra manifest added
 	crNameOriginal := "predefined-mc-master"
-	versionOriginal := "3.2.0"
+	versionOriginal := "3.4.0"
 	crNameOverridden := "override-extra-manifest-module"
 	versionOverridden := "2.2.0"
 

--- a/ztp/siteconfig-generator/siteConfig/siteConfigHelper_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigHelper_test.go
@@ -20,7 +20,7 @@ func Test_mergeExtraManifests(t *testing.T) {
   spec:
     config:
       ignition:
-        version: 3.2.0
+        version: 3.4.0
       storage:
         files:
         - contents:
@@ -37,7 +37,7 @@ func Test_mergeExtraManifests(t *testing.T) {
   spec:
     config:
       ignition:
-        version: 3.2.0
+        version: 3.4.0
       storage:
         files:
         - contents:
@@ -54,7 +54,7 @@ func Test_mergeExtraManifests(t *testing.T) {
   spec:
     config:
       ignition:
-        version: 3.2.0
+        version: 3.4.0
       storage:
         files:
         - contents:
@@ -92,7 +92,7 @@ test.yaml: |
   spec:
     config:
       ignition:
-        version: 3.2.0
+        version: 3.4.0
       storage:
         files:
         - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/mergeMC.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/mergeMC.yaml
@@ -101,7 +101,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -262,7 +262,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/splitMC.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/splitMC.yaml
@@ -101,7 +101,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -175,7 +175,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -301,7 +301,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -387,7 +387,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -473,7 +473,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 systemd:
                     units:
                         - enabled: true
@@ -492,7 +492,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 systemd:
                     units:
                         - enabled: true

--- a/ztp/siteconfig-generator/siteConfig/testdata/extra-manifest/01-predefined-mc-master.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/extra-manifest/01-predefined-mc-master.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       files:
       - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/extra-manifest/01-predefined-mc-worker.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/extra-manifest/01-predefined-mc-worker.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       files:
       - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/extra-manifest/image-registry-partition-mc.yaml.tmpl
+++ b/ztp/siteconfig-generator/siteConfig/testdata/extra-manifest/image-registry-partition-mc.yaml.tmpl
@@ -9,7 +9,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       disks:
       {{- range .DiskPartition }}

--- a/ztp/siteconfig-generator/siteConfig/testdata/extra-manifest/workload/03-workload-partitioning.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/extra-manifest/workload/03-workload-partitioning.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       files:
       - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/partialfilter.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/partialfilter.yaml
@@ -101,7 +101,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -131,7 +131,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningDeprecatedTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningDeprecatedTestOutput.yaml
@@ -123,7 +123,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -153,7 +153,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -183,7 +183,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningNewTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningNewTestOutput.yaml
@@ -122,7 +122,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -152,7 +152,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigDualStackStandardClusterTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigDualStackStandardClusterTestOutput.yaml
@@ -208,7 +208,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -240,7 +240,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterTestOutput.yaml
@@ -267,7 +267,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -299,7 +299,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
@@ -163,7 +163,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -192,7 +192,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     disks:
                         - device: /dev/sda
@@ -229,7 +229,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -261,7 +261,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigV2TestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigV2TestOutput.yaml
@@ -163,7 +163,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -192,7 +192,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     disks:
                         - device: /dev/sda
@@ -229,7 +229,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:
@@ -261,7 +261,7 @@ data:
         spec:
             config:
                 ignition:
-                    version: 3.2.0
+                    version: 3.4.0
                 storage:
                     files:
                         - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/01-container-mount-ns-and-kubelet-conf-master.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/01-container-mount-ns-and-kubelet-conf-master.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       files:
       - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/01-container-mount-ns-and-kubelet-conf-worker.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/01-container-mount-ns-and-kubelet-conf-worker.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       files:
       - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/04-accelerated-container-startup-master.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/04-accelerated-container-startup-master.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       files:
       - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/04-accelerated-container-startup-worker.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/04-accelerated-container-startup-worker.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       files:
       - contents:

--- a/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/06-kdump-master.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/06-kdump-master.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     systemd:
       units:
       - enabled: true

--- a/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/06-kdump-worker.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/06-kdump-worker.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     systemd:
       units:
       - enabled: true

--- a/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/disk-encryption.yaml.tmpl
+++ b/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/disk-encryption.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       luks:
         - name: root

--- a/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/image-registry-partition-mc.yaml.tmpl
+++ b/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/image-registry-partition-mc.yaml.tmpl
@@ -11,7 +11,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       disks:
       {{- range .DiskPartition }}

--- a/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/workload/03-workload-partitioning.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/source-cr-extra-manifest-copy/workload/03-workload-partitioning.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       files:
       - contents:


### PR DESCRIPTION
This version bump in the test cases is needed because the machine-config-operator version bumped the coreos/ignition depededency.

Fixes `ci/prow/ztp-ci`

refs:
- https://github.com/openshift/machine-config-operator/commit/79286c5dbd07169eb93a66e7d8f196cb81a7636d

/cc @jzding 