### PR TITLE
cnf-tests: Ginkgo version mismatch

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -28,7 +28,7 @@ RUN mkdir ~/bin && \
     eval "$(gimme $GOVERSION)" && \
     cat $GIMME_ENV >> $HOME/.bashrc && \
     # get required golang tools and OC client
-    go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.4 && \
+    go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0 && \
     go install golang.org/x/lint/golint@latest && \
     go install github.com/lack/mcmaker@v0.0.6 && \
     export latest_oc_client_version=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ 2>/dev/null | grep -o \"openshift-client-linux-4.*tar.gz\" | tr -d \") && \


### PR DESCRIPTION
The version of `ginkgo` installed in the image is mismatched with the version found in the go.mod, last updated in https://github.com/openshift-kni/cnf-features-deploy/pull/1793