### PR TITLE
Retry BeforeAll when initial setup fails

### DIFF
--- a/cnf-tests/testsuites/pkg/execute/ginkgo.go
+++ b/cnf-tests/testsuites/pkg/execute/ginkgo.go
@@ -8,8 +8,8 @@ func BeforeAll(fn func()) {
 	first := true
 	ginkgo.BeforeEach(func() {
 		if first {
-			first = false
 			fn()
+			first = false
 		}
 	})
 }


### PR DESCRIPTION
When the BeforeEach inside BeforeAll fails with a Ginkgo exception, subsequent tests (or retries of the first test) fail because the initial setup (code inside this BeforeEach) has not being executed. This change forces the BeforeEach to run again in case of failure.