### PR TITLE
ztp: Update example yaml files for 4.17 RAN RDS - make UEFISecureBoot d…

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
@@ -54,7 +54,7 @@ spec:
         bmcCredentialsName:
           name: "example-node1-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:11"
-        # Use UEFISecureBoot to enable secure boot, UEFI to disable. 
+        # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable. 
         bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
@@ -130,7 +130,8 @@ spec:
         bmcCredentialsName:
           name: "example-node3-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:33"
-        bootMode: "UEFI"
+        # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable. 
+        bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
         nodeNetwork:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
@@ -54,8 +54,8 @@ spec:
         bmcCredentialsName:
           name: "example-node1-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:11"
-        # Use UEFISecureBoot to enable secure boot for this node
-        bootMode: "UEFI"
+        # Use UEFISecureBoot to enable secure boot, UEFI to disable. 
+        bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
         nodeNetwork:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-3node.yaml
@@ -92,7 +92,8 @@ spec:
         bmcCredentialsName:
           name: "example-node2-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:22"
-        bootMode: "UEFI"
+        # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable. 
+        bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
         nodeNetwork:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-sno.yaml
@@ -72,8 +72,8 @@ spec:
         bmcCredentialsName:
           name: "example-node1-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:11"
-        # Use UEFISecureBoot to enable secure boot
-        bootMode: "UEFI"
+        # Use UEFISecureBoot to enable secure boot, UEFI to disable.
+        bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
         # disk partition at `/var/lib/containers` with ignitionConfigOverride. Some values must be updated. See DiskPartitionContainer.md for more details

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
@@ -89,7 +89,8 @@ spec:
         bmcCredentialsName:
           name: "example-node2-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:22"
-        bootMode: "UEFI"
+        # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable.
+        bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
         nodeNetwork:
@@ -126,7 +127,8 @@ spec:
         bmcCredentialsName:
           name: "example-node3-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:33"
-        bootMode: "UEFI"
+        # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable.
+        bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
         nodeNetwork:
@@ -163,7 +165,8 @@ spec:
         bmcCredentialsName:
           name: "example-node4-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:44"
-        bootMode: "UEFI"
+        # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable.
+        bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
         nodeNetwork:
@@ -200,7 +203,8 @@ spec:
         bmcCredentialsName:
           name: "example-node5-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:55"
-        bootMode: "UEFI"
+        # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable.
+        bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
         nodeNetwork:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
@@ -51,8 +51,8 @@ spec:
         bmcCredentialsName:
           name: "example-node1-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:11"
-        # Use UEFISecureBoot to enable secure boot for this node
-        bootMode: "UEFI"
+        # Use UEFISecureBoot to enable secure boot, UEFI to disable.
+        bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"
         nodeNetwork:

--- a/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/siteconfig/example-standard.yaml
@@ -51,7 +51,7 @@ spec:
         bmcCredentialsName:
           name: "example-node1-bmh-secret"
         bootMACAddress: "AA:BB:CC:DD:EE:11"
-        # Use UEFISecureBoot to enable secure boot, UEFI to disable.
+        # Use UEFISecureBoot to enable secure boot for this node, UEFI to disable.
         bootMode: "UEFISecureBoot"
         rootDeviceHints:
           deviceName: "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0"


### PR DESCRIPTION
…efault

In the 4.17 RAN RDS, we want to have secure boot enabled as the default boot mode, which is the mode that our System Test enables in their testing of the RAN RDS (this can optionally be disabled by changing bootMode back to just "UEFI").