### PR TITLE
ztp: OCPBUGS-25820: Include SiteConfig error in SiteConfig Content

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfigHelper.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigHelper.go
@@ -443,3 +443,18 @@ func suppressCrGeneration(kind string, crSuppression []string) bool {
 	}
 	return false
 }
+
+// PrintSiteConfigError function prints the SiteConfig with associated error to std output.
+func PrintSiteConfigError(fileData []byte, errorMsg string) {
+	log.Print(errorMsg)
+
+	// Build the error status.
+	errorStatus := fmt.Sprintf("\nsiteConfigError: \"%s\"", errorMsg)
+
+	// Concatenate the SiteConfig file with the error status.
+	fileDataWithError := fmt.Sprintf(strings.TrimRight(string(fileData), "\n ") + errorStatus)
+
+	// Print the final SiteConfig.
+	fmt.Println(string(Separator))
+	fmt.Println(string(fileDataWithError))
+}


### PR DESCRIPTION
Description:
- When there is an error in SiteConfig, add the error as a field in the SiteConfig that's printed out.
Example:
```
apiVersion: ran.openshift.io/v1
kind: SiteConfig
metadata:
    labels:
        app.kubernetes.io/instance: clusters
    name: mgmt-spoke1
    namespace: mgmt-spoke1
siteConfigError: >-Error: could not build the entire SiteConfig defined by/tmp/kust-plugin-config-2679372: stat custom-manifests/: no such file or directory spec: ...
```
- Include a new parameter to the siteconfig-generator utility, stopOnError. When this field is set to true, the siteconfig-generator completely halts and does not continue if an error is detected. If the field is set to false, the siteconfig-generator prints the SiteConfig with the error included and then continues to processing the next SiteConfig file. stopOnError defaults to false.