### PR TITLE
ztp: OCPBUGS-32039: Siteconfig blocks MNO cluster deployment for more or less than 3 master nodes

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfig.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig.go
@@ -276,8 +276,8 @@ func (rv *Clusters) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			rv.NumWorkers += 1
 		}
 	}
-	if rv.NumMasters != 1 && rv.NumMasters != 3 {
-		return fmt.Errorf("Number of masters (counted %d) must be exactly 1 or 3", rv.NumMasters)
+	if rv.NumMasters < 1 {
+		return fmt.Errorf("Number of masters (counted %d) must be 1 or more", rv.NumMasters)
 	}
 	// Autodetect ClusterType based on the node counts and fix number of workers to 0 for sno.
 	// The latter prevents AgentClusterInstall from being mutated upon SNO expansion

--- a/ztp/siteconfig-generator/siteConfig/siteConfig_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfig_test.go
@@ -194,9 +194,8 @@ spec:
 	assert.Equal(t, siteConfig.Spec.Clusters[2].ClusterType, "standard")
 	assert.Equal(t, siteConfig.Spec.Clusters[3].ClusterType, "standard")
 
-	// Failure cases: Wrong number of masters
-	for _, i := range []int{0, 2, 4, 5, 10, 100} {
-		badInput := `
+	// Failure cases: Wrong number of masters(0)
+	badInput := `
 apiVersion: ran.openshift.io/v1
 kind: SiteConfig
 spec:
@@ -204,13 +203,9 @@ spec:
   - clusterName: "ignore-user-supplied-numbers"
     nodes:
 `
-		for j := 0; j < i; j++ {
-			badInput = badInput + fmt.Sprintf("\n    - hostName: \"node%d\"", j)
-		}
-		err := yaml.Unmarshal([]byte(badInput), &siteConfig)
-		assert.Error(t, err, "Expected an error with %d masters defined", i)
-		assert.True(t, strings.Contains(err.Error(), fmt.Sprintf("(counted %d)", i)), "Expecting counted masters to match %d: %s", i, err.Error())
-	}
+	err = yaml.Unmarshal([]byte(badInput), &siteConfig)
+	assert.Error(t, err, "Expected an error with 0 masters defined")
+	assert.True(t, strings.Contains(err.Error(), "must be 1 or more"), "Expecting counted masters to match %d:", 0, err.Error())
 }
 
 func TestGetSiteConfigFieldValue(t *testing.T) {
@@ -586,7 +581,7 @@ spec:
 `
 	siteConfig := SiteConfig{}
 	err := yaml.Unmarshal([]byte(siteConfigStr), &siteConfig)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t,
 		siteConfig.Spec.Clusters[0].Proxy,
 		Proxy{


### PR DESCRIPTION
- checking the number of master node to be greater than 1
- otherwise it blocks replacing faulty master nodes where master nodes can be less than 3 and for high availability case when it is more than 3 nodes.