### PR TITLE
ztp: change IBU source cr to v1

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/README.md
+++ b/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/README.md
@@ -90,9 +90,9 @@ Choose either [ibu-upgrade-ranGen.yaml](./ibu-upgrade-ranGen.yaml) example using
 * group-ibu-finalize-policy: to transition ibu to Idle stage
 * group-ibu-rollback-policy(optional): to transition ibu to Rollback stage
 
-Add the template to [kustomization.yaml](./kustomization.yaml) file in the `generator` object.
+Add the template to [kustomization.yaml](./kustomization.yaml) file in the `generators` object.
 ```yaml
-generator:
+generators:
 # Use policygentemplate to create oadp cm and ibu policies
 - ibu-upgrade-ranGen.yaml
 # Use acmpolicygenerator to create oadp cm and ibu policies

--- a/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/acm-ibu-upgrade-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/acm-ibu-upgrade-ranGen.yaml
@@ -48,6 +48,7 @@ policies:
         - reason: Completed
           status: "True"
           type: PrepCompleted
+          message: "Prep stage completed successfully"
 # The policy for Upgrade stage transition
 - name: "group-ibu-upgrade-stage-policy"
   manifests:

--- a/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/ibu-upgrade-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/image-based-upgrades/ibu-upgrade-ranGen.yaml
@@ -34,6 +34,7 @@ spec:
           - reason: Completed
             status: "True"
             type: PrepCompleted
+            message: "Prep stage completed successfully"
     # The policy for Upgrade stage transition
     - fileName: ibu/ImageBasedUpgrade.yaml
       policyName: "upgrade-stage-policy"

--- a/ztp/source-crs/ibu/ImageBasedUpgrade.yaml
+++ b/ztp/source-crs/ibu/ImageBasedUpgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: lca.openshift.io/v1alpha1
+apiVersion: lca.openshift.io/v1
 kind: ImageBasedUpgrade
 metadata:
   name: upgrade

--- a/ztp/source-crs/ibu/ImageBasedUpgradeStatus.yaml
+++ b/ztp/source-crs/ibu/ImageBasedUpgradeStatus.yaml
@@ -1,4 +1,4 @@
-apiVersion: lca.openshift.io/v1alpha1
+apiVersion: lca.openshift.io/v1
 kind: ImageBasedUpgrade
 metadata:
   name: upgrade


### PR DESCRIPTION
- since the IBU apiVersion is changed to v1 in https://github.com/openshift-kni/lifecycle-agent/pull/497, update the source cr in ztp repo
- typo fix in doc
- small update in prep policy for adding message field in status condition


/cc @leo8a @pixelsoccupied @sabbir-47 