### PR TITLE
CNF-14780: fix ptp templates

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-standard-ranGen.yaml
@@ -41,9 +41,9 @@ policies:
             name: du-ptp-slave
           spec:
             profile:
-                - interface: ens6f0
+                - interface: ens5f0
                   name: slave
-                  phc2sysOpts: -a -r -n 25
+                  phc2sysOpts: -a -r -n 24
                   ptp4lOpts: -2 -s --summary_interval -4
       openapi:
         path: schema.openapi

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/group-du-standard-ranGen.yaml
@@ -21,9 +21,9 @@ spec:
         profile:
         - name: "slave"
           # This interface must match the hardware in this group
-          interface: "ens6f0"
+          interface: "ens5f0"
           ptp4lOpts: "-2 -s --summary_interval -4"
-          phc2sysOpts: "-a -r -n 25"
+          phc2sysOpts: "-a -r -n 24"
     - fileName: SriovOperatorConfig.yaml
       policyName: "config-policy"
     - fileName: PerformanceProfile.yaml


### PR DESCRIPTION
This is to fix a typo in ptp templates using interface ens6f0 instead of interface enf5f0 and phc2sysOpts: "-a -r -n 25" instead of phc2sysOpts: "-a -r -n 24"