### PR TITLE
cnf-tests: Add debug information for flake tests

### DIFF
--- a/cnf-tests/testsuites/pkg/pods/pods.go
+++ b/cnf-tests/testsuites/pkg/pods/pods.go
@@ -424,7 +424,7 @@ func ExecCommandInContainer(cs *testclient.ClientSet, pod corev1.Pod, containerN
 			Stdin:     true,
 			Stdout:    true,
 			Stderr:    true,
-			TTY:       true,
+			TTY:       false,
 		}, scheme.ParameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(cs.Config, "POST", req.URL())
@@ -436,7 +436,7 @@ func ExecCommandInContainer(cs *testclient.ClientSet, pod corev1.Pod, containerN
 		Stdin:  os.Stdin,
 		Stdout: &buf,
 		Stderr: os.Stderr,
-		Tty:    true,
+		Tty:    false,
 	})
 	if err != nil {
 		return buf, fmt.Errorf("remote command %v error [%w]. output [%s]", command, err, buf.String())


### PR DESCRIPTION
Test case
```
[sriov] NUMA node alignment [BeforeAll] Validate the creation of a pod with excludeTopology set to False and an SRIOV interface in a different NUMA node than the pod
```

flakes with the following error:
```
Can't find a suitable node for testing: node [cnfdu3] has no NUMA0 devices, node [cnfdu4] has no NUMA0 devices,
```

Dump NUMA nodes for each network device when failing.
Use Gomega instead of `ginkgo.Fail` to trigger a k8sreporter archive.

[Sample failure](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.18-e2e-telco5g-cnftests/1857483975761596416)