### PR TITLE
CNF-14178: ztp: reference: Use binary realease of helm-convert instead of go install [release-4.16]

### DIFF
--- a/ztp/kube-compare-reference/Makefile
+++ b/ztp/kube-compare-reference/Makefile
@@ -1,8 +1,5 @@
-GOPATH  ?= $(HOME)/go
-GOBIN ?= $(GOPATH)/bin
-export HELMCONVERTOR := $(GOBIN)/helm-convert
-DOWNLOAD_URL := $(shell curl -s https://api.github.com/repos/openshift/kube-compare/releases/latest | jq -r '.assets[] | select(.name? | match("linux_amd64")) | .browser_download_url')
-ARCHIVE_NAME := kubectl-cluster_compare-linux_amd64.tar.gz
+CLUSTER_COMPARE_DOWNLOAD_URL := $(shell curl -s https://api.github.com/repos/openshift/kube-compare/releases/latest | jq -r '.assets[] | select(.name? | match("kube-compare_linux_amd64")) | .browser_download_url')
+HELM_CONVERT_DOWNLOAD_URL := $(shell curl -s https://api.github.com/repos/openshift/kube-compare/releases/latest | jq -r '.assets[] | select(.name? | match("kube-compare_addon_tools_linux_amd64")) | .browser_download_url')
 HELM_URL := https://get.helm.sh/helm-v3.16.1-linux-amd64.tar.gz
 HELM_PKG := helm-linux-amd64.tar.gz
 
@@ -10,10 +7,16 @@ HELM_PKG := helm-linux-amd64.tar.gz
 check: metadata_lint compare
 
 kubectl-cluster_compare:
-	@echo "Downloading kube-compare tool"
-	curl -sL $(DOWNLOAD_URL) -o $(ARCHIVE_NAME)
-	tar zxvf $(ARCHIVE_NAME) $@
-	rm -f $(ARCHIVE_NAME)
+	@echo "Downloading $@"
+	curl -sL $(CLUSTER_COMPARE_DOWNLOAD_URL) -o $@.tgz
+	tar zxvf $@.tgz $@
+	rm -f $@.tgz
+
+helm-convert:
+	@echo "Downloading $@"
+	curl -sL $(HELM_CONVERT_DOWNLOAD_URL) -o $@.tgz
+	tar zxvf $@.tgz $@
+	rm -f $@.tgz
 
 .PHONY: metadata_lint
 metadata_lint: kubectl-cluster_compare
@@ -33,17 +36,12 @@ clean:
 
 
 .PHONY: convert
-convert: $(HELMCONVERTOR) helm
+convert: helm-convert helm
 	@echo "Converting reference files to Helm Charts."
 	@rm -rf Chartv1 renderedv1
-	@$(HELMCONVERTOR) -r ./metadata.yaml -n Chartv1 -v default_value.yaml
+	@./helm-convert -r ./metadata.yaml -n Chartv1 -v default_value.yaml
 	@echo "Rendering Helm Charts to CR files."
 	@./helm template renderedv1 ./Chartv1 --output-dir renderedv1
-
-.PHONY: $(HELMCONVERTOR)
-$(HELMCONVERTOR):
-	@echo "Installing helm-convert tool..."
-	go install github.com/openshift/kube-compare/addon-tools/helm-convert@latest
 
 helm:
 	@echo "Installing helm..."


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
