### PR TITLE
ztp: reference: Add a CI check to ensure the reference metadata syntax is okay

### DIFF
--- a/ztp/Makefile
+++ b/ztp/Makefile
@@ -1,6 +1,6 @@
-.PHONY: ci-job test-policygen checkExtraManifests checkSourceCRsAnnotation test-policygen-kustomize test-siteconfig test-siteconfig-kustomize test-acm-ztp-generated-policies
+.PHONY: ci-job test-policygen checkExtraManifests checkSourceCRsAnnotation test-policygen-kustomize test-siteconfig test-siteconfig-kustomize test-acm-ztp-generated-policies check-reference
 
-ci-job: test-policygen checkExtraManifests checkSourceCRsAnnotation test-policygen-kustomize test-siteconfig test-siteconfig-kustomize test-acm-ztp-generated-policies
+ci-job: test-policygen checkExtraManifests checkSourceCRsAnnotation test-policygen-kustomize test-siteconfig test-siteconfig-kustomize test-acm-ztp-generated-policies check-reference
 
 test-policygen:
 	@echo "ZTP: Build policy generator and run test"
@@ -33,3 +33,6 @@ test-siteconfig-kustomize:
 
 test-acm-ztp-generated-policies:
 	$(MAKE) -C ./gitops-subscriptions test
+
+check-reference:
+	$(MAKE) -C ./kube-compare-reference check

--- a/ztp/kube-compare-reference/.gitignore
+++ b/ztp/kube-compare-reference/.gitignore
@@ -1,0 +1,1 @@
+/kubectl-cluster_compare

--- a/ztp/kube-compare-reference/Makefile
+++ b/ztp/kube-compare-reference/Makefile
@@ -1,0 +1,27 @@
+DOWNLOAD_URL := $(shell curl -s https://api.github.com/repos/openshift/kube-compare/releases/latest | jq -r '.assets[] | select(.name? | match("linux_amd64")) | .browser_download_url')
+ARCHIVE_NAME := kubectl-cluster_compare-linux_amd64.tar.gz
+
+.PHONY: check
+check: metadata_lint
+
+kubectl-cluster_compare:
+	@echo "Downloading kube-compare tool"
+	curl -sL $(DOWNLOAD_URL) -o $(ARCHIVE_NAME)
+	tar zxvf $(ARCHIVE_NAME) $@
+	rm -f $(ARCHIVE_NAME)
+
+.PHONY: metadata_lint
+metadata_lint: kubectl-cluster_compare
+	@echo "Running kube-compare to ensure metadata.yaml is sane"
+	@COMPARE_OUTPUT=$$(./kubectl-cluster_compare -r ./metadata.yaml -f /dev/null 2>&1); \
+	if grep -q 'an error occurred while parsing template' <<<"$${COMPARE_OUTPUT}"; then \
+		echo "Template parsing error"; \
+		echo "$${COMPARE_OUTPUT}"; \
+		exit 1; \
+	fi; \
+	echo "Okay"; \
+	exit 0
+
+.PHONY: clean
+clean:
+	rm -rf kubectl-cluster_compare


### PR DESCRIPTION
This doesn't make sure we are in sync with source-crs yet, but at least
it ensures our metadata.yaml isn't accidentally broken.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
