### PR TITLE
cnf-tests: Add podman logs when build index fails

### DIFF
--- a/hack/setup-build-index-image.sh
+++ b/hack/setup-build-index-image.sh
@@ -143,6 +143,7 @@ if [[ $success -eq 1 ]]; then
   echo "[INFO] index build succeeded"
 else
   echo "[ERROR] index build failed"
+  ${OC_TOOL} -n openshift-marketplace get pod podman | tail
   exit 1
 fi
 


### PR DESCRIPTION
This commit modifies the setup-build-index-image.sh script to print the logs of the podman pod when it fails. This to provide clarity as to why the pods failed to move toe the succeeded phase.