### PR TITLE
ztp: Reference: Replace the node selector reference logic with something more flexible

### DIFF
--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
@@ -229,6 +229,6 @@ spec:
     priority: 4
     match:
     {{- range .match }}
-    - nodeLabel: {{ template "matchNodeSelector" (list .nodeLabel "node-role.kubernetes.io" ) }}
+    - nodeLabel: {{ template "matchNodeSelectorValue" (list .nodeLabel "node-role.kubernetes.io" ) }}
     {{- end }}
   {{- end }}

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHA.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHA.yaml
@@ -19,6 +19,6 @@ spec:
     priority: 4
     match:
     {{- range .match }}
-    - nodeLabel: {{ template "matchNodeSelector" (list .nodeLabel "node-role.kubernetes.io" ) }}
+    - nodeLabel: {{ template "matchNodeSelectorValue" (list .nodeLabel "node-role.kubernetes.io" ) }}
     {{- end }}
   {{- end }}

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHAForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHAForEvent.yaml
@@ -19,7 +19,7 @@ spec:
     priority: 4
     match:
     {{- range .match }}
-    - nodeLabel: {{ template "matchNodeSelector" (list .nodeLabel "node-role.kubernetes.io" ) }}
+    - nodeLabel: {{ template "matchNodeSelectorValue" (list .nodeLabel "node-role.kubernetes.io" ) }}
     {{- end }}
   {{- end }}
 

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMaster.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMaster.yaml
@@ -128,6 +128,6 @@ spec:
     priority: 4
     match:
     {{- range .match }}
-    - nodeLabel: {{ template "matchNodeSelector" (list .nodeLabel "node-role.kubernetes.io" ) }}
+    - nodeLabel: {{ template "matchNodeSelectorValue" (list .nodeLabel "node-role.kubernetes.io" ) }}
     {{- end }}
   {{- end }}

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMasterForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMasterForEvent.yaml
@@ -126,7 +126,7 @@ spec:
     priority: 4
     match:
     {{- range .match }}
-    - nodeLabel: {{ template "matchNodeSelector" (list .nodeLabel "node-role.kubernetes.io" ) }}
+    - nodeLabel: {{ template "matchNodeSelectorValue" (list .nodeLabel "node-role.kubernetes.io" ) }}
     {{- end }}
   {{- end }}
 

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlave.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlave.yaml
@@ -126,6 +126,6 @@ spec:
     priority: 4
     match:
     {{- range .match }}
-    - nodeLabel: {{ template "matchNodeSelector" (list .nodeLabel "node-role.kubernetes.io" ) }}
+    - nodeLabel: {{ template "matchNodeSelectorValue" (list .nodeLabel "node-role.kubernetes.io" ) }}
     {{- end }}
   {{- end }}

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlaveCvl.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlaveCvl.yaml
@@ -128,6 +128,6 @@ spec:
     priority: 4
     match:
     {{- range .match }}
-    - nodeLabel: {{ template "matchNodeSelector" (list .nodeLabel "node-role.kubernetes.io" ) }}
+    - nodeLabel: {{ template "matchNodeSelectorValue" (list .nodeLabel "node-role.kubernetes.io" ) }}
     {{- end }}
   {{- end }}

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlaveForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlaveForEvent.yaml
@@ -126,6 +126,6 @@ spec:
     priority: 4
     match:
     {{- range .match }}
-    - nodeLabel: {{ template "matchNodeSelector" (list .nodeLabel "node-role.kubernetes.io" ) }}
+    - nodeLabel: {{ template "matchNodeSelectorValue" (list .nodeLabel "node-role.kubernetes.io" ) }}
     {{- end }}
   {{- end }}

--- a/ztp/kube-compare-reference/optional/storage/StoragePV.yaml
+++ b/ztp/kube-compare-reference/optional/storage/StoragePV.yaml
@@ -18,7 +18,7 @@ spec:
       {{- range .spec.nodeAffinity.required.nodeSelectorTerms }}
       - matchExpressions:
         {{- range .matchExpressions }}
-        - key: {{ template "matchNodeSelector" (list .key "node-role.kubernetes.io" ) }}
+        - key: {{ template "matchNodeSelectorValueValue" (list .key "node-role.kubernetes.io" ) }}
           operator: In
           values:
           - ""

--- a/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
+++ b/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
@@ -29,7 +29,7 @@ spec:
         {{- end }}
       {{- end }}
   machineConfigPoolSelector:
-    pools.operator.machineconfiguration.openshift.io/master: ""
+    {{ template "matchNodeSelector" (list .spec.machineConfigPoolSelector "pools.operator.machineconfiguration.openshift.io" ) }}
   {{- if .spec.nodeSelector }}
   nodeSelector:
     {{ template "matchNodeSelector" (list .spec.nodeSelector "node-role.kubernetes.io" ) }}

--- a/ztp/kube-compare-reference/validate_node_selector.tmpl
+++ b/ztp/kube-compare-reference/validate_node_selector.tmpl
@@ -1,13 +1,23 @@
-{{- define "matchNodeSelector" }}
-{{- $answerKey := "A" }}
-{{- $answerValue := "B" }}
+{{- define "matchNodeSelectorValue" }}
 {{- $prefix := index . 1 }}
+{{- $value := index . 0 -}}
+{{- if (hasPrefix $prefix $value) -}}
+        {{ $value }}
+{{- else -}}
+        {{ $prefix }}/.*
+{{- end -}}
+{{- end }}
+
+{{- define "matchNodeSelector" }}
+{{- $prefix := index . 1 }}
+{{- $answerKey := (list $prefix "/.*") | join "" }}
+{{- $answerValue := "Prefix must match" }}
 {{- range $key, $value := (index . 0) -}}
-	{{- if (or (eq ((list $prefix "/master") | join "") $key) (eq ((list $prefix "/worker") | join "") $key )) -}}
+	{{- if (hasPrefix $prefix $key) -}}
 		{{- $answerKey = $key}}
 		{{- $answerValue = $value }}
 		{{- break }}
 	{{- end -}}
 {{- end -}}
 {{ $answerKey }}: {{ $answerValue | toYaml }}
-{{ end }}
+{{- end }}


### PR DESCRIPTION
This is needed both for templates where the node selector is a value and
not a yaml key:value mapping, as well as for forthcoming efforts to
introduce tooling to keep the reference config and source-crs in sync.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
