### PR TITLE
OCPBUGS-33597: Add TIMELS indication on T-GMs

### DIFF
--- a/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
@@ -13,7 +13,7 @@ spec:
   profile:
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -O -37 -N 8 -R 16 -s $iface_nic1 -n 24
+    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_nic1 -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -89,6 +89,12 @@ spec:
               - "29.20"
               - "-p"
               - "MON-HW"
+            reportOutput: true
+          - args: #ubxtool -P 29.20 -p NAV-TIMELS
+              - "-P"
+              - "29.20"
+              - "-p"
+              - "NAV-TIMELS"
             reportOutput: true
     ts2phcOpts: " "
     ts2phcConf: |

--- a/ztp/source-crs/PtpConfigGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigGmWpc.yaml
@@ -11,7 +11,7 @@ spec:
   profile:
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -O -37 -N 8 -R 16 -s $iface_master -n 24
+    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_master -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -82,6 +82,12 @@ spec:
               - "29.20"
               - "-p"
               - "MON-HW"
+            reportOutput: true
+          - args: #ubxtool -P 29.20 -p NAV-TIMELS
+              - "-P"
+              - "29.20"
+              - "-p"
+              - "NAV-TIMELS"
             reportOutput: true
     ts2phcOpts: " "
     ts2phcConf: |


### PR DESCRIPTION
This commit enables NAV-TIMELS indications on WPC T-GM
configurations. This is required to enable automatic
leap seconds file update.
The phc2sys options are also changed to obtain the leap
seconds from phc instead of passing  them as the command
line argument
/cc @josephdrichard @jzding @aneeshkp @nishant-parekh 