### PR TITLE
CNF-15050: ztp: Remove ztp-deploy-wave number from validator source crs for ACM PGs

### DIFF
--- a/ztp/source-crs/validatorCRs/informDuValidatorMaster.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidatorMaster.yaml
@@ -2,8 +2,6 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
   name: master
-  annotations:
-    ran.openshift.io/ztp-deploy-wave: "10000"
 status:
   conditions:
     - type: Updated

--- a/ztp/source-crs/validatorCRs/informDuValidatorWorker.yaml
+++ b/ztp/source-crs/validatorCRs/informDuValidatorWorker.yaml
@@ -2,8 +2,6 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
   name: worker
-  annotations:
-    ran.openshift.io/ztp-deploy-wave: "10000"
 status:
   conditions:
     - type: Updated


### PR DESCRIPTION
informDuValidatorMaster.yaml and informDuValidatorWorker.yaml were created for use in AGM PGs only, so the wave numbers added in the crs are unccessary and useless. For auto-created CGU that pick up the policy, the wave number should be added directly in the PG , as shown in the example (https://github.com/openshift-kni/cnf-features-deploy/blob/master/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-group-du-sno-validator-ranGen.yaml#L40).

With the O-Cloud manager orchestrating the lifecycle of cluster provisioning, CGU is not part of the process for cluster configuration.  Enforce policies are generated directly for configurations, along with an inform validator policy to validate completion. The ztp-deploy-wave number in the validator source crs causes the validator policy to never become compliant, we should, and can safely, remove it from these files.


/cc @browsell @irinamihai 