### PR TITLE
ztp: OCPBUGS-27893: OperatorHub.yaml is missing from the ztp source-crs

### DIFF
--- a/ztp/gitops-subscriptions/argocd/README.md
+++ b/ztp/gitops-subscriptions/argocd/README.md
@@ -126,7 +126,8 @@ EOF
    4. Commit your SiteConfig and associated kustomization.yaml in git.
 3. Create the PolicyGenTemplate CR for your site in your local clone of the git repository:
    1. Begin by choosing an appropriate example from out/argocd/example/policygentemplates. This directory demonstrates a 3-level policy framework which represents a well-supported low-latency profile tuned for the needs of 5G Telco DU deployments:
-      - A single `common-ranGen.yaml` that should apply to all types of sites
+      - A single `common-ranGen.yaml` should be applied to SNO, and do not use `common-mno-ranGen.yaml` file for SNO clusters.
+      - For MNO clusters, it will require both `common-ranGen.yaml` and `common-mno-ranGen.yaml` file.
       - A set of shared `group-du-*-ranGen.yaml`, each of which should be common across a set of similar clusters
       - An example `example-*-site.yaml` which will normally be copied and updated for each individual site
    2. Ensure the labels defined in your PGTs `bindingRules` section correspond to the proper labels defined on the SiteConfig file(s) of the clusters you are managing.

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-mno-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-mno-ranGen.yaml
@@ -1,0 +1,17 @@
+# For MNO(multi node cluster), both common-ranGen.yaml and common-mno-ranGen.yaml needs to be applied
+# For SNO, please avoid adding common-mno-ranGen.yaml
+---
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "common-mno-latest"
+  namespace: "ztp-common"
+spec:
+  bindingRules:
+    # These policies will correspond to all clusters with this label:
+    common: "true"
+    du-profile: "latest"
+  sourceFiles:
+      # Create operators policies that will be installed in all clusters
+    - fileName: OperatorHub.yaml
+      policyName: "config-policy"

--- a/ztp/policygenerator-kustomize-plugin/kustomization.yaml
+++ b/ztp/policygenerator-kustomize-plugin/kustomization.yaml
@@ -1,5 +1,6 @@
 generators:
 - testPolicyGenTemplate/common-ranGen.yaml
+- testPolicyGenTemplate/common-mno-ranGen.yaml
 - testPolicyGenTemplate/group-du-ranGen.yaml
 - testPolicyGenTemplate/group-du-sno-ranGen.yaml
 - testPolicyGenTemplate/site-du-sno-ranGen.yaml

--- a/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/common-mno-ranGen.yaml
+++ b/ztp/policygenerator-kustomize-plugin/testPolicyGenTemplate/common-mno-ranGen.yaml
@@ -1,0 +1,18 @@
+# For MNO(multi node cluster), both common-ranGen.yaml and common-mno-ranGen.yaml needs to be applied
+# For SNO, please avoid adding common-mno-ranGen.yaml
+---
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "common-mno"
+  namespace: "common-policies"
+spec:
+  bindingRules:
+    common: "true"
+  evaluationInterval:
+    compliant: 20m
+    noncompliant: 20s
+  sourceFiles:
+      # Create operators policies that will be installed in all clusters
+    - fileName: OperatorHub.yaml
+      policyName: "config-policy"

--- a/ztp/source-crs/OperatorHub.yaml
+++ b/ztp/source-crs/OperatorHub.yaml
@@ -1,0 +1,8 @@
+apiVersion: config.openshift.io/v1
+kind: OperatorHub
+metadata:
+    name: cluster
+    annotations:
+        ran.openshift.io/ztp-deploy-wave: "1"
+spec:
+    disableAllDefaultSources: true


### PR DESCRIPTION
**Context:**
In 4.15 release, we removed [Openshift-market place operator](https://github.com/openshift-kni/cnf-features-deploy/commit/e21269dfa9915b195a79619ff23f1caeff1d95cb), which is not needed for SNO if a customer is manager its own catalog source. But, for MNO clusters will still require openshift-market place capability

**What changed?**

- Added a common-mno-ranGen.yaml file targeting MNO cluster
- OperatorHub.yaml file added back, and this is only require for MNO cluster

/assign @lack @imiller0 