### PR TITLE
ztp: CNF-14991: Fix instability in policy-generator-plugin usage

### DIFF
--- a/ztp/tools/pgt2acmpg/.gitignore
+++ b/ztp/tools/pgt2acmpg/.gitignore
@@ -1,0 +1,1 @@
+kustomize/

--- a/ztp/tools/pgt2acmpg/scripts/build-acmpg-plugin.sh
+++ b/ztp/tools/pgt2acmpg/scripts/build-acmpg-plugin.sh
@@ -11,8 +11,8 @@ echo "Created ${TMP_DIR}"
 pushd "${TMP_DIR}"
 
 # The details we will use to query ACM
-ACM_FORK="stolostron"
-ACM_BRANCH="main"
+ACM_FORK="${ACM_FORK:-stolostron}"
+ACM_BRANCH="${ACM_BRANCH:-main}"
 
 # We need to check what version of the policy generator tag is in use
 POLICY_GENERATOR_TAG=$(

--- a/ztp/tools/pgt2acmpg/scripts/build-acmpg-plugin.sh
+++ b/ztp/tools/pgt2acmpg/scripts/build-acmpg-plugin.sh
@@ -4,16 +4,38 @@ set -o errexit -o nounset -o pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CNF_FEATURE_DEPLOY_ROOT=$SCRIPT_DIR/../../../..
 
-# Builds the latest version of policy-generator-plugin
-# We can no longer use go install because of https://github.com/golang/go/issues/44840
-# Instead we need to clone the policy-generator-plugin project and build the executable
+# Due to https://github.com/golang/go/issues/44840 we are unable to use go install
+# Instead we will download the source code and compile it ourselves
 TMP_DIR=$(mktemp -d -p .)
-echo "Created $TMP_DIR"
-cd "$TMP_DIR"
-git clone --depth 1 --branch main --single-branch https://github.com/open-cluster-management-io/policy-generator-plugin.git
-cd policy-generator-plugin
+echo "Created ${TMP_DIR}"
+pushd "${TMP_DIR}"
+
+# The details we will use to query ACM
+ACM_FORK="stolostron"
+ACM_BRANCH="main"
+
+# We need to check what version of the policy generator tag is in use
+POLICY_GENERATOR_TAG=$(
+    curl "https://raw.githubusercontent.com/${ACM_FORK}/multicloud-operators-subscription/refs/heads/${ACM_BRANCH}/build/Dockerfile" \
+    | awk '/ENV POLICY_GENERATOR_TAG=/ {print $2}' | cut -d= -f2-
+)
+
+# Print the tag to make diagnosing issues easier
+echo "Detected POLICY_GENERATOR_TAG=${POLICY_GENERATOR_TAG}"
+
+# Download the matching branch
+git clone --depth 1 --branch "${POLICY_GENERATOR_TAG}" --single-branch "https://github.com/${ACM_FORK}/policy-generator-plugin.git"
+
+# build binary and copy it out
+pushd "policy-generator-plugin"
 go mod vendor
 make build-binary
 cp PolicyGenerator "$1"
-rm -rf "$TMP_DIR"
-echo "Deleted $TMP_DIR"
+
+# popd twice to get back where we started
+popd
+popd
+
+# cleanup directory
+rm -rf "${TMP_DIR}"
+echo "Deleted ${TMP_DIR}"


### PR DESCRIPTION
- Specifically check for and use the exact policy-generator-plugin version used by ACM
- When used in older branches the ACM_BRANCH value can be updated to match the appropriate ACM version in use in that release
- Fixed tmp dir not getting cleaned up due to incorrect working directory when rm was called
- Add .gitignore entry for built kustomize files