### PR TITLE
ztp: add install and config CRs for LCA and OADP operators

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-common-ranGen.yaml
@@ -69,3 +69,15 @@ policies:
     - path: source-crs/StorageOperGroup.yaml
     - path: source-crs/StorageSubscription.yaml
     - path: source-crs/StorageOperatorStatus.yaml
+    #
+    # LCA operator is used for orchestrating Image Based Upgrade for SNO
+    # - path: source-crs/LcaSubscriptionNS.yaml
+    # - path: source-crs/LcaSubscriptionOperGroup.yaml
+    # - path: source-crs/LcaSubscription.yaml
+    # - path: source-crs/LcaOperatorStatus.yaml
+    #
+    # OADP operator is used for backing up and restoring application during Image Based Upgrade
+    # - path: source-crs/OadpSubscriptionNS.yaml
+    # - path: source-crs/OadpSubscriptionOperGroup.yaml
+    # - path: source-crs/OadpSubscription.yaml
+    # - path: source-crs/OadpOperatorStatus.yaml

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-example-sno-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-example-sno-site.yaml
@@ -74,3 +74,29 @@ policies:
           numVfs: 8
           priority: 10
           resourceName: du_mh
+#   --- START of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---
+#   - path: source-crs/OadpSecret.yaml
+#     patches:
+#     - data:
+#         cloud: W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPVdicktaSFpFOXZGWEVFemo2RU12CmF3c19zZWNyZXRfYWNjZXNzX2tleT1RRDNmRVZMNzVsOWJpSWswYW9PdlRSc2diN01ZRUlnZmF5bzVzRnlmCg==
+#   - path: source-crs/OadpDataProtectionApplication.yaml
+#     patches:
+#     - spec:
+#         backupLocations:
+#         - velero:
+#             provider: aws
+#             default: true
+#             credential:
+#               key: cloud
+#               name: cloud-credentials
+#             config:
+#               profile: "default"
+#               region: minio
+#               s3Url: http://s3storage.example.com:9000
+#               insecureSkipTLSVerify: "true"
+#               s3ForcePathStyle: "true"
+#             objectStorage:
+#               bucket: ibu
+#               prefix: '{{hub .ManagedClusterName hub}}'
+#   - path: source-crs/OadpBackupStorageLocationStatus.yaml
+#   --- END of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/hub-side-templating/acm-group-du-sno-ranGen-templated.yaml
@@ -358,3 +358,33 @@ policies:
 #                  path: /etc/kubernetes/openshift-workload-pinning
 #                  user:
 #                    name: root
+# --- START of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---
+# - name: oadp-config-policy
+#   policyAnnotations:
+#     ran.openshift.io/ztp-deploy-wave: "100"
+#   manifests:
+#     - path: source-crs/OadpSecret.yaml
+#       patches:
+#       - data:
+#           cloud: W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPVdicktaSFpFOXZGWEVFemo2RU12CmF3c19zZWNyZXRfYWNjZXNzX2tleT1RRDNmRVZMNzVsOWJpSWswYW9PdlRSc2diN01ZRUlnZmF5bzVzRnlmCg==
+#     - path: source-crs/OadpDataProtectionApplication.yaml
+#       patches:
+#       - spec:
+#           backupLocations:
+#           - velero:
+#               provider: aws
+#               default: true
+#               credential:
+#                 key: cloud
+#                 name: cloud-credentials
+#               config:
+#                 profile: "default"
+#                 region: minio
+#                 s3Url: http://s3storage.example.com:9000
+#                 insecureSkipTLSVerify: "true"
+#                 s3ForcePathStyle: "true"
+#               objectStorage:
+#                 bucket: ibu
+#                 prefix: '{{hub .ManagedClusterName hub}}'
+#     - path: source-crs/OadpBackupStorageLocationStatus.yaml
+#   --- END of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/common-ranGen.yaml
@@ -55,6 +55,27 @@ spec:
     #   policyName: "subscriptions-policy"
     # - fileName: BareMetalEventRelaySubscription.yaml
     #   policyName: "subscriptions-policy"
+    #
+    # LCA operator is used for orchestrating Image Based Upgrade for SNO
+    # - fileName: LcaSubscriptionNS.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: LcaSubscriptionOperGroup.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: LcaSubscription.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: LcaOperatorStatus.yaml
+    #   policyName: "subscriptions-policy"
+    #
+    # OADP operator is used for backing up and restoring application during Image Based Upgrade
+    # - fileName: OadpSubscriptionNS.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: OadpSubscriptionOperGroup.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: OadpSubscription.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: OadpOperatorStatus.yaml
+    #   policyName: "subscriptions-policy"
+    #
     - fileName: ReduceMonitoringFootprint.yaml
       policyName: "config-policy"
     #

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-site.yaml
@@ -48,3 +48,30 @@ spec:
         numVfs: 8
         priority: 10
         resourceName: du_mh
+#   --- START of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---
+#   - fileName: OadpSecret.yaml
+#     policyName: "config-policy"
+#     data:
+#       cloud: W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPVdicktaSFpFOXZGWEVFemo2RU12CmF3c19zZWNyZXRfYWNjZXNzX2tleT1RRDNmRVZMNzVsOWJpSWswYW9PdlRSc2diN01ZRUlnZmF5bzVzRnlmCg==
+#   - fileName: OadpDataProtectionApplication.yaml
+#     policyName: "config-policy"
+#     spec:
+#       backupLocations:
+#       - velero:
+#           provider: aws
+#           default: true
+#           credential:
+#             key: cloud
+#             name: cloud-credentials
+#           config:
+#             profile: "default"
+#             region: minio
+#             s3Url: http://s3storage.example.com:9000
+#             insecureSkipTLSVerify: "true"
+#             s3ForcePathStyle: "true"
+#           objectStorage:
+#             bucket: ibu
+#             prefix: '{{hub .ManagedClusterName hub}}'
+#   - fileName: OadpBackupStorageLocationStatus.yaml
+#     policyName: "config-policy"
+#   --- END of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
@@ -244,3 +244,33 @@ spec:
 #                user:
 #                  name: root
 #    # ---- END of source CRs needed for updating CRI-O workload-partitioning ends here ----
+#    ######################
+#    # oadp-config-policy #
+#    ######################
+#    # --- START of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---
+#    - fileName: OadpSecret.yaml  # wave 100
+#      policyName: "oadp-config-policy"
+#      data:
+#        cloud: W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPVdicktaSFpFOXZGWEVFemo2RU12CmF3c19zZWNyZXRfYWNjZXNzX2tleT1RRDNmRVZMNzVsOWJpSWswYW9PdlRSc2diN01ZRUlnZmF5bzVzRnlmCg==
+#    - fileName: OadpDataProtectionApplication.yaml  # wave 100
+#      policyName: "oadp-config-policy"
+#      spec:
+#        backupLocations:
+#        - velero:
+#            provider: aws
+#            default: true
+#            credential:
+#              key: cloud
+#              name: cloud-credentials
+#            config:
+#              profile: "default"
+#              region: minio
+#              s3Url: http://s3storage.example.com:9000
+#              insecureSkipTLSVerify: "true"
+#              s3ForcePathStyle: "true"
+#            objectStorage:
+#              bucket: ibu
+#              prefix: '{{hub .ManagedClusterName hub}}'
+#    - fileName: OadpBackupStorageLocationStatus.yaml  # wave 100
+#      policyName: "oadp-config-policy"
+#    --- END of source CRs needed for configuring OADP operator for SNO Image Based Upgrade ---

--- a/ztp/source-crs/LcaOperatorStatus.yaml
+++ b/ztp/source-crs/LcaOperatorStatus.yaml
@@ -1,0 +1,26 @@
+# This CR verifies the installation/upgrade of the Lifecycle Agent Operator
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+  name: lifecycle-agent.openshift-lifecycle-agent 
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+status:
+  components:
+    refs:
+    - kind: Subscription
+      namespace: openshift-lifecycle-agent
+      conditions:
+      - type: CatalogSourcesUnhealthy
+        status: "False"
+    - kind: InstallPlan
+      namespace: openshift-lifecycle-agent
+      conditions:
+      - type: Installed
+        status: "True"
+    - kind: ClusterServiceVersion
+      namespace: openshift-lifecycle-agent
+      conditions:
+      - type: Succeeded
+        status: "True"
+        reason: InstallSucceeded

--- a/ztp/source-crs/LcaSubscription.yaml
+++ b/ztp/source-crs/LcaSubscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lifecycle-agent
+  namespace: openshift-lifecycle-agent
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  channel: "stable"
+  name: lifecycle-agent
+  source: redhat-operators-disconnected
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/ztp/source-crs/LcaSubscriptionNS.yaml
+++ b/ztp/source-crs/LcaSubscriptionNS.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-lifecycle-agent
+  annotations:
+    workload.openshift.io/allowed: management
+    ran.openshift.io/ztp-deploy-wave: "2"
+  labels:
+    kubernetes.io/metadata.name: openshift-lifecycle-agent

--- a/ztp/source-crs/LcaSubscriptionOperGroup.yaml
+++ b/ztp/source-crs/LcaSubscriptionOperGroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: lifecycle-agent
+  namespace: openshift-lifecycle-agent
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  targetNamespaces:
+    - openshift-lifecycle-agent

--- a/ztp/source-crs/OadpBackupStorageLocationStatus.yaml
+++ b/ztp/source-crs/OadpBackupStorageLocationStatus.yaml
@@ -1,0 +1,9 @@
+# This CR verifies the availability of backup storage locations created by OADP
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  namespace: openshift-adp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "100"
+status:
+  phase: Available

--- a/ztp/source-crs/OadpDataProtectionApplication.yaml
+++ b/ztp/source-crs/OadpDataProtectionApplication.yaml
@@ -1,0 +1,40 @@
+# The configuration CR for OADP operator
+# More information can be found in https://docs.openshift.com/container-platform/4.15/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: dataprotectionapplication
+  namespace: openshift-adp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "100"
+spec:
+  configuration:
+    restic:
+      enable: false
+    velero:
+      defaultPlugins:
+        - aws
+        - openshift
+      resourceTimeout: 10m
+# User needs to configure the following backupLocations through PGT overlay
+# backupLocations:
+# - velero:
+#     provider: aws
+#     default: true
+#     credential:
+#       key: cloud
+#       name: cloud-credentials
+#     config:
+#       profile: "default"
+#       region: minio
+#       s3Url: $url
+#       insecureSkipTLSVerify: "true"
+#       s3ForcePathStyle: "true"
+#     objectStorage:
+#       bucket: $bucketName
+#       prefix: $prefixName
+status:
+  conditions:
+  - reason: Complete
+    status: "True"
+    type: Reconciled

--- a/ztp/source-crs/OadpOperatorStatus.yaml
+++ b/ztp/source-crs/OadpOperatorStatus.yaml
@@ -1,0 +1,26 @@
+# This CR verifies the installation/upgrade of the OADP operator
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+  name: redhat-oadp-operator.openshift-adp 
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+status:
+  components:
+    refs:
+    - kind: Subscription
+      namespace: openshift-adp
+      conditions:
+      - type: CatalogSourcesUnhealthy
+        status: "False"
+    - kind: InstallPlan
+      namespace: openshift-adp
+      conditions:
+      - type: Installed
+        status: "True"
+    - kind: ClusterServiceVersion
+      namespace: openshift-adp
+      conditions:
+      - type: Succeeded
+        status: "True"
+        reason: InstallSucceeded

--- a/ztp/source-crs/OadpSecret.yaml
+++ b/ztp/source-crs/OadpSecret.yaml
@@ -1,0 +1,10 @@
+# The OADP secret for the s3 storage connection
+# should be referenced in the OadpDataProtectionApplication.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-credentials
+  namespace: openshift-adp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "100"
+type: Opaque

--- a/ztp/source-crs/OadpSubscription.yaml
+++ b/ztp/source-crs/OadpSubscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: redhat-oadp-operator
+  namespace: openshift-adp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  channel: "stable-1.3"
+  name: redhat-oadp-operator
+  source: redhat-operators-disconnected
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown

--- a/ztp/source-crs/OadpSubscriptionNS.yaml
+++ b/ztp/source-crs/OadpSubscriptionNS.yaml
@@ -1,0 +1,11 @@
+# OADP is not intended to be deployed on reserved cores for platform.
+# It is solely used for backing up and restoring application during Image Based Upgrade(IBU).
+# It can be removed after IBU is completed.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-adp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+  labels:
+    kubernetes.io/metadata.name: openshift-adp

--- a/ztp/source-crs/OadpSubscriptionOperGroup.yaml
+++ b/ztp/source-crs/OadpSubscriptionOperGroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: redhat-oadp-operator
+  namespace: openshift-adp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  targetNamespaces:
+  - openshift-adp


### PR DESCRIPTION
- Include source crs for LCA and OADP operators used for image based upgrade
- Provide reference examples in the policygentemplates and acmpolicygenerator

For EPIC: https://issues.redhat.com/browse/CNF-10498

/cc @browsell @pixelsoccupied @imiller0 