### PR TITLE
CNF-14990: Fix gimme golang install for go > 1.20

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -25,7 +25,9 @@ RUN mkdir ~/bin && \
     # install Go using gimme
     curl -sL -o /usr/local/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && \
     chmod +x /usr/local/bin/gimme && \
-    eval "$(gimme $GOVERSION)" && \
+    # we must include the .x for gimme for golang > 1.20
+    # see https://github.com/travis-ci/gimme/issues/210
+    eval "$(gimme $GOVERSION.x)" && \
     cat $GIMME_ENV >> $HOME/.bashrc && \
     # get required golang tools and OC client
     go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0 && \


### PR DESCRIPTION
Fixes failing CI job after golang was updated to 1.21 for release-4.16
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-openshift-kni-cnf-features-deploy-release-4.16-images/1846645209954258944
