### PR TITLE
OCPBUGS-33299:ztp: fix GM clock type

### DIFF
--- a/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
@@ -209,7 +209,7 @@ spec:
       #
       # Default interface options
       #
-      clock_type BC
+      clock_type OC
       network_transport L2
       delay_mechanism E2E
       time_stamping hardware

--- a/ztp/source-crs/PtpConfigGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigGmWpc.yaml
@@ -189,7 +189,7 @@ spec:
       #
       # Default interface options
       #
-      clock_type BC
+      clock_type OC
       network_transport L2
       delay_mechanism E2E
       time_stamping hardware


### PR DESCRIPTION
This commit sets the clock type in the GM reference configuration to OC as per IEEE1588