### PR TITLE
ztp: Added compare script to compare rendered CRs with source-crs

### DIFF
--- a/ztp/kube-compare-reference/Makefile
+++ b/ztp/kube-compare-reference/Makefile
@@ -1,5 +1,10 @@
+GOPATH  ?= $(HOME)/go
+GOBIN ?= $(GOPATH)/bin
+export HELMCONVERTOR := $(GOBIN)/helm-convert
 DOWNLOAD_URL := $(shell curl -s https://api.github.com/repos/openshift/kube-compare/releases/latest | jq -r '.assets[] | select(.name? | match("linux_amd64")) | .browser_download_url')
 ARCHIVE_NAME := kubectl-cluster_compare-linux_amd64.tar.gz
+HELM_URL := https://get.helm.sh/helm-v3.16.1-linux-amd64.tar.gz
+HELM_PKG := helm-linux-amd64.tar.gz
 
 .PHONY: check
 check: metadata_lint
@@ -24,4 +29,28 @@ metadata_lint: kubectl-cluster_compare
 
 .PHONY: clean
 clean:
-	rm -rf kubectl-cluster_compare
+	rm -rf kubectl-cluster_compare Chartv1 renderedv1 helm
+
+
+.PHONY: convert
+convert: $(HELMCONVERTOR) helm
+	@echo "Converting reference files to Helm Charts."
+	@$(HELMCONVERTOR) -r ./metadata.yaml -n Chartv1 -v default_value.yaml
+	@echo "Rendering Helm Charts to CR files."
+	@./helm template renderedv1 ./Chartv1 --output-dir renderedv1
+
+.PHONY: $(HELMCONVERTOR)
+$(HELMCONVERTOR):
+	@echo "Installing helm-convert tool..."
+	go install github.com/openshift/kube-compare/addon-tools/helm-convert@latest
+
+helm:
+	@echo "Installing helm..."
+	curl -fsSL $(HELM_URL) -o $(HELM_PKG)
+	tar -zxvf $(HELM_PKG) linux-amd64/helm --strip-components 1
+	rm -f $(HELM_PKG)
+
+
+.PHONY: compare
+compare: convert
+	./compare.sh

--- a/ztp/kube-compare-reference/compare.sh
+++ b/ztp/kube-compare-reference/compare.sh
@@ -1,0 +1,60 @@
+#! /bin/bash
+trap cleanup EXIT
+
+function cleanup() {
+  rm -rf source_file rendered_file same_file
+}
+
+function read_dir() {
+  local dir=$1
+  local file
+
+  for file in $(ls "$dir"); do
+    if [ -d "$dir""/""$file" ]; then
+      read_dir "$dir""/""$file"
+    else
+      echo "$dir""/""$file"
+    fi
+  done
+}
+
+
+function compare_cr {
+  local rendered_dir=$1
+  local source_dir=$2
+  status=0
+
+  read_dir "$rendered_dir" |grep yaml  > rendered_file
+  read_dir "$source_dir" |grep yaml  > source_file
+
+
+  while IFS= read -r file1; do
+    while IFS= read -r file2; do
+      if [ "${file1##*/}" = "${file2##*/}" ]; then
+        diff -u "$file1" "$file2"
+        status=$(( "$status" || $? ))
+        printf "\n\n" 
+        echo "$file1" >> same_file
+      fi
+    done < rendered_file
+  done < source_file
+
+
+  while IFS= read -r file; do
+    sed -i "/${file##*/}/d" source_file
+    sed -i "/${file##*/}/d" rendered_file
+  done < same_file
+
+}
+
+
+
+compare_cr renderedv1 ../source-crs
+
+if [[ -s source_file || -s rendered_file ]]; then
+  [ -s source_file ] && printf "\n\nThe following files exist in source-crs only, but not found in reference:\n" && cat source_file
+  [ -s rendered_file ] && printf "\nThe following files exist in reference only, but not found in source-crs:\n" && cat rendered_file
+  exit 1
+else
+  exit $status
+fi

--- a/ztp/kube-compare-reference/default_value.yaml
+++ b/ztp/kube-compare-reference/default_value.yaml
@@ -1,0 +1,177 @@
+optional_image_registry_ImageRegistryConfig:
+- spec:
+    httpSecret: {}
+    observedConfig: {}
+    operatorLogLevel: {}
+    proxy: {}
+    storage: {}
+optional_local_storage_operator_StorageClass:
+- metadata:
+    name: example-storage-class
+optional_local_storage_operator_StorageLV:
+- metadata:
+    name: local-disks
+optional_local_storage_operator_StorageSubscription:
+- spec:
+    source: redhat-operators-disconnected
+optional_ptp_config_PtpConfigDualCardGmWpc:
+- spec:
+    profile:
+    - plugins:
+        e810:
+          pins: $e810_pins
+    recommend:
+    - match:
+      - nodeLabel: "node-role.kubernetes.io/$mcp"
+optional_ptp_config_PtpConfigForHA:
+- spec:
+    recommend:
+    - match:
+      - nodeLabel: "node-role.kubernetes.io/$mcp"
+optional_ptp_config_PtpConfigForHAForEvent:
+- spec:
+    recommend:
+    - match:
+      - nodeLabel: "node-role.kubernetes.io/$mcp"
+optional_ptp_config_PtpConfigMaster:
+- spec:
+    profile:
+    - interface: $interface
+    recommend:
+    - match:
+      - nodeLabel: "node-role.kubernetes.io/$mcp"
+optional_ptp_config_PtpConfigMasterForEvent:
+- spec:
+    profile:
+    - interface: $interface
+    recommend:
+    - match:
+      - nodeLabel: "node-role.kubernetes.io/$mcp"
+optional_ptp_config_PtpConfigSlave:
+- spec:
+    profile:
+    - interface: $interface
+    recommend:
+    - match:
+      - nodeLabel: "node-role.kubernetes.io/$mcp"
+optional_ptp_config_PtpConfigSlaveCvl:
+- spec:
+    profile:
+    - interface: $interface
+    recommend:
+    - match:
+      - nodeLabel: "node-role.kubernetes.io/$mcp"
+optional_ptp_config_PtpConfigSlaveForEvent:
+- spec:
+    profile:
+    - interface: $interface
+    recommend:
+    - match:
+      - nodeLabel: "node-role.kubernetes.io/$mcp"
+optional_ptp_config_PtpOperatorConfig:
+- spec:
+    daemonNodeSelector:
+      node-role.kubernetes.io/$mcp: ""
+optional_ptp_config_PtpOperatorConfigForEvent:
+- spec:
+    daemonNodeSelector:
+      node-role.kubernetes.io/$mcp: ""
+    ptpEventConfig:
+      transportHost: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
+optional_sriov_fec_operator_AcceleratorsSubscription:
+- spec:
+    source: redhat-operators-disconnected
+optional_sriov_fec_operator_SriovFecClusterConfig:
+- spec:
+    acceleratorSelector:
+      pciAddress: {}
+    drainSkip: {}
+    nodeSelector: {}
+    physicalFunction:
+      bbDevConfig: {}
+optional_storage_StorageLVMCluster:
+- spec: {}
+optional_storage_StorageLVMSubscription:
+- spec:
+    source: redhat-operators-disconnected
+optional_storage_StoragePV:
+- spec:
+    nodeAffinity:
+      required:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: "node-role.kubernetes.io/$mcp"
+optional_storage_StoragePVC:
+- spec: {}
+required_cluster_logging_ClusterLogForwarder:
+- spec:
+    filters: {}
+    managementState: {}
+    outputs:
+    - name: {}
+      kafka:
+        url: {}
+    pipelines: {}
+    serviceAccount:
+      name: {}
+required_cluster_logging_ClusterLogSubscription:
+- spec:
+    source: redhat-operators-disconnected
+required_cluster_tuning_operator_hub_DefaultCatsrc:
+- metadata:
+    name: {}
+  spec:
+    displayName: {}
+    image: {}
+required_cluster_tuning_operator_hub_DisconnectedICSP:
+- metadata:
+    name: {}
+  spec:
+    repositoryDigestMirrors:
+    - mirrors: {}
+required_lca_LcaSubscription:
+- spec:
+    source: {}
+required_node_tuning_operator_PerformanceProfile:
+- spec:
+    additionalKernelArgs: {}
+    cpu:
+      isolated: {}
+      reserved: {}
+    hugepages:
+      defaultHugepagesSize: {}
+      pages:
+      - count: {}
+        node: {}
+        size: {}
+    machineConfigPoolSelector: {}
+    nodeSelector: {}
+    realTimeKernel:
+      enabled: {}
+required_ptp_operator_PtpSubscription:
+- spec:
+    source: redhat-operators-disconnected
+required_sriov_operator_SriovNetwork:
+- metadata:
+    name: {}
+  spec: {}
+required_sriov_operator_SriovNetworkNodePolicy:
+- metadata:
+    name: $name
+  spec:
+    deviceType: {}
+    isRdma: {}
+    nicSelector: {}
+    nodeSelector: {}
+    numVfs: {}
+    priority: {}
+    resourceName: {}
+required_sriov_operator_SriovOperatorConfig:
+- spec:
+    configDaemonNodeSelector: {}
+required_sriov_operator_SriovOperatorConfigForSNO:
+- spec:
+    configDaemonNodeSelector: {}
+required_sriov_operator_SriovSubscription:
+- spec:
+    source: redhat-operators-disconnected


### PR DESCRIPTION
This PR includes the following changes:
1. The helm-convert tool is used to generate helm chart from reference files and default_value.yaml;
2. The helm template cmd is used to render chart to CR files;
3. Using script compare.sh to compare the rendered CR files with source-crs.