### PR TITLE
ztp: Reference: make SriovNetworkNodePolicy more flexible

### DIFF
--- a/ztp/kube-compare-reference/required/sriov-operator/SriovNetworkNodePolicy.yaml
+++ b/ztp/kube-compare-reference/required/sriov-operator/SriovNetworkNodePolicy.yaml
@@ -4,18 +4,4 @@ metadata:
   name: {{ .metadata.name }}
   namespace: openshift-sriov-network-operator
 spec:
-  # The attributes for Mellanox/Intel based NICs as below.
-  #     deviceType: netdevice/vfio-pci
-  #     isRdma: true/false
-  deviceType: {{ .spec.deviceType }}
-  isRdma: {{ .spec.isRdma }}
-  nicSelector:
-    # The exact physical function name must match the hardware used
-    {{- nindent 4 (.spec.nicSelector | toYaml) }}
-  {{- if .spec.nodeSelector }}
-  nodeSelector:
-    {{ template "matchNodeSelector" (list .spec.nodeSelector "node-role.kubernetes.io" ) }}
-  {{- end }}
-  numVfs: {{ .spec.numVfs }}
-  priority: {{ .spec.priority }}
-  resourceName: {{ .spec.resourceName }}
+{{ .spec | toYaml | indent 2 }}


### PR DESCRIPTION
This is to fix the issue below that isRdma and priority are reported as unexpected with null value on the live cluster:

```
--- /tmp/MERGED-3869953538/sriovnetwork-openshift-io-v1_sriovnetworknodepolicy_openshift-sriov-network-operator_pci-sriov 2024-09-12 15:31:10.502529916 +0000
+++ /tmp/LIVE-1145655967/sriovnetwork-openshift-io-v1_sriovnetworknodepolicy_openshift-sriov-network-operator_pci-sriov 2024-09-12 15:31:10.502529916 +0000
@@ -5,12 +5,10 @@
   namespace: openshift-sriov-network-operator
 spec:
   deviceType: netdevice
-  isRdma: null
   nicSelector:
     pfNames:
     - '%!s(<nil>)#0-3'
   nodeSelector:
     node-role.kubernetes.io/master: ""
   numVfs: 8
-  priority: null
   resourceName: pci_sriov
```