### PR TITLE
ztp: Update example-sno.yaml

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -72,8 +72,8 @@ spec:
         bmcCredentialsName:
           name: "example-node1-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:11"
-        # Use UEFISecureBoot to enable secure boot
-        bootMode: "UEFI"
+        # Use UEFISecureBoot to enable secure boot, UEFI to disable
+        bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
         # disk partition at `/var/lib/containers` with ignitionConfigOverride. Some values must be updated. See DiskPartitionContainer.md for more details


### PR DESCRIPTION
In the 4.17 RAN RDS, we want to have secure boot enabled as the default boot mode, which is the mode that our System Test enables in their testing of the RAN RDS (this can optionally be disabled by changing bootMode back to just "UEFI").