### PR TITLE
OCPBUGS-39093: ztp: reference: Fix ImageRegistryConfig.yaml to not show differences for null values

### DIFF
--- a/ztp/kube-compare-reference/metadata.yaml
+++ b/ztp/kube-compare-reference/metadata.yaml
@@ -136,8 +136,6 @@ parts:
       - name: image-registry
         allOrNoneOf:
           - path: optional/image-registry/ImageRegistryConfig.yaml
-            config:
-              ignore-unspecified-fields: true
           - path: optional/image-registry/ImageRegistryPV.yaml
   - name: optional-ptp-config
     components:

--- a/ztp/kube-compare-reference/optional/image-registry/ImageRegistryConfig.yaml
+++ b/ztp/kube-compare-reference/optional/image-registry/ImageRegistryConfig.yaml
@@ -5,12 +5,16 @@ metadata:
 spec:
   logLevel: Normal
   managementState: Managed
-  observedConfig: {{ .spec.observedConfig | toYaml | indent 2 }}
-  operatorLogLevel: {{ .spec.operatorLogLevel }}
-  {{- if .spec.proxy }}
-  proxy:
-{{ .spec.proxy | toYaml | indent 4 }}
+  {{- if .spec.httpSecret }}
+  httpSecret: {{ .spec.httpSecret | toYaml }}
   {{- end }}
+  observedConfig:
+    {{- .spec.observedConfig | toYaml | nindent 4 }}
+  {{- if .spec.operatorLogLevel }}
+  operatorLogLevel: {{ .spec.operatorLogLevel | toYaml }}
+  {{- end }}
+  proxy:
+    {{- .spec.proxy | toYaml | nindent 4 }}
   replicas: 1
   requests:
     read:
@@ -19,5 +23,5 @@ spec:
       maxWaitInQueue: 0s
   rolloutStrategy: Recreate
   storage:
-{{ .spec.storage | toYaml | indent 4 }}
+    {{- .spec.storage | toYaml | nindent 4 }}
   unsupportedConfigOverrides: null


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
