### PR TITLE
OCPBUGS-31496: ztp: start chrony after network online

### DIFF
--- a/ztp/extra-manifests-builder/99-sync-time-once/build.sh
+++ b/ztp/extra-manifests-builder/99-sync-time-once/build.sh
@@ -19,7 +19,8 @@ spec:
         - contents: |
             [Unit]
             Description=Sync time once
-            After=network.service
+            After=network-online.target
+            Wants=network-online.target
             [Service]
             Type=oneshot
             TimeoutStartSec=${SYNC_ATTEMPT_TIMEOUT_SEC}

--- a/ztp/source-crs/extra-manifest/99-sync-time-once-master.yaml
+++ b/ztp/source-crs/extra-manifest/99-sync-time-once-master.yaml
@@ -15,7 +15,8 @@ spec:
         - contents: |
             [Unit]
             Description=Sync time once
-            After=network.service
+            After=network-online.target
+            Wants=network-online.target
             [Service]
             Type=oneshot
             TimeoutStartSec=300

--- a/ztp/source-crs/extra-manifest/99-sync-time-once-worker.yaml
+++ b/ztp/source-crs/extra-manifest/99-sync-time-once-worker.yaml
@@ -15,7 +15,8 @@ spec:
         - contents: |
             [Unit]
             Description=Sync time once
-            After=network.service
+            After=network-online.target
+            Wants=network-online.target
             [Service]
             Type=oneshot
             TimeoutStartSec=300


### PR DESCRIPTION
This commit fixes a bug where a single-shot chronyd service starts too early, before the network is fully online, and fails on timeout.
/cc @sabbir-47 @lack 