### PR TITLE
ztp: Add PlatformBackupRestoreWithIBGU to source-crs

### DIFF
--- a/ztp/source-crs/ibu/PlatformBackupRestoreWithIBGU.yaml
+++ b/ztp/source-crs/ibu/PlatformBackupRestoreWithIBGU.yaml
@@ -1,0 +1,35 @@
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: acm-klusterlet
+  annotations:
+    lca.openshift.io/apply-label: "apps/v1/deployments/open-cluster-management-agent/klusterlet,v1/secrets/open-cluster-management-agent/bootstrap-hub-kubeconfig,rbac.authorization.k8s.io/v1/clusterroles/klusterlet,v1/serviceaccounts/open-cluster-management-agent/klusterlet,scheduling.k8s.io/v1/priorityclasses/klusterlet-critical,rbac.authorization.k8s.io/v1/clusterroles/open-cluster-management:klusterlet-work:ibu-role,rbac.authorization.k8s.io/v1/clusterroles/open-cluster-management:klusterlet-admin-aggregate-clusterrole,rbac.authorization.k8s.io/v1/clusterrolebindings/klusterlet,operator.open-cluster-management.io/v1/klusterlets/klusterlet,apiextensions.k8s.io/v1/customresourcedefinitions/klusterlets.operator.open-cluster-management.io,v1/secrets/open-cluster-management-agent/open-cluster-management-image-pull-credentials" 
+  labels:
+    velero.io/storage-location: default
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+  - open-cluster-management-agent
+  includedClusterScopedResources:
+  - klusterlets.operator.open-cluster-management.io
+  - clusterroles.rbac.authorization.k8s.io
+  - clusterrolebindings.rbac.authorization.k8s.io
+  - priorityclasses.scheduling.k8s.io
+  includedNamespaceScopedResources:
+  - deployments
+  - serviceaccounts
+  - secrets
+  excludedNamespaceScopedResources: []
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: acm-klusterlet
+  namespace: openshift-adp
+  labels:
+    velero.io/storage-location: default
+  annotations:
+    lca.openshift.io/apply-wave: "1"
+spec:
+  backupName:
+    acm-klusterlet


### PR DESCRIPTION
When using ibgu,
`rbac.authorization.k8s.io/v1/clusterroles/open-cluster-management:klusterlet-work:ibu-role` should be added to apply-label annotation. This ClusterRole is needed to be resotred after pivot so that cgu can see the status of IBU.