### PR TITLE
ztp: CNF-11904: Update kustomize version dynamically

### DIFF
--- a/ztp/gitops-subscriptions/Makefile
+++ b/ztp/gitops-subscriptions/Makefile
@@ -2,13 +2,20 @@
 export KUSTOMIZE_PLUGIN_HOME=$(PWD)/.config/kustomize/plugin
 export XDG_CONFIG_HOME=$(KUSTOMIZE_PLUGIN_HOME)
 
+# KEEP THIS UP TO DATE (UNTIL IT WILL BE AUTOMATICALLY DETERMINED)
+OCP_VERSION=4.16
+
 ACM_POLICYGEN_EX_DIR=./argocd/example/acmpolicygenerator
 ACM_POLICYGEN_KUSTOMIZE_DIR=$(XDG_CONFIG_HOME)/policy.open-cluster-management.io/v1/policygenerator
 POLICYGEN_EX_DIR=./argocd/example/policygentemplates
 POLICYGEN_KUSTOMIZE_DIR=$(XDG_CONFIG_HOME)/ran.openshift.io/v1/policygentemplate
+GITOPS_OPERATOR_SUB_FILE=./argocd/deployment/openshift-gitops-operator.yaml
 KUSTOMIZE_DIR=/tmp
+KUSTOMIZE_VERSION_DIR=kustomize_version_dir
 KUSTOMIZE_BIN=$(KUSTOMIZE_DIR)/kustomize
-KUSTOMIZE_VERSION=4.4.0
+KUSTOMIZE_VERSION_DEFAULT=5.2.1
+KUSTOMIZE_GET_VERSION_SCRIPT=../tools/get-kustomize-version/get-gitops-operator-kustomize-version.sh
+KUSTOMIZE_VERSION=$(shell ./$(KUSTOMIZE_GET_VERSION_SCRIPT) v$(OCP_VERSION) $(GITOPS_OPERATOR_SUB_FILE) $(KUSTOMIZE_VERSION_DEFAULT) $(KUSTOMIZE_VERSION_DIR))
 KUSTOMIZE := $(if $(shell command -v kustomize 2>/dev/null), $(shell command -v kustomize), $(KUSTOMIZE_BIN))
 POLICYGEN_DIR := ../policygenerator
 SOURCE_CRS_DIR := ../source-crs
@@ -48,6 +55,7 @@ gen-files: build $(KUSTOMIZE)
 
 clean:
 	rm -rf $(ACM_POLICYGEN_KUSTOMIZE_DIR) $(POLICYGEN_KUSTOMIZE_DIR) $(POLICYGEN_EX_DIR)/out $(ACM_POLICYGEN_EX_DIR)/out $(ACM_POLICYGEN_EX_DIR)/source-crs $(POLICYGEN_EX_DIR)/source-crs $(ACMPG_FROM_PGT_DIR)
+	rm -rf $(KUSTOMIZE_VERSION_DIR)
 
 pgt2acmpg-clean:
 	rm -rf ../tools/pgt2acmpg

--- a/ztp/policygenerator-kustomize-plugin/Makefile
+++ b/ztp/policygenerator-kustomize-plugin/Makefile
@@ -1,10 +1,17 @@
 # Set kustomize env variable
 export XDG_CONFIG_HOME=./
 
+# KEEP THIS UP TO DATE (UNTIL IT WILL BE AUTOMATICALLY DETERMINED)
+OCP_VERSION=4.16
+
 POLICYGEN_KUSTOMIZE_DIR=./kustomize/plugin/ran.openshift.io/v1/policygentemplate
+GITOPS_OPERATOR_SUB_FILE=../gitops-subscriptions/argocd/deployment/openshift-gitops-operator.yaml
 KUSTOMIZE_DIR=/tmp
+KUSTOMIZE_VERSION_DIR=kustomize_version_dir
 KUSTOMIZE_BIN=$(KUSTOMIZE_DIR)/kustomize
-KUSTOMIZE_VERSION=4.4.0
+KUSTOMIZE_VERSION_DEFAULT=5.0.0
+KUSTOMIZE_GET_VERSION_SCRIPT=../tools/get-kustomize-version/get-gitops-operator-kustomize-version.sh
+KUSTOMIZE_VERSION=$(shell ./$(KUSTOMIZE_GET_VERSION_SCRIPT) v$(OCP_VERSION) $(GITOPS_OPERATOR_SUB_FILE) $(KUSTOMIZE_VERSION_DEFAULT) $(KUSTOMIZE_VERSION_DIR))
 KUSTOMIZE := $(if $(shell command -v kustomize 2>/dev/null), $(shell command -v kustomize), $(KUSTOMIZE_BIN))
 POLICYGEN_DIR := ../policygenerator
 SOURCE_CRS_DIR := ../source-crs
@@ -32,4 +39,4 @@ gen-files: build $(KUSTOMIZE)
 	$(KUSTOMIZE) build --enable-alpha-plugins ./ -o out/
 
 clean:
-	rm -rf kustomize out
+	rm -rf kustomize out $(KUSTOMIZE_VERSION_DIR)

--- a/ztp/siteconfig-generator-kustomize-plugin/Makefile
+++ b/ztp/siteconfig-generator-kustomize-plugin/Makefile
@@ -1,11 +1,18 @@
 # Set kustomize env variable
 export XDG_CONFIG_HOME=./
 
+# KEEP THIS UP TO DATE (UNTIL IT WILL BE AUTOMATICALLY DETERMINED)
+OCP_VERSION=4.16
+
 SITECONFIG_V1_KUSTOMIZE_DIR=./kustomize/plugin/ran.openshift.io/v1/siteconfig
 SITECONFIG_V2_KUSTOMIZE_DIR=./kustomize/plugin/ran.openshift.io/v2/siteconfig
+GITOPS_OPERATOR_SUB_FILE=../gitops-subscriptions/argocd/deployment/openshift-gitops-operator.yaml
 KUSTOMIZE_DIR=/tmp
+KUSTOMIZE_VERSION_DIR=kustomize_version_dir
 KUSTOMIZE_BIN=$(KUSTOMIZE_DIR)/kustomize
-KUSTOMIZE_VERSION=4.4.0
+KUSTOMIZE_VERSION_DEFAULT=5.0.0
+KUSTOMIZE_GET_VERSION_SCRIPT=../tools/get-kustomize-version/get-gitops-operator-kustomize-version.sh
+KUSTOMIZE_VERSION=$(shell ./$(KUSTOMIZE_GET_VERSION_SCRIPT) v$(OCP_VERSION) $(GITOPS_OPERATOR_SUB_FILE) $(KUSTOMIZE_VERSION_DEFAULT) $(KUSTOMIZE_VERSION_DIR))
 KUSTOMIZE := $(if $(shell command -v kustomize 2>/dev/null), $(shell command -v kustomize), $(KUSTOMIZE_BIN))
 SITECONFIG_DIR := ../siteconfig-generator
 EXTRAMANIFEST_DIR := ../source-crs/extra-manifest
@@ -36,5 +43,5 @@ gen-files: build $(KUSTOMIZE)
 	$(KUSTOMIZE) build --enable-alpha-plugins ./ -o out/
 
 clean:
-	rm -rf kustomize out
+	rm -rf kustomize out $(KUSTOMIZE_VERSION_DIR)
 

--- a/ztp/tools/get-kustomize-version/get-gitops-operator-kustomize-version.sh
+++ b/ztp/tools/get-kustomize-version/get-gitops-operator-kustomize-version.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Script to determine the kustomize version used in the corresponding argocd container
+# of the current openshift-gitops operator.
+
+# Check for empty parameters.
+if [[ $# -ne 4 ]]; then
+  exit 1
+fi
+
+# From now on return 0 even in case of error since we default to a kustomize version.
+
+# Save the parameters to variables with meaningful names.
+# Usually the OCP version.
+index_tag=$1
+# ztp/gitops-subscriptions/argocd/deployment/openshift-gitops-operator.yaml
+openshift_gitops_operator_sub=$2
+# Default kustomize version.
+default_kustomize_version=$3
+# The name of the local test directory.
+test_dir=$4
+
+mkdir -p "$test_dir"
+# Used files.
+index_results_file="$test_dir/index_results"
+
+cleanup() {
+    rm -f "$test_dir"
+}
+
+# Check the second parameter points to a file that exists.
+if [[ ! -f "$2" ]]; then
+  echo "$default_kustomize_version"
+  exit 0
+fi
+
+# Render file based catalog from redhat-operator-index.
+if ! podman run --rm registry.redhat.io/redhat/redhat-operator-index:"$index_tag" render /configs/ > "$index_results_file"; then
+    echo "$default_kustomize_version"
+    exit 0
+fi
+
+# Extract the latest desired openshift-gitops channel.
+if ! gitops_channel=$(awk '/channel: gitops-/ {print $2}' "$openshift_gitops_operator_sub"); then
+    echo "$default_kustomize_version"
+    exit 0
+fi
+
+if [[ -z $gitops_channel ]]; then
+    echo "$default_kustomize_version"
+    exit 0
+fi
+
+# Extract the last openshift-gitops image.
+gitops_version=$(echo "$gitops_channel" | grep -oE "[0-9.\]+")
+gitops_image=$(jq -r \
+  --arg gitops_channel "$gitops_channel" \
+  --arg gitops_version "$gitops_version" \
+  'select(.name == $gitops_channel) | .entries[] | select(.name | contains($gitops_version)) | .name' \
+  "$index_results_file" | \
+  tail -n 1)
+if [[ $? -ne 0 || -z $gitops_image ]]; then
+    echo "$default_kustomize_version"
+    exit 0
+fi
+
+# Extract the related argocd image.
+argocd_image=$(jq -r \
+  --arg gitops_image "$gitops_image" \
+  'select(.name == $gitops_image).relatedImages[] | select (.name == "argocd_image") | .image' \
+  "$index_results_file")
+if [[ $? -ne 0 || -z $argocd_image ]]; then
+    echo "$default_kustomize_version"
+    exit 0
+fi
+
+# Get the kustomize version.
+if ! kustomize_version=$(podman run --rm "$argocd_image" kustomize version | grep -oE "v[0-9.\]+" | grep -oE "[0-9.\]+"); then
+  echo "$default_kustomize_version"
+  exit 0
+fi
+
+# If not empty, print the resulted kustomize version and exit.
+if [[ -n $kustomize_version ]]; then
+  echo "$kustomize_version"
+  exit 0
+fi
+
+# Print the default kustomize version.
+echo "$default_kustomize_version"
+


### PR DESCRIPTION
Description:
- update the ZTP Makefiles to dynamically determine the kustomize version to use
- the kustomize version is obtained in a new script by:
  * looking at the redhat-operator-index & rendering the catalog
  * searching for the argocd image of the current gitops operator version (in gitops-subscriptions/argocd/deployment/ openshift-gitops-operator.yaml )
  * getting the kustomize version from the argocd image
- the default kustomize version is set to 5.2.1 for 4.16

/cc @sabbir-47 @lack 