### PR TITLE
infra: Bump go v1.22 in CI jobs

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder-stresser
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS builder-stresser
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
 ENV TESTER_PATH=$PKG_PATH/cnf-tests/pod-utils/stresser
@@ -10,7 +10,7 @@ WORKDIR $TESTER_PATH
 
 RUN go build -mod=vendor -o /stresser
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder-sctptester
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS builder-sctptester
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
 ENV TESTER_PATH=$PKG_PATH/cnf-tests/pod-utils/sctptester
@@ -23,7 +23,7 @@ WORKDIR $TESTER_PATH
 RUN go build -mod=vendor -o /sctptest
 
 # build latency-test's runner binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder-latency-test-runners
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS builder-latency-test-runners
 
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
@@ -39,7 +39,7 @@ RUN go build -mod=vendor -o /oslat-runner oslat-runner/main.go && \
     go build -mod=vendor -o /hwlatdetect-runner hwlatdetect-runner/main.go
 
 # build latency testing suite
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS go-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS go-builder
 WORKDIR /app
 COPY . .
 RUN make test-bin

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # This dockerfile is specific to building the OpenShift CNF stresser image
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 as builder-stresser
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 as builder-stresser
 
 # Add everything
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
@@ -14,7 +14,7 @@ WORKDIR $STRESSER_PATH
 RUN go build -mod=vendor -o /stresser
 
 # This dockerfile is specific to building the OpenShift CNF sctp tester image
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 as builder-sctptester
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 as builder-sctptester
 
 # Add everything
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
@@ -29,7 +29,7 @@ WORKDIR $TESTER_PATH
 RUN go build -mod=vendor -o /sctptest
 
 # build latency-test's runner binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS builder-latency-test-runners
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS builder-latency-test-runners
 
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
@@ -45,13 +45,13 @@ RUN go build -mod=vendor -o /oslat-runner oslat-runner/main.go && \
     go build -mod=vendor -o /hwlatdetect-runner hwlatdetect-runner/main.go
 
 # build latency testing suite
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 AS go-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS go-builder
 WORKDIR /app
 COPY . .
 RUN make test-bin
 
 # Build latency-test binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 as builder-latency-test-tools
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 as builder-latency-test-tools
 
 ENV RT_TESTS_URL=https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git/snapshot
 ENV RT_TESTS_PKG=rt-tests-2.0

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -3,7 +3,7 @@ FROM quay.io/fedora/fedora:37-x86_64
 ENV GOPATH /go
 ENV GOBIN /go/bin
 ENV GOCACHE /go/.cache
-ENV GOVERSION=1.20
+ENV GOVERSION=1.22.4
 ENV PATH=$PATH:/root/.gimme/versions/go"$GOVERSION".linux.amd64/bin:$GOBIN
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/cnf-features-deploy
 


### PR DESCRIPTION
Prow jobs like `e2e-aws-ci-tests` uses runs using the `openshift-ci/Dockerfile.tools` iamge. (See https://github.com/openshift/release/blob/0a257490e7c4aba7c6164bd79626791ed3dae819/ci-operator/config/openshift-kni/cnf-features-deploy/openshift-kni-cnf-features-deploy-master.yaml#L21, where the job has `from: src` and the file has
```
build_root:
  project_image:
    dockerfile_path: openshift-ci/Dockerfile.tools
```)

This bump is needed because a submodule (cluster-node-tuning-operator in this case) bumped to go1.22 and jobs are reporting the error:

```
go: errors parsing go.mod:
/go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/submodules/cluster-node-tuning-operator/go.mod:3: invalid go version '1.22.0': must match format 1.23
/go/src/github.com/openshift-kni/cnf-features-deploy/cnf-tests/submodules/cluster-node-tuning-operator/go.mod:5: unknown directive: toolchain
```