### PR TITLE
OCPBUGS-33524: change ptp4lOpts from empty spaced string to null

### DIFF
--- a/ztp/source-crs/PtpConfigForHA.yaml
+++ b/ztp/source-crs/PtpConfigForHA.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   profile:
     - name: "boundary-ha"
-      ptp4lOpts: " "
+      ptp4lOpts: ""
       phc2sysOpts: "-a -r -n 24"
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10


### PR DESCRIPTION
In linuxPTPDaemon, a string containing a space character (" ") is not considered nil, whereas an empty string ("") is considered nil. The nil value determines whether to execute the processes related to the configured Opts.
For an example 
1. ptp4lOpts: " "  will run the ptp4l process with empty options 
2. ptp4lOpts:  ""  will not  run the ptp4l process