### PR TITLE
ztp: CNF-10965: Remove cgroups v1 enablement

### DIFF
--- a/ztp/source-crs/extra-manifest/enable-cgroups-v1.yaml
+++ b/ztp/source-crs/extra-manifest/enable-cgroups-v1.yaml
@@ -1,6 +1,0 @@
-apiVersion: config.openshift.io/v1
-kind: Node
-metadata:
-  name: cluster
-spec:
-  cgroupMode: "v1"


### PR DESCRIPTION
Installations will have cgroups v2 enabled as the openshift default.

Performance profile no longer sets the cluster to cgroups v1 for 4.16 and above , see https://github.com/openshift/cluster-node-tuning-operator/pull/1010 .

Reverts https://github.com/openshift-kni/cnf-features-deploy/pull/1763 .