### PR TITLE
OCPBUGS-39104: ztp: Reference: Make OperatorHub and DisableOLMPprof optional

### DIFF
--- a/ztp/kube-compare-reference/metadata.yaml
+++ b/ztp/kube-compare-reference/metadata.yaml
@@ -24,7 +24,7 @@ Parts:
           - path: required/cluster-tuning/operator-hub/DisconnectedICSP.yaml
       - name: optional-cluster-tuning
         type: Optional
-        requiredTemplates:
+        optionalTemplates:
           - path: required/cluster-tuning/operator-hub/OperatorHub.yaml
           - path: required/cluster-tuning/DisableOLMPprof.yaml
   - name: required-lca


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
