### PR TITLE
ztp: Add IBU platform OADP backup and restore CRs for LVMS

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/README.md
+++ b/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/README.md
@@ -45,6 +45,9 @@ generatorOptions:
   disableNameSuffixHash: true
 ```
 
+Note that an optional [`source-crs/ibu/PlatformBackupRestoreLvms.yaml`](https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/source-crs/ibu/PlatformBackupRestoreLvms.yaml) is provided for
+use cases when the LVMS is configured in the cluster as the storage solution.
+
 Ensure that the `custom-oadp-workload-crs.yaml` file includes a one-to-one mapping of OADP backup and restore CRs. It's important to note that these CRs can be stored either in separate YAML manifests or consolidated within a single YAML file (as shown below), with each CR section separated by the `---` directive.
 
 ```yaml

--- a/ztp/source-crs/ibu/PlatformBackupRestoreLvms.yaml
+++ b/ztp/source-crs/ibu/PlatformBackupRestoreLvms.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: lvmcluster
+  namespace: openshift-adp
+  labels:
+    velero.io/storage-location: default
+spec:
+  includedNamespaces:
+  - openshift-storage
+  includedNamespaceScopedResources:
+  - lvmclusters
+  - lvmvolumegroups
+  - lvmvolumegroupnodestatuses
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: lvmcluster
+  namespace: openshift-adp
+  labels:
+    velero.io/storage-location: default
+  annotations:
+    lca.openshift.io/apply-wave: "2"
+spec:
+  backupName:
+    lvmcluster
+
+# For a sample Backup and Restore CRs for an user's app, you will find more info in IBU docs at the below link:
+# https://github.com/openshift-kni/lifecycle-agent/blob/main/docs/backuprestore-with-oadp.md#11-backup-resource-when-lvms-is-used


### PR DESCRIPTION
When LVMS is configured as the storage solution in the cluster, IBU will need to backup and restore the corresponding objects in order to properly preserve the PV's contents after pivoting. 

/cc @browsell @Missxiaoguo @sakhoury @sabbir-47 

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>