### PR TITLE
OCPBUGS-39149: ztp: empty file in sitegen kustomize plugin

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
@@ -601,7 +601,7 @@ func (scbuilder *SiteConfigBuilder) getExtraManifestMaps(roles map[string]bool, 
 							if err != nil {
 								errStr := fmt.Sprintf("Error could not read WorkloadManifest %s %s\n", clusterSpec.ClusterName, err)
 								return dataMap, doNotMerge, errors.New(errStr)
-							} else {
+							} else if v.(string) != "" {
 								data, err := addZTPAnnotationToManifest(v.(string))
 								if err != nil {
 									return dataMap, doNotMerge, err
@@ -670,11 +670,13 @@ func (scbuilder *SiteConfigBuilder) getExtraManifest(dataMap map[string]interfac
 				return dataMap, err
 			}
 
-			manifestFileStr, err := addZTPAnnotationToManifest(string(manifestFile))
-			if err != nil {
-				return dataMap, err
+			if len(manifestFile) != 0 {
+				manifestFileStr, err := addZTPAnnotationToManifest(string(manifestFile))
+				if err != nil {
+					return dataMap, err
+				}
+				dataMap[file.Name()] = manifestFileStr
 			}
-			dataMap[file.Name()] = manifestFileStr
 
 			// user provided CRs don't need to be merged
 			doNotMerge[file.Name()] = true


### PR DESCRIPTION
This MR includes a check to safely ignore empty file in testUserExtraManifest consumed by siteconfig-generator-kustomize-plugin, which caused addZTPAnnotationToManifest to panic.

This is an additional MR for addressing a missed scenario from 
https://github.com/openshift-kni/cnf-features-deploy/pull/2022