### PR TITLE
ztp: CNF-11960: remove kernel timer migration

### DIFF
--- a/ztp/source-crs/TunedPerformancePatch.yaml
+++ b/ztp/source-crs/TunedPerformancePatch.yaml
@@ -17,8 +17,6 @@ spec:
         [main]
         summary=Configuration changes profile inherited from performance created tuned
         include=openshift-node-performance-openshift-node-performance-profile
-        [sysctl]
-        kernel.timer_migration=1
         [scheduler]
         group.ice-ptp=0:f:10:*:ice-ptp.*
         group.ice-gnss=0:f:10:*:ice-gnss.*


### PR DESCRIPTION
 For DU-profile, realTime workloadHint is set to true. When it is set to true, from the NTO operator side [kernel](https://github.com/openshift/cluster-node-tuning-operator/blob/master/assets/performanceprofile/tuned/openshift-node-performance#L73-L86) migration timer is already set. Therefore removing the redundant sysctl directive.