### PR TITLE
ztp: Remove OperatorHub from metadata.yaml of compare tool

### DIFF
--- a/ztp/kube-compare-reference/metadata.yaml
+++ b/ztp/kube-compare-reference/metadata.yaml
@@ -25,7 +25,6 @@ Parts:
       - name: optional-cluster-tuning
         type: Optional
         requiredTemplates:
-          - path: required/cluster-tuning/operator-hub/OperatorHub.yaml
           - path: required/cluster-tuning/DisableOLMPprof.yaml
   - name: required-lca
     Components:


### PR DESCRIPTION
Since 4.16 disabled the marketplace operator via cluster capabilities in the siteConfig, there is no need to disable default catalogsources with OperatorHub, so we can remove this check from the metadata.yaml