### PR TITLE
cnf-tests: Read guaranteed CPU list for cgroupv2

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -510,7 +510,8 @@ sleep INF
 			})
 
 			execute.BeforeAll(func() {
-				buff, err := pods.ExecCommand(client.Client, *dpdkWorkloadPod, []string{"cat", "/sys/fs/cgroup/cpuset/cpuset.cpus"})
+				buff, err := pods.ExecCommand(client.Client, *dpdkWorkloadPod,
+					[]string{"sh", "-c", "cat /sys/fs/cgroup/cpuset/cpuset.cpus 2>/dev/null || cat /sys/fs/cgroup/cpuset.cpus 2>/dev/null"})
 				Expect(err).ToNot(HaveOccurred())
 				cpuList, err = getCpuSet(buff.String())
 				Expect(err).ToNot(HaveOccurred())
@@ -543,7 +544,8 @@ sleep INF
 
 			BeforeEach(func() {
 				Expect(dpdkWorkloadPod).ToNot(BeNil(), "No dpdk workload pod found")
-				buff, err := pods.ExecCommand(client.Client, *dpdkWorkloadPod, []string{"cat", "/sys/fs/cgroup/cpuset/cpuset.cpus"})
+				buff, err := pods.ExecCommand(client.Client, *dpdkWorkloadPod,
+					[]string{"sh", "-c", "cat /sys/fs/cgroup/cpuset/cpuset.cpus 2>/dev/null || cat /sys/fs/cgroup/cpuset.cpus 2>/dev/null"})
 				Expect(err).ToNot(HaveOccurred())
 				cpuList, err := getCpuSet(buff.String())
 				Expect(err).ToNot(HaveOccurred())
@@ -956,7 +958,7 @@ func createRegularPolicy(sriovDevice *sriovv1.InterfaceExt, testNode, dpdkResour
 
 func dpdkWorkloadCommand(dpdkResourceName, testpmdCommand string, runningTime int) string {
 	return fmt.Sprintf(`set -ex
-export CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
+export CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus 2>/dev/null || cat /sys/fs/cgroup/cpuset.cpus 2>/dev/null)
 echo ${CPU}
 echo ${PCIDEVICE_OPENSHIFT_IO_%s}
 

--- a/cnf-tests/testsuites/e2esuite/s2i/s2i.go
+++ b/cnf-tests/testsuites/e2esuite/s2i/s2i.go
@@ -38,7 +38,7 @@ const (
 	DPDK_SERVER_WORKLOAD_MAC = "60:00:00:00:00:01"
 	DPDK_CLIENT_WORKLOAD_MAC = "60:00:00:00:00:02"
 	CLIENT_TESTPMD_COMMAND   = `set -ex
-export CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
+export CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus 2>/dev/null || cat /sys/fs/cgroup/cpuset.cpus 2>/dev/null)
 echo ${CPU}
 echo ${PCIDEVICE_OPENSHIFT_IO_%s}
 testpmd -l ${CPU} -a ${PCIDEVICE_OPENSHIFT_IO_%s} --iova-mode=va --  --portmask=0x1 --nb-cores=2 --eth-peer=0,ff:ff:ff:ff:ff:ff --forward-mode=txonly --no-mlockall --stats-period 5

--- a/tools/s2i-dpdk/test/test-app/run.sh
+++ b/tools/s2i-dpdk/test/test-app/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 
-export CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
+export CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus 2>/dev/null || cat /sys/fs/cgroup/cpuset.cpus 2>/dev/null)
 echo ${CPU}
 echo ${PCIDEVICE_OPENSHIFT_IO_DPDKNIC}
 


### PR DESCRIPTION
Guaranteed workload pods can be in a different cgroup if on the node there has been applied a PerformanceProfile.

The Cluster Node Tuning Operator configures the cpuset cgroup on specific condition and it doesn't come back to the original configuration when the node is moved to a differenent MachineConfigPool.

Update the DPDK test cases' logic to retrieve the list of dedicated CPUs.

Refs:
- https://github.com/openshift/cluster-node-tuning-operator/blob/a4c70abb71036341dfaf0cac30dab0d166e55cbd/assets/performanceprofile/scripts/cpuset-configure.sh#L9
- https://github.com/openshift-kni/cnf-features-deploy/pull/1592/commits/d2e763a91476a8891bfdd55c0add46a610c6da7f
- https://github.com/openshift-kni/cnf-features-deploy/issues/1902

cc @gregkopels , @ffromani 
