### PR TITLE
OCPBUGS-42750: Support upgrade from Cluster Logging 5.x to 6.0

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-clo5-cleanup.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-clo5-cleanup.yaml
@@ -1,0 +1,37 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: group-du-sno-clo5-cleanup
+placementBindingDefaults:
+  name: group-du-sno-clo5-cleanup-placement-binding
+policyDefaults:
+  namespace: ztp-group
+  # Allow this policy to be unbound from clusters based on a custom label
+  placement:
+    labelSelector:
+      matchExpressions:
+      - key: group-du-sno
+        operator: Exists
+      - key: du-profile
+        operator: In
+        values: ["latest"]
+      - key: clo5-cleanup-done
+        operator: DoesNotExist
+  remediationAction: inform
+  severity: low
+  # standards: []
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+    compliant: 10m
+    noncompliant: 10s
+policies:
+- name: group-du-sno-clo5-cleanup
+  policyAnnotations:
+    ran.openshift.io/ztp-deploy-wave: "11"
+  manifests:
+    - path: source-crs/ClusterLogging5Cleaup.yaml
+

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-clo5-cleanup.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-clo5-cleanup.yaml
@@ -33,5 +33,5 @@ policies:
   policyAnnotations:
     ran.openshift.io/ztp-deploy-wave: "11"
   manifests:
-    - path: source-crs/ClusterLogging5Cleaup.yaml
+    - path: source-crs/ClusterLogging5Cleanup.yaml
 

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/kustomization.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/kustomization.yaml
@@ -19,6 +19,8 @@ generators:
 # These are examples that should be replicated for every individual site. Use just one for each cluster configuration.
 - acm-example-sno-site.yaml
 - acm-example-multinode-site.yaml
+# This policy removes Cluster Logging operator 5.x artifacts after upgrading to 6.x
+- acm-group-du-clo5-cleanup.yaml
 
 resources:
 - ns.yaml

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-clo5-cleanup-policy.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-clo5-cleanup-policy.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+        ran.openshift.io/ztp-deploy-wave: "11"
+    name: group-du-sno-clo5-cleanup
+    namespace: ztp-group
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: group-du-sno-clo5-cleanup
+            spec:
+                evaluationInterval:
+                    compliant: 10m
+                    noncompliant: 10s
+                namespaceSelector:
+                    exclude:
+                        - kube-*
+                    include:
+                        - '*'
+                object-templates-raw: |
+                    {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterlogforwarders.logging.openshift.io").metadata.name) "" }}
+                    - complianceType: mustnothave
+                      objectDefinition:
+                        apiVersion: logging.openshift.io/v1
+                        kind: ClusterLogForwarder
+                        metadata:
+                          name: instance
+                          namespace: openshift-logging
+                    - complianceType: mustnothave
+                      objectDefinition:
+                        apiVersion: apiextensions.k8s.io/v1
+                        kind: CustomResourceDefinition
+                        metadata:
+                          name: clusterlogforwarders.logging.openshift.io
+                    {{ end }}
+                    {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterloggings.logging.openshift.io").metadata.name) "" }}
+                    - complianceType: mustnothave
+                      objectDefinition:
+                        apiVersion: logging.openshift.io/v1
+                        kind: ClusterLogging
+                        metadata:
+                          name: instance
+                          namespace: openshift-logging
+                    - complianceType: mustnothave
+                      objectDefinition:
+                        apiVersion: apiextensions.k8s.io/v1
+                        kind: CustomResourceDefinition
+                        metadata:
+                          name: clusterloggings.logging.openshift.io
+                    {{ end }}
+                remediationAction: inform
+                severity: low
+    remediationAction: inform
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placementrule-group-du-sno-clo5-cleanup
+    namespace: ztp-group
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: group-du-sno
+              operator: Exists
+            - key: du-profile
+              operator: In
+              values:
+                - latest
+            - key: clo5-cleanup-done
+              operator: DoesNotExist
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-group-du-sno-clo5-cleanup
+    namespace: ztp-group
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placementrule-group-du-sno-clo5-cleanup
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: group-du-sno-clo5-cleanup

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/hub-side-templating/group-du-sno-ranGen-templated.yaml
@@ -26,6 +26,7 @@ spec:
       policyName: "gr-du-sno-cfg-pc-templated"
       spec:
         outputs: '{{hub fromConfigMap "" "group-zones-configmap" (printf "%s-cluster-log-fwd-outputs" (index .ManagedClusterLabels "group-du-sno-zone")) | toLiteral hub}}'
+        filters: '{{hub fromConfigMap "" "group-zones-configmap" (printf "%s-cluster-log-fwd-filters" (index .ManagedClusterLabels "group-du-sno-zone")) | toLiteral hub}}'
         pipelines: '{{hub fromConfigMap "" "group-zones-configmap" (printf "%s-cluster-log-fwd-pipelines" (index .ManagedClusterLabels "group-du-sno-zone")) | toLiteral hub}}'
     ###
     - fileName: DisableOLMPprof.yaml # wave 10

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/kustomization.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/kustomization.yaml
@@ -26,6 +26,8 @@ resources:
 - hub-side-templating/configMaps/group-hardware-types-configmap.yaml
 - hub-side-templating/configMaps/group-zones-configmap.yaml
 - hub-side-templating/configMaps/site-data-configmap.yaml
+# This policy removes Cluster Logging operator 5.x artifacts after upgrading to 6.x
+- group-du-clo5-cleanup-policy.yaml
 
 # Updates to the PerformanceProfile or MachineConfigurations may take a short period of time before 
 # causing the MachineConfigPool to move to degraded. This patch adds an annotation to validator policy.

--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogForwarder.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogForwarder.yaml
@@ -20,7 +20,7 @@ spec:
     {{- .spec.pipelines | toYaml | nindent 2 }}
   {{- end }}
   serviceAccount:
-    name: log6collector
+    name: collector
   {{- if .spec.managementState }}
   managementState: {{ .spec.managementState }}
   {{- end }}

--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogForwarder.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogForwarder.yaml
@@ -20,7 +20,7 @@ spec:
     {{- .spec.pipelines | toYaml | nindent 2 }}
   {{- end }}
   serviceAccount:
-    name: {{ .spec.serviceAccount.name }}
+    name: log6collector
   {{- if .spec.managementState }}
   managementState: {{ .spec.managementState }}
   {{- end }}

--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccount.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: logcollector
+  name: log6collector
   namespace: openshift-logging
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"

--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccount.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: log6collector
+  name: collector
   namespace: openshift-logging
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"

--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountAuditBinding.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountAuditBinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: collect-audit-logs
 subjects:
 - kind: ServiceAccount
-  name: logcollector
+  name: log6collector
   namespace: openshift-logging

--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountAuditBinding.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountAuditBinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: collect-audit-logs
 subjects:
 - kind: ServiceAccount
-  name: log6collector
+  name: collector
   namespace: openshift-logging

--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: collect-infrastructure-logs
 subjects:
 - kind: ServiceAccount
-  name: logcollector
+  name: log6collector
   namespace: openshift-logging

--- a/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/ztp/kube-compare-reference/required/cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: collect-infrastructure-logs
 subjects:
 - kind: ServiceAccount
-  name: log6collector
+  name: collector
   namespace: openshift-logging

--- a/ztp/source-crs/ClusterLogForwarder.yaml
+++ b/ztp/source-crs/ClusterLogForwarder.yaml
@@ -11,7 +11,7 @@ spec:
   serviceAccount:
     name: collector
 status:
-  # Verify that that configuration is correct
+  # Verify that the configuration is correct
   conditions:
   - type: observability.openshift.io/Valid
     status: "True"

--- a/ztp/source-crs/ClusterLogForwarder.yaml
+++ b/ztp/source-crs/ClusterLogForwarder.yaml
@@ -9,7 +9,7 @@ spec:
 # outputs: $outputs
 # pipelines: $pipelines
   serviceAccount:
-    name: logcollector
+    name: log6collector
 
 #apiVersion: "observability.openshift.io/v1"
 #kind: ClusterLogForwarder
@@ -22,7 +22,7 @@ spec:
 #     name: kafka-open
 #     # below url is an example
 #     kafka:
-#       url: tcp://10.46.55.190:9092/test
+#       url: tcp://10.11.12.13:9092/test
 #   filters:
 #   - name: test-labels
 #     type: openshiftLabels

--- a/ztp/source-crs/ClusterLogForwarder.yaml
+++ b/ztp/source-crs/ClusterLogForwarder.yaml
@@ -9,7 +9,12 @@ spec:
 # outputs: $outputs
 # pipelines: $pipelines
   serviceAccount:
-    name: log6collector
+    name: collector
+status:
+  # Verify that that configuration is correct
+  conditions:
+  - type: observability.openshift.io/Valid
+    status: "True"
 
 #apiVersion: "observability.openshift.io/v1"
 #kind: ClusterLogForwarder
@@ -41,4 +46,4 @@ spec:
 #     outputRefs:
 #     - kafka-open
 #   serviceAccount:
-#     name: logcollector
+#     name: collector

--- a/ztp/source-crs/ClusterLogServiceAccount.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: log6collector
+  name: collector
   namespace: openshift-logging
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"

--- a/ztp/source-crs/ClusterLogServiceAccount.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: logcollector
+  name: log6collector
   namespace: openshift-logging
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"

--- a/ztp/source-crs/ClusterLogServiceAccountAuditBinding.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccountAuditBinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: collect-audit-logs
 subjects:
 - kind: ServiceAccount
-  name: logcollector
+  name: log6collector
   namespace: openshift-logging

--- a/ztp/source-crs/ClusterLogServiceAccountAuditBinding.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccountAuditBinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: collect-audit-logs
 subjects:
 - kind: ServiceAccount
-  name: log6collector
+  name: collector
   namespace: openshift-logging

--- a/ztp/source-crs/ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: collect-infrastructure-logs
 subjects:
 - kind: ServiceAccount
-  name: logcollector
+  name: log6collector
   namespace: openshift-logging

--- a/ztp/source-crs/ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: collect-infrastructure-logs
 subjects:
 - kind: ServiceAccount
-  name: log6collector
+  name: collector
   namespace: openshift-logging

--- a/ztp/source-crs/ClusterLogging5Cleanup.yaml
+++ b/ztp/source-crs/ClusterLogging5Cleanup.yaml
@@ -1,8 +1,15 @@
-# This content is only for use in creating a Policy which will remove 
-# the Cluster Logging Operator 5.x ClusterLogForwarder and ClusterLogging 
-# CRs from a cluster. The object-template-raw is used in order to handle 
-# existing clusters where the CRD is defined as well as new clusters 
+# This content is only for use in creating a Policy which will remove
+# the Cluster Logging Operator 5.x ClusterLogForwarder and ClusterLogging
+# CRs from a cluster. The object-template-raw is used in order to handle
+# existing clusters where the CRD is defined as well as new clusters
 # where the CRD is not defined.
+
+# This CR does not include the ran.openshift.io/ztp-deploy-wave
+# annotation because it is used only as part of a PolicyGenerator CR
+# where the annotation is explicitly added. To ensure logs are not
+# lost during upgrade this CR must be applied in a wave later than the
+# creation of the CLO 6.0 ClusterLogForwarder.observability CR and
+# validation that it is valid.
 object-templates-raw: |
   {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterlogforwarders.logging.openshift.io").metadata.name) "" }}
   - complianceType: mustnothave

--- a/ztp/source-crs/ClusterLogging5Cleaup.yaml
+++ b/ztp/source-crs/ClusterLogging5Cleaup.yaml
@@ -12,6 +12,12 @@ object-templates-raw: |
       metadata:
         name: instance
         namespace: openshift-logging
+  - complianceType: mustnothave
+    objectDefinition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: clusterlogforwarders.logging.openshift.io
   {{ end }}
   {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterloggings.logging.openshift.io").metadata.name) "" }}
   - complianceType: mustnothave
@@ -21,4 +27,10 @@ object-templates-raw: |
       metadata:
         name: instance
         namespace: openshift-logging
+  - complianceType: mustnothave
+    objectDefinition:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: clusterloggings.logging.openshift.io
   {{ end }}

--- a/ztp/source-crs/ClusterLogging5Cleaup.yaml
+++ b/ztp/source-crs/ClusterLogging5Cleaup.yaml
@@ -1,0 +1,24 @@
+# This content is only for use in creating a Policy which will remove 
+# the Cluster Logging Operator 5.x ClusterLogForwarder and ClusterLogging 
+# CRs from a cluster. The object-template-raw is used in order to handle 
+# existing clusters where the CRD is defined as well as new clusters 
+# where the CRD is not defined.
+object-templates-raw: |
+  {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterlogforwarders.logging.openshift.io").metadata.name) "" }}
+  - complianceType: mustnothave
+    objectDefinition:
+      apiVersion: logging.openshift.io/v1
+      kind: ClusterLogForwarder
+      metadata:
+        name: instance
+        namespace: openshift-logging
+  {{ end }}
+  {{ if ne (default "" (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterloggings.logging.openshift.io").metadata.name) "" }}
+  - complianceType: mustnothave
+    objectDefinition:
+      apiVersion: logging.openshift.io/v1
+      kind: ClusterLogging
+      metadata:
+        name: instance
+        namespace: openshift-logging
+  {{ end }}


### PR DESCRIPTION
The service account "logcollector" is owned by the Cluster Logging Operator version 5.x. If we use the same name for our user-created SA the upgrade from 5.x to 6.0 will delete the SA resulting in a loss of logging. Use log6collector to make it unique.