### PR TITLE
ztp: OCPBUGS-37572: Fix aZTP for SiteConfig v1

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -342,7 +342,7 @@ spec:
 `
 
 const siteConfigStandardClusterTestZap = `
-apiVersion: ran.openshift.io/v2
+apiVersion: ran.openshift.io/v1
 kind: SiteConfig
 metadata:
   name: "test-standard"


### PR DESCRIPTION
Accelerated ZTP relies on ZTP adding a second ConfigMap reference in the AgentClusterInstall CR.  However, SiteConfig v1 only supports adding a single ConfigMap reference through the manifestsConfigMapRef field of the AgentClusterInstall CR.
This fix changes manifestsConfigMapRef to manifestsConfigMapRefs and allows adding the second ConfigMap reference.  It only does that if SiteConfig v1 is used and the "accelerated-ztp" label is found on the SiteConfig to be backward compatible.
Also changed the unit-test to test with v1 siteConfig