### PR TITLE
infra: Fix gimme version (again...)

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -3,7 +3,9 @@ FROM quay.io/fedora/fedora:37-x86_64
 ENV GOPATH /go
 ENV GOBIN /go/bin
 ENV GOCACHE /go/.cache
-ENV GOVERSION=1.21
+# we must include the .z version for gimme for golang > 1.20
+# see https://issues.redhat.com/browse/CNF-14990
+ENV GOVERSION=1.21.13
 ENV PATH=$PATH:/root/.gimme/versions/go"$GOVERSION".linux.amd64/bin:$GOBIN
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/cnf-features-deploy
 
@@ -25,9 +27,7 @@ RUN mkdir ~/bin && \
     # install Go using gimme
     curl -sL -o /usr/local/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && \
     chmod +x /usr/local/bin/gimme && \
-    # we must include the .x for gimme for golang > 1.20
-    # see https://github.com/travis-ci/gimme/issues/210
-    eval "$(gimme $GOVERSION.x)" && \
+    eval "$(gimme $GOVERSION)" && \
     cat $GIMME_ENV >> $HOME/.bashrc && \
     # get required golang tools and OC client
     go install github.com/onsi/ginkgo/v2/ginkgo@v2.15.0 && \


### PR DESCRIPTION
- By using .x previously, it would cause the $PATH to not be set correctly and thus the go binaries were not being found
- A more permanent fix it being worked (CNF-14990) but this will fix 4.16 for now