### PR TITLE
Add ClusterImageSet CR in the whitelist of policies-app-project

### DIFF
--- a/ztp/gitops-subscriptions/argocd/deployment/policies-app-project.yaml
+++ b/ztp/gitops-subscriptions/argocd/deployment/policies-app-project.yaml
@@ -8,6 +8,8 @@ spec:
   clusterResourceWhitelist:
   - group: ''
     kind: Namespace
+  - group: 'hive.openshift.io'
+    kind: ClusterImageSet
   destinations:
   - namespace: 'ztp*'
     server: '*'


### PR DESCRIPTION
We are managing the ClusterImageSets through the policies, as a result we need this in the whitelist of policies-app-project, otherwise the sync will fail due to error below:

`time="2024-06-11T17:44:46Z" level=info msg="Adding resource result, status: 'SyncFailed', phase: '', message: 'resource hive.openshift.io:ClusterImageSet is not permitted in project policy-app-project'" application=openshift-gitops/policies kind=ClusterImageSet name=cluster-image-set-4-14-25-20240606 namespace=policies-sub phase=Sync syncId=00006-pQxCU`

Similar PR for app-project: https://github.com/openshift-kni/cnf-features-deploy/pull/1880 