### PR TITLE
OCPBUGS-43574: ztp: Fix kube compare unordered list

### DIFF
--- a/ztp/kube-compare-reference/unordered_list.tmpl
+++ b/ztp/kube-compare-reference/unordered_list.tmpl
@@ -2,17 +2,13 @@
 {{- $result := list }}
 {{- $expectedArgs := index . 1 }}
 {{- range $value := (index . 0) }}
-	{{- $found := false }}
-	{{- range $expected := $expectedArgs }}
-		{{- if eq $value $expected }}
-			{{- $result = append $result $value }}
-			{{- $found = true }}
-			{{- break }}
-		{{- end }}
-	{{- end }}
-	{{- if not $found }}
-                {{- $result = append $result $value }}
-	{{- end }}
+  {{- if has $value $expectedArgs }}
+    {{- $result = append $result $value }}
+    {{- $expectedArgs = without $expectedArgs $value }}
+  {{- end }}
+{{- end }}
+{{- range $value := $expectedArgs }}
+  {{- $result = append $result $value }}
 {{- end }}
 {{- $result | toYaml | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
The unordered list handler needs to preserve all values from the expected list when comparing. This fix orders the "expected" keys to match any entries in the list being tested and then appends any remaining expected entries to the end.