### PR TITLE
cnf-tests: Print podman logs before the check

### DIFF
--- a/hack/setup-build-index-image.sh
+++ b/hack/setup-build-index-image.sh
@@ -139,15 +139,15 @@ do
    sleep $sleep_time
 done
 
+# print the build logs
+${OC_TOOL} -n openshift-marketplace logs podman
+
 if [[ $success -eq 1 ]]; then
   echo "[INFO] index build succeeded"
 else
   echo "[ERROR] index build failed"
   exit 1
 fi
-
-# print the build logs
-${OC_TOOL} -n openshift-marketplace logs podman
 
 #Note: adding a CI index image
 cat <<EOF | ${OC_TOOL} apply -f -


### PR DESCRIPTION
This commit modifies the setup-build-index-image.sh script to print the logs of the Podman pod before checking if the index build succeeded. This improvement enhances debuggability because, currently, if the build fails, it does not display the logs, forcing us to consult the must-gather report.