### PR TITLE
ztp: Fix diffs between ref and source-crs

### DIFF
--- a/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
+++ b/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
@@ -38,12 +38,12 @@ spec:
     topologyPolicy: "restricted"
   # To use the standard (non-realtime) kernel, set enabled to false
   realTimeKernel:
-    enabled: true
+    enabled: {{ .spec.realTimeKernel.enabled }}
   workloadHints:
     # WorkloadHints defines the set of upper level flags for different type of workloads.
     # See https://github.com/openshift/cluster-node-tuning-operator/blob/master/docs/performanceprofile/performance_profile.md#workloadhints
     # for detailed descriptions of each item.
     # The configuration below is set for a low latency, performance mode.
-    realTime: {{ .spec.workloadHints.realTime }}
+    realTime: true
     highPowerConsumption: false
     perPodPowerManagement: false

--- a/ztp/kube-compare-reference/required/ptp-operator/PtpConfigGmWpc.yaml
+++ b/ztp/kube-compare-reference/required/ptp-operator/PtpConfigGmWpc.yaml
@@ -81,11 +81,11 @@ spec:
               - "-p"
               - "MON-HW"
             reportOutput: true
-          - args: #ubxtool -P 29.20 -p NAV-TIMELS
+          - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,248
               - "-P"
               - "29.20"
               - "-p"
-              - "NAV-TIMELS"
+              - "CFG-MSG,1,38,248"
             reportOutput: true
     ts2phcOpts: " "
     ts2phcConf: |


### PR DESCRIPTION
Match the PTP config to the source crs (source of truth) and set the realtime kernel as allowable variation (though RT is recommended)