### PR TITLE
OCPBUGS-34064: ZTP tuned patch typo: s/ice-dppls/ice-dplls/ 

### DIFF
--- a/ztp/source-crs/TunedPerformancePatch.yaml
+++ b/ztp/source-crs/TunedPerformancePatch.yaml
@@ -20,7 +20,7 @@ spec:
         [scheduler]
         group.ice-ptp=0:f:10:*:ice-ptp.*
         group.ice-gnss=0:f:10:*:ice-gnss.*
-        group.ice-dppls=0:f:10:*:ice-dplls.*
+        group.ice-dplls=0:f:10:*:ice-dplls.*
         [service]
         service.stalld=start,enable
         service.chronyd=stop,disable


### PR DESCRIPTION
fix typo 
s/ice-dppls/ice-dplls/