### PR TITLE
OCPBUGS-29706: PtpConfigSlave.yaml and PtpConfigSlaveCvl.yaml are identical

### DIFF
--- a/ztp/source-crs/PtpConfigSlaveCvl.yaml
+++ b/ztp/source-crs/PtpConfigSlaveCvl.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-ptp
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"
+    ran.openshift.io/deprecation-warning: "source-cr PtpConfigSlaveCvl.yaml is deprecated, please use PtpConfigSlave.yaml instead"
 spec:
   profile:
   - name: "slave"


### PR DESCRIPTION
This PR adds deprecated message to PtpConfigSlaveCvl.yaml file since   PtpConfigSlave.yaml and PtpConfigSlaveCvl.yaml are identical.