### PR TITLE
OCPBUGS-36695: remove space from ptp4lopts for PTP HA

### DIFF
--- a/ztp/source-crs/PtpConfigForHAForEvent.yaml
+++ b/ztp/source-crs/PtpConfigForHAForEvent.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   profile:
     - name: "boundary-ha"
-      ptp4lOpts: " "
+      ptp4lOpts: ""
       phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16"
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10


### PR DESCRIPTION
The ptp4lOpts should be set to an empty string without any spaces for setting up the HA profile in PTP. This PR addresses the issue by removing the unintended empty space.