### PR TITLE
OCPBUGS-36774: [release-4.15] Update ptpconfig to configure NAV-TIMELS to be periodically sent via the UBX-CFG-MSG message

### DIFF
--- a/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
@@ -1,7 +1,7 @@
 # The grandmaster profile is provided for testing only
 # It is not installed on production clusters
-# In this example 2 cards $iface_master and $iface_master_1 are connected via SMA1 ports by a cable
-# and $iface_master_1 receives 1PPS signals from $iface_master
+# In this example two cards $iface_nic1 and $iface_nic2 are connected via
+# SMA1 ports by a cable and $iface_nic2 receives 1PPS signals from $iface_nic1
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
@@ -13,7 +13,7 @@ spec:
   profile:
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -O -37 -N 8 -R 16 -s $iface_master -n 24
+    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_nic1 -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -26,12 +26,12 @@ spec:
           LocalHoldoverTimeout: 14400
           MaxInSpecOffset: 100
         pins: $e810_pins
-        #  "$iface_master":
+        #  "$iface_nic1":
         #    "U.FL2": "0 2"
         #    "U.FL1": "0 1"
         #    "SMA2": "0 2"
         #    "SMA1": "2 1"
-        #  "$iface_master_1":
+        #  "$iface_nic2":
         #    "U.FL2": "0 2"
         #    "U.FL1": "0 1"
         #    "SMA2": "0 2"
@@ -90,6 +90,12 @@ spec:
               - "-p"
               - "MON-HW"
             reportOutput: true
+          - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,300
+              - "-P"
+              - "29.20"
+              - "-p"
+              - "CFG-MSG,1,38,300"
+            reportOutput: true
     ts2phcOpts: " "
     ts2phcConf: |
       [nmea]
@@ -103,21 +109,30 @@ spec:
       #example value of gnss_serialport is /dev/ttyGNSS_1700_0
       ts2phc.nmea_serialport $gnss_serialport
       leapfile  /usr/share/zoneinfo/leap-seconds.list
-      [$iface_master]
+      [$iface_nic1]
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0
-      [$iface_master_1]
+      [$iface_nic2]
+      ts2phc.master 0
       ts2phc.extts_polarity rising
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |
-      [$iface_master]
+      [$iface_nic1]
       masterOnly 1
-      [$iface_master_1]
+      [$iface_nic1_1]
       masterOnly 1
-      [$iface_master_1_1]
+      [$iface_nic1_2]
       masterOnly 1
-      [$iface_master_1_2]
+      [$iface_nic1_3]
+      masterOnly 1
+      [$iface_nic2]
+      masterOnly 1
+      [$iface_nic2_1]
+      masterOnly 1
+      [$iface_nic2_2]
+      masterOnly 1
+      [$iface_nic2_3]
       masterOnly 1
       [global]
       #

--- a/ztp/source-crs/PtpConfigGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigGmWpc.yaml
@@ -11,7 +11,7 @@ spec:
   profile:
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -O -37 -N 8 -R 16 -s $iface_master -n 24
+    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_master -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -82,6 +82,12 @@ spec:
               - "29.20"
               - "-p"
               - "MON-HW"
+            reportOutput: true
+          - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,300
+              - "-P"
+              - "29.20"
+              - "-p"
+              - "CFG-MSG,1,38,300"
             reportOutput: true
     ts2phcOpts: " "
     ts2phcConf: |


### PR DESCRIPTION
This is cherry pick cherry-pick of 
1. https://github.com/openshift-kni/cnf-features-deploy/pull/1929
2. https://github.com/openshift-kni/cnf-features-deploy/pull/1943

This commit enables NAV-TIMELS indications on WPC T-GM
configurations. This is required to enable automatic
leap seconds file update.
The phc2sys options are also changed to obtain the leap
seconds from phc instead of passing them as the command
line argument