### PR TITLE
infra: Create a special hypershift-ci feature config

### DIFF
--- a/feature-configs/hypershift-ci/metallb/kustomization.yaml
+++ b/feature-configs/hypershift-ci/metallb/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../deploy/metallb
+
+patchesStrategicMerge:
+  - operator_subscription.yaml

--- a/feature-configs/hypershift-ci/metallb/operator_subscription.yaml
+++ b/feature-configs/hypershift-ci/metallb/operator_subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: metallb-operator-sub
+  namespace: openshift-metallb-system
+spec:
+  name: metallb-operator
+  channel: "alpha"
+  source: ci-index
+  sourceNamespace: openshift-marketplace

--- a/feature-configs/hypershift-ci/multinetworkpolicy/kustomization.yaml
+++ b/feature-configs/hypershift-ci/multinetworkpolicy/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../deploy/multinetworkpolicy

--- a/feature-configs/hypershift-ci/ptp/kustomization.yaml
+++ b/feature-configs/hypershift-ci/ptp/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../deploy/ptp
+
+patchesStrategicMerge:
+  - subscription.yaml
+

--- a/feature-configs/hypershift-ci/ptp/subscription.yaml
+++ b/feature-configs/hypershift-ci/ptp/subscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ptp-operator-subscription
+  namespace: openshift-ptp
+spec:
+  channel: "alpha"
+  name: ptp-operator
+  source: ci-index
+  sourceNamespace: openshift-marketplace

--- a/feature-configs/hypershift-ci/s2i/kustomization.yaml
+++ b/feature-configs/hypershift-ci/s2i/kustomization.yaml
@@ -1,0 +1,9 @@
+# Note: This feature request to deploy the sriov feature and the performance also in the cluster
+# For example:
+# FEATURES_ENVIRONMENT=demo FEATURES="performance sriov s2i" make feature-deploy
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../deploy/s2i

--- a/feature-configs/hypershift-ci/s2i/post_deploy.sh
+++ b/feature-configs/hypershift-ci/s2i/post_deploy.sh
@@ -1,0 +1,1 @@
+../../deploy/dpdk/post_deploy.sh

--- a/feature-configs/hypershift-ci/sriov/kustomization.yaml
+++ b/feature-configs/hypershift-ci/sriov/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../deploy/sriov
+
+patchesStrategicMerge:
+  - sriov-subscription.yaml

--- a/feature-configs/hypershift-ci/sriov/sriov-subscription.yaml
+++ b/feature-configs/hypershift-ci/sriov/sriov-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sriov-network-operator-subscription
+  namespace: openshift-sriov-network-operator
+spec:
+  channel: "alpha"
+  name: sriov-network-operator
+  source: ci-index
+  sourceNamespace: openshift-marketplace

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -31,6 +31,7 @@ export OC_TOOL="${OC_TOOL:-oc}"
 
 export CONTAINER_MGMT_CLI="${CONTAINER_MGMT_CLI:-podman}"
 export TESTS_IN_CONTAINER="${TESTS_IN_CONTAINER:-false}"
+export HYPERSHIFT_ENVIRONMENT="${HYPERSHIFT_ENVIRONMENT:-false}"
 
 # Map for the tests paths
 declare -A TESTS_PATHS=\

--- a/hack/setup-test-cluster.sh
+++ b/hack/setup-test-cluster.sh
@@ -44,6 +44,7 @@ do
     ${OC_TOOL} label --overwrite $node ptp/slave=""
 done
 
+if [ "${HYPERSHIFT_ENVIRONMENT}" == "false" ]; then
 # Note: this is intended to be the only pool we apply all mcs to.
 # Additional mcs must be added to this poll in the selector
 cat <<EOF | ${OC_TOOL} apply -f -
@@ -67,6 +68,7 @@ spec:
       node-role.kubernetes.io/${ROLE_WORKER_CNF}: ""
 ---
 EOF
+fi
 
 # Note: Patch the openshift network operator.
 # Add a dummy dhcp network to start the dhcp daemonset by the operator.


### PR DESCRIPTION
Create a feature-config for Hypershift which doesn't include
anything not supported like MachineConfigs for example.
Add a special variable for setting hypershift environment to avoid
setting MachineConfigs in the script.