### PR TITLE
OCPBUGS-33573: ztp: IPsec: configure local gateway mode

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/optional-extra-manifest/ipsec/enable-ipsec.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/optional-extra-manifest/ipsec/enable-ipsec.yaml
@@ -7,3 +7,5 @@ spec:
     ovnKubernetesConfig:
       ipsecConfig:
         mode: External
+      gatewayConfig:
+        routingViaHost: true


### PR DESCRIPTION
For IPsec support for encrypting traffic to external hosts OVN-Kubernetes network plugin must be configured in local gateway mode