### PR TITLE
ztp: CNF-14990: Fix golang ocp builder image in resource generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ module github.com/openshift-kni/cnf-features-deploy
 // This should also be matched within this project at:
 //   - cnf-tests/Dockerfile*
 //   - openshift-ci/Dockerfile*
+//   - ztp/resource-generator/Containerfile
 //   - ztp/tools/pgt2acmpg/go.mod
 go 1.22
 

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 as builder
 ARG IMAGE_REF
 USER root
 ENV PKG_ROOT=cnf-features-deploy


### PR DESCRIPTION
- Should match the golang and ocp versions used in current release