### PR TITLE
OCPBUGS-34914: remove leapfile from reference config

### DIFF
--- a/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
@@ -108,7 +108,6 @@ spec:
       #cat /dev/GNSS to find available serial port
       #example value of gnss_serialport is /dev/ttyGNSS_1700_0
       ts2phc.nmea_serialport $gnss_serialport
-      leapfile  /usr/share/zoneinfo/leap-seconds.list
       [$iface_nic1]
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0

--- a/ztp/source-crs/PtpConfigGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigGmWpc.yaml
@@ -101,7 +101,6 @@ spec:
       #cat /dev/GNSS to find available serial port
       #example value of gnss_serialport is /dev/ttyGNSS_1700_0
       ts2phc.nmea_serialport $gnss_serialport
-      leapfile  /usr/share/zoneinfo/leap-seconds.list
       [$iface_master]
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0


### PR DESCRIPTION
Leapfile is managed by linuxptp-daemon, but still appears in the reference config. This config entry will also be logged, which is misleading. This commit removes the entry from the reference config ts2phcConf section.

/cc @aneeshkp @josephdrichard @jzding  @nishant-parekh 