### PR TITLE
ztp: CNF-14458: Remove namespace from ClusterLogServiceAccount ClusterRoleBindings

### DIFF
--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountAuditBinding.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountAuditBinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logcollector-audit-logs-binding
-  namespace: openshift-logging
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"
 roleRef:

--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logcollector-infrastructure-logs-binding
-  namespace: openshift-logging
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"
 roleRef:

--- a/ztp/source-crs/ClusterLogServiceAccountAuditBinding.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccountAuditBinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logcollector-audit-logs-binding
-  namespace: openshift-logging
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 roleRef:

--- a/ztp/source-crs/ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logcollector-infrastructure-logs-binding
-  namespace: openshift-logging
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 roleRef:


### PR DESCRIPTION
- ClusterRoleBindings do not have namespaces, and it is currently being ignored when the resources are created