### PR TITLE
Minor cleanup of annotated reference config

### DIFF
--- a/ztp/kube-compare-reference/metadata.yaml
+++ b/ztp/kube-compare-reference/metadata.yaml
@@ -94,24 +94,17 @@ Parts:
       - name: local-storage-operator
         type: Optional
         requiredTemplates:
-          - path: optional/local-storage-operator/StorageClass.yaml
-            config:
-              ignore-unspecified-fields: true
-          - path: optional/local-storage-operator/StorageLV.yaml
-            config:
-              ignore-unspecified-fields: true
           - path: optional/local-storage-operator/StorageNS.yaml
           - path: optional/local-storage-operator/StorageOperGroup.yaml
           - path: optional/local-storage-operator/StorageSubscription.yaml
             config:
               ignore-unspecified-fields: true
           - path: optional/storage/StoragePVC.yaml
-  - name: optional-storage
+  - name: optional-storage-lvmo
     Components:
       - name: storage
         type: Optional
         requiredTemplates:
-          - path: optional/storage/StorageLV.yaml
           - path: optional/storage/StorageLVMCluster.yaml
           - path: optional/storage/StorageLVMSubscription.yaml
             config:
@@ -120,6 +113,17 @@ Parts:
           - path: optional/storage/StorageLVMSubscriptionOperGroup.yaml
           - path: optional/storage/StoragePV.yaml
           # - path: optional/storage/StoragePVC.yaml # NOTE: we don't assert any of it's content so validation is not needed
+  - name: optional-storage
+    Components:
+      - name: storage
+        type: Optional
+        requiredTemplates:
+          - path: optional/local-storage-operator/StorageClass.yaml
+            config:
+              ignore-unspecified-fields: true
+          - path: optional/local-storage-operator/StorageLV.yaml
+            config:
+              ignore-unspecified-fields: true
   - name: optional-sriov-fec-operator
     Components:
       - name: sriov-fec-operator

--- a/ztp/kube-compare-reference/optional/local-storage-operator/StorageLV.yaml
+++ b/ztp/kube-compare-reference/optional/local-storage-operator/StorageLV.yaml
@@ -1,7 +1,7 @@
 apiVersion: "local.storage.openshift.io/v1"
 kind: "LocalVolume"
 metadata:
-  name: "local-disks"
+  name: {{ .metadata.name }}
   namespace: "openshift-local-storage"
 spec:
   logLevel: Normal

--- a/ztp/kube-compare-reference/optional/local-storage-operator/StorageOperGroup.yaml
+++ b/ztp/kube-compare-reference/optional/local-storage-operator/StorageOperGroup.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   targetNamespaces:
   - openshift-local-storage
+  upgradeStrategy: Default

--- a/ztp/kube-compare-reference/optional/sriov-fec-operator/AcceleratorsOperGroup.yaml
+++ b/ztp/kube-compare-reference/optional/sriov-fec-operator/AcceleratorsOperGroup.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   targetNamespaces:
   - vran-acceleration-operators
+  upgradeStrategy: Default

--- a/ztp/kube-compare-reference/optional/storage/StorageLVMSubscriptionOperGroup.yaml
+++ b/ztp/kube-compare-reference/optional/storage/StorageLVMSubscriptionOperGroup.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   targetNamespaces:
   - openshift-storage
+  upgradeStrategy: Default

--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogOperGroup.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogOperGroup.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   targetNamespaces:
   - openshift-logging
+  upgradeStrategy: Default

--- a/ztp/kube-compare-reference/required/cluster-tuning/operator-hub/DisconnectedICSP.yaml
+++ b/ztp/kube-compare-reference/required/cluster-tuning/operator-hub/DisconnectedICSP.yaml
@@ -3,6 +3,7 @@ kind: ImageContentSourcePolicy
 metadata:
     name: {{ .metadata.name }}
 spec:
-  {{- range .spec.repositoryDigestMirrors }}
-  - {{ . }}
-  {{- end }}
+{{ if .spec.repositoryDigestMirrors }}
+  repositoryDigestMirrors:
+{{ .spec.repositoryDigestMirrors | toYaml | indent 2 }}
+{{end}}

--- a/ztp/kube-compare-reference/required/lca/LcaSubscriptionOperGroup.yaml
+++ b/ztp/kube-compare-reference/required/lca/LcaSubscriptionOperGroup.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   targetNamespaces:
     - openshift-lifecycle-agent
+  upgradeStrategy: Default

--- a/ztp/kube-compare-reference/required/ptp-operator/PtpSubscriptionOperGroup.yaml
+++ b/ztp/kube-compare-reference/required/ptp-operator/PtpSubscriptionOperGroup.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   targetNamespaces:
   - openshift-ptp
+  upgradeStrategy: Default

--- a/ztp/kube-compare-reference/required/sriov-operator/SriovSubscriptionOperGroup.yaml
+++ b/ztp/kube-compare-reference/required/sriov-operator/SriovSubscriptionOperGroup.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   targetNamespaces:
   - openshift-sriov-network-operator
+  upgradeStrategy: Default


### PR DESCRIPTION
Assert default upgradeStrategy for OperatorGroup (the operator adds/prints the default value and we want to be explicit about requiring the default value)
Allow flexibility in storage operator (allowable 4.15+).
Fix handling of ICSP.