### PR TITLE
ztp: Add ClusterInstance to allowable CR types

### DIFF
--- a/ztp/gitops-subscriptions/argocd/deployment/app-project.yaml
+++ b/ztp/gitops-subscriptions/argocd/deployment/app-project.yaml
@@ -39,5 +39,7 @@ spec:
     kind: ManagedCluster
   - group: 'ran.openshift.io'
     kind: SiteConfig
+  - group: 'siteconfig.open-cluster-management.io'
+    kind: ClusterInstance
   sourceRepos:
   - '*'


### PR DESCRIPTION
CNF-12633 Add ClusterInstance to the set of allowable CR types to be synchronized via gitops. This CR is part of the SiteConfig operator which will allow cluster deployment from a ClusterInstance CR.