### PR TITLE
cnf-tests: use sriov config daemon for exec instead of mco

### DIFF
--- a/cnf-tests/testsuites/pkg/utils/consts.go
+++ b/cnf-tests/testsuites/pkg/utils/consts.go
@@ -61,6 +61,7 @@ const (
 const (
 	// SriovOperatorDeploymentName contains the name of the sriov operator deployment
 	SriovOperatorDeploymentName = "sriov-network-operator"
+	ContainerSriovConfigDaemon  = "sriov-network-config-daemon"
 
 	// SriovNetworkNodePolicies contains the name of the sriov network node policies CRD
 	SriovNetworkNodePolicies = "sriovnetworknodepolicies.sriovnetwork.openshift.io"


### PR DESCRIPTION
for env like hypershift we don't have MCO so we need to use the sriov-config-daemon that is running on the cluster