### PR TITLE
OCPBUGS-38670: ztp: enable automatic leap second handlling

### DIFF
--- a/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
@@ -13,7 +13,7 @@ spec:
   profile:
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -O -37 -N 8 -R 16 -s $iface_master -n 24
+    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_master -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -89,6 +89,12 @@ spec:
               - "29.20"
               - "-p"
               - "MON-HW"
+            reportOutput: true
+          - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,248
+              - "-P"
+              - "29.20"
+              - "-p"
+              - "CFG-MSG,1,38,248"
             reportOutput: true
     ts2phcOpts: " "
     ts2phcConf: |

--- a/ztp/source-crs/PtpConfigGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigGmWpc.yaml
@@ -11,7 +11,7 @@ spec:
   profile:
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -O -37 -N 8 -R 16 -s $iface_master -n 24
+    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_master -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -82,6 +82,12 @@ spec:
               - "29.20"
               - "-p"
               - "MON-HW"
+            reportOutput: true
+          - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,248
+              - "-P"
+              - "29.20"
+              - "-p"
+              - "CFG-MSG,1,38,248"
             reportOutput: true
     ts2phcOpts: " "
     ts2phcConf: |

--- a/ztp/source-crs/TunedPerformancePatch.yaml
+++ b/ztp/source-crs/TunedPerformancePatch.yaml
@@ -22,7 +22,7 @@ spec:
         [scheduler]
         group.ice-ptp=0:f:10:*:ice-ptp.*
         group.ice-gnss=0:f:10:*:ice-gnss.*
-        group.ice-dppls=0:f:10:*:ice-dplls.*
+        group.ice-dplls=0:f:10:*:ice-dplls.*
         [service]
         service.stalld=start,enable
         service.chronyd=stop,disable


### PR DESCRIPTION
This commit enables NAV-TIMELS indications on WPC T-GM configurations. This is required to enable automatic leap seconds file update.
The phc2sys options are also changed to obtain the leap seconds from phc instead of passing  them as the command line argument.
In addition, it fixes a typo in Tuned patch allowing correct ice dpll scheduling

This is is a manual cherry-pick of #1931, #1943, #1922 and #1975
