### PR TITLE
ztp: cnf-7840: Allow ClusterImageSet to be synced

### DIFF
--- a/ztp/gitops-subscriptions/argocd/deployment/app-project.yaml
+++ b/ztp/gitops-subscriptions/argocd/deployment/app-project.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-gitops
 spec:
   clusterResourceWhitelist:
+  - group: 'hive.openshift.io'
+    kind: ClusterImageSet
   - group: 'cluster.open-cluster-management.io'
     kind: ManagedCluster
   - group: ''


### PR DESCRIPTION
Allow the ztp-app-project AppProject to be able to sync ClusterImageSet CRs from git onto the hub cluster.
The ClusterImageSet is a cluster wide CR so we add its Group and Kind to the ClusterResourceWhitelist.