### PR TITLE
[release-4.14] ztp: OCPBUGS-30886: Include SiteConfig error in SiteConfig Content

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfigHelper.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigHelper.go
@@ -433,3 +433,18 @@ func transformNodeLabelAnnotation(bmhCR map[string]interface{}) map[string]inter
 
 	return bmhCR
 }
+
+// PrintSiteConfigError function prints the SiteConfig with associated error to std output.
+func PrintSiteConfigError(fileData []byte, errorMsg string) {
+	log.Print(errorMsg)
+
+	// Build the error status.
+	errorStatus := fmt.Sprintf("\nsiteConfigError: \"%s\"", errorMsg)
+
+	// Concatenate the SiteConfig file with the error status.
+	fileDataWithError := fmt.Sprintf(strings.TrimRight(string(fileData), "\n ") + errorStatus)
+
+	// Print the final SiteConfig.
+	fmt.Println(string(Separator))
+	fmt.Println(string(fileDataWithError))
+}


### PR DESCRIPTION
This is a manual cherry-pick of #1818

Description:
- When there is an error in SiteConfig, add the error as a field in the SiteConfig that's printed out.
- Include a new parameter to the siteconfig-generator utility, stopOnError. When this field is set to true, the siteconfig-generator completely halts and does not continue if an error is detected. If the field is set to false, the siteconfig-generator prints the SiteConfig with the error included and then continues to processing the next SiteConfig file. stopOnError defaults to false.