### PR TITLE
OCPBUGS-35105: Update ptpconfig to configure NAV-TIMELS to be periodically sent via the UBX-CFG-MSG message

### DIFF
--- a/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
@@ -90,11 +90,11 @@ spec:
               - "-p"
               - "MON-HW"
             reportOutput: true
-          - args: #ubxtool -P 29.20 -p NAV-TIMELS
+          - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,300
               - "-P"
               - "29.20"
               - "-p"
-              - "NAV-TIMELS"
+              - "CFG-MSG,1,38,300"
             reportOutput: true
     ts2phcOpts: " "
     ts2phcConf: |

--- a/ztp/source-crs/PtpConfigGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigGmWpc.yaml
@@ -83,11 +83,11 @@ spec:
               - "-p"
               - "MON-HW"
             reportOutput: true
-          - args: #ubxtool -P 29.20 -p NAV-TIMELS
+          - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,300
               - "-P"
               - "29.20"
               - "-p"
-              - "NAV-TIMELS"
+              - "CFG-MSG,1,38,300"
             reportOutput: true
     ts2phcOpts: " "
     ts2phcConf: |


### PR DESCRIPTION
This PR Updates ptpconfig to configure the hardware plugin to periodically send the u-blox command NAV-TIMELS via the UBX-CFG-MSG message. NAV-TIMELS carries information about leap dates and offsets.
Required for T-WPC leap events cc @vitus133 