### PR TITLE
infra: Create `SriovOperatorConfig` while deploying

### DIFF
--- a/feature-configs/deploy/sriov/04-sriov-operator-config.yaml
+++ b/feature-configs/deploy/sriov/04-sriov-operator-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: openshift-sriov-network-operator
+spec:
+  enableInjector: true
+  enableOperatorWebhook: true
+  logLevel: 2
+  disableDrain: false

--- a/feature-configs/deploy/sriov/kustomization.yaml
+++ b/feature-configs/deploy/sriov/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - 01-sriov-namespace.yaml
   - 02-sriov-operatorgroup.yaml
   - 03-sriov-subscription.yaml
+  - 04-sriov-operator-config.yaml


### PR DESCRIPTION
To align CI to PR
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/617

an `SriovOperatorConfig/default` needs to be created to make the SR-IOV network operator start working.