### PR TITLE
OCPBUGS-39095: ztp: DU reference should mark LCA operator as optional

### DIFF
--- a/ztp/kube-compare-reference/metadata.yaml
+++ b/ztp/kube-compare-reference/metadata.yaml
@@ -30,7 +30,7 @@ Parts:
   - name: required-lca
     Components:
       - name: lca
-        type: Required
+        type: Optional
         requiredTemplates:
           - path: required/lca/LcaSubscription.yaml
           - path: required/lca/LcaSubscriptionNS.yaml


### PR DESCRIPTION
This is not a required part of the DU RDS, but an optional component.