### PR TITLE
CNF-12277: chore: move LVMS to mgmt cores

### DIFF
--- a/ztp/source-crs/StorageLVMSubscriptionNS.yaml
+++ b/ztp/source-crs/StorageLVMSubscriptionNS.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: openshift-storage
   labels:
+    workload.openshift.io/allowed: "management"
     openshift.io/cluster-monitoring: "true"
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"


### PR DESCRIPTION
This adds a namespace annotation so that the LVMS workloads will be scheduled into the management core set instead of the isolated cores.