### PR TITLE
ztp: Change ArgoCD apps default deletion behavior

### DIFF
--- a/ztp/gitops-subscriptions/argocd/deployment/clusters-app.yaml
+++ b/ztp/gitops-subscriptions/argocd/deployment/clusters-app.yaml
@@ -27,3 +27,4 @@ spec:
       selfHeal: true
     syncOptions:
     - CreateNamespace=true
+    - PrunePropagationPolicy=background


### PR DESCRIPTION
after some investigations, ArgoCD deletion by
default is done in foreground mode. The opposite
than Kubernetes/Openshif that deletes on
background.

this seems to be creating issues deleting
ManagedClusters with observability enabled, and
not all the resources are cleaned correctly.

solves [CNF-13673)](https://issues.redhat.com/browse/CNF-13673)