### PR TITLE
ztp: Fix fips=true tag in siteconfig-generator test code

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfigHelper_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigHelper_test.go
@@ -188,8 +188,8 @@ func Test_agentClusterInstallAnnotation(t *testing.T) {
 
 		{
 			networkType:           "OVNKubernetes",
-			installConfigOverride: "{\"controlPlane\":{\"hyperthreading\":\"Disabled\"},\"fips\":\"true\"}",
-			expected:              "{\"networking\":{\"networkType\":\"OVNKubernetes\"},\"controlPlane\":{\"hyperthreading\":\"Disabled\"},\"fips\":\"true\"}",
+			installConfigOverride: "{\"controlPlane\":{\"hyperthreading\":\"Disabled\"},\"fips\":true}",
+			expected:              "{\"networking\":{\"networkType\":\"OVNKubernetes\"},\"controlPlane\":{\"hyperthreading\":\"Disabled\"},\"fips\":true}",
 			error:                 nil,
 			name:                  "Multiple json object set at installConfigOverride",
 		},


### PR DESCRIPTION
Enabling fips in site-config requires setting fips=true as a boolean in the installConfigOverrides, which means no quotes around the `true`. Having it quoted means it is read as a string and fails to install.

This update has no functional change, it just fixes the test case that includes fips in the installConfigOverrides string, removing the quotes around `true`.