### PR TITLE
[release-4.16] infra: Updated submodules refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 export FEATURES?=sctp performance vrf container-mount-namespace metallb tuningcni bondcni
 export SKIP_TESTS?=
 export FOCUS_TESTS?=
-export METALLB_OPERATOR_TARGET_COMMIT?=main
-export SRIOV_NETWORK_OPERATOR_TARGET_COMMIT?=master
-export CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT?=master
+export METALLB_OPERATOR_TARGET_COMMIT?=release-4.16
+export SRIOV_NETWORK_OPERATOR_TARGET_COMMIT?=release-4.16
+export CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT?=release-4.16
 IMAGE_BUILD_CMD ?= "docker"
 
 # The environment represents the kustomize patches to apply when deploying the features


### PR DESCRIPTION
Makefile rule `init-git-submodules` reads environment variables `METALLB_OPERATOR_TARGET_COMMIT`, `SRIOV_NETWORK_OPERATOR_TARGET_COMMIT`, `CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT` to
checkout the right branch for each submodules.
Though we need to find a better way to manage these dependency, this commit prevents Prow jobs to checkout master branch in 4.16 jobs.