### PR TITLE
cnf-tests: Reduce size of cnf-tests image

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -65,7 +65,8 @@ FROM quay.io/openshift/origin-oc-rpms:4.16 AS oc
 FROM centos:7
 
 # python3 is needed for hwlatdetect
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs linuxptp iperf3 python3 nc iptables
+RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs linuxptp iperf3 python3 nc iptables && \
+    yum clean all
 
 RUN mkdir -p /usr/local/etc/cnf
 

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -71,7 +71,8 @@ FROM quay.io/openshift/origin-oc-rpms:4.16 AS oc
 FROM openshift/origin-base
 
 # python3 is needed for hwlatdetect
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3 python3 nc iptables
+RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3 python3 nc iptables && \
+    yum clean all
 
 RUN mkdir -p /usr/local/etc/cnf
 


### PR DESCRIPTION
Container image size of `quay.io/openshift-kni/cnf-tests:4.18` is 1.85GB:
```
$  docker images quay.io/openshift-kni/cnf-tests:4.18
REPOSITORY                        TAG       IMAGE ID       CREATED        SIZE
quay.io/openshift-kni/cnf-tests   4.18      a58152e3611a   22 hours ago   1.85GB
```

This cause test flakiness, as pulling the image might exceed timeouts. [1]

Most of the problem is in the dnf cache:
```
$ docker run quay.io/openshift-kni/cnf-tests:4.18 du -sh /var/cache/dnf
1.2G    /var/cache/dnf
```

Add `yum clean all` command after installing dependencies in the final image

With these changes, the image size is reduced to `665MB`:
```
$ docker images local-cnf-tests
REPOSITORY        TAG       IMAGE ID       CREATED          SIZE
local-cnf-tests   latest    681d224cbd65   44 seconds ago   665MB
```

[1] https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-kni_cnf-features-deploy/1990/pull-ci-openshift-kni-cnf-features-deploy-master-e2e-aws-ci-tests/1843231458743816192