### PR TITLE
ztp: CNF-14762: add vrb2 and update refs

### DIFF
--- a/ztp/source-crs/SriovFecClusterConfig.yaml
+++ b/ztp/source-crs/SriovFecClusterConfig.yaml
@@ -17,5 +17,6 @@ spec:
     vfDriver: "vfio-pci"
     vfAmount: 16
     bbDevConfig: $bbDevConfig
-#Recommended configuration for Intel ACC100 (Mount Bryce) FPGA here: https://github.com/smart-edge-open/openshift-operator/blob/main/spec/openshift-sriov-fec-operator.md#sample-cr-for-wireless-fec-acc100
-#Recommended configuration for Intel N3000 FPGA here: https://github.com/smart-edge-open/openshift-operator/blob/main/spec/openshift-sriov-fec-operator.md#sample-cr-for-wireless-fec-n3000
+#Recommended configuration for Intel ACC100 eASIC here: https://github.com/intel/sriov-fec-operator/blob/main/spec/sriov-fec-operator.md#sample-cr-for-wireless-fec-acc100
+#Recommended configuration for Intel ACC200 (SPR-EE) here: https://github.com/intel/sriov-fec-operator/blob/main/spec/sriov-fec-operator.md#sample-cr-for-wireless-fec-acc200
+

--- a/ztp/source-crs/SriovVrbClusterConfig.yaml
+++ b/ztp/source-crs/SriovVrbClusterConfig.yaml
@@ -1,0 +1,20 @@
+apiVersion: sriovvrb.intel.com/v1
+kind: SriovVrbClusterConfig
+metadata:
+  name: config
+  namespace: vran-acceleration-operators 
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  drainSkip: $drainSkip # use true for SNO, false by default
+  priority: 1
+  nodeSelector:
+    node-role.kubernetes.io/$mcp: "" # use master for SNO
+  acceleratorSelector:
+    pciAddress: $pciAddress
+  physicalFunction:  
+    pfDriver: "vfio-pci"
+    vfDriver: "vfio-pci"
+    vfAmount: 16
+    bbDevConfig: $bbDevConfig
+


### PR DESCRIPTION
This PR:

- Adds support for the Intel vRAN Boost v2 (vrb2) accelerator in ZTP via a new source CR called SriovVrbClusterConfig.  This is necessary to support changes in the Intel authored SR-IOV FEC Operator to support this accelerator.
- Updates documentation links for Intel's ACC100 and ACC200 accelerators, as the links were no longer correct and giving 404s.  Note that the Intel N3000 FPGA is a discontinued product, so I have removed references to it: https://www.intel.com/content/www/us/en/content-details/724231/product-discontinuance-notification-pdn2211.html

The source Custom Resource I am including contains:

- wave set to 10 as any other configuration manifest
- drainskip set to optional. 
- bbDevConfig is referenced and it is expected that the user will provide the appropriate configuration.  I have not included a reference to Intel's documentation as they do not have a reference yet.  I will push a new PR later once references are added by Intel to aid our customers and partners.