### PR TITLE
CNF-15792: ztp: reference: Use capturegroupInlineDiff for PTPConfig [4.14]

### DIFF
--- a/ztp/kube-compare-reference/metadata.yaml
+++ b/ztp/kube-compare-reference/metadata.yaml
@@ -157,8 +157,28 @@ parts:
         oneOf:
           # TODO: the INI files embedded in PtpConfig objects are not handled. CNF-13528
           - path: optional/ptp-config/PtpConfigBoundary.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
           - path: optional/ptp-config/PtpConfigGmWpc.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ts2phcConf
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
           - path: optional/ptp-config/PtpConfigDualCardGmWpc.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ts2phcConf
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
           - path: optional/ptp-config/PtpConfigMaster.yaml
           - path: optional/ptp-config/PtpConfigSlave.yaml
           # TODO: If one of these 4 is selected, they should be paired with 'PtpOperatorConfigForEvent.yaml' above
@@ -166,6 +186,10 @@ parts:
           - path: optional/ptp-config/PtpConfigForHAForEvent.yaml
           - path: optional/ptp-config/PtpConfigMasterForEvent.yaml
           - path: optional/ptp-config/PtpConfigBoundaryForEvent.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
   - name: optional-console-disable
     components:
       - name: console-disable

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundary.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundary.yaml
@@ -16,13 +16,13 @@ spec:
       logReduce: "true"
     ptp4lConf: |
       # The interface name is hardware-specific
-      [$iface_slave]
+      [(?<iface_timeRx>[[:alnum:]]+)]
       masterOnly 0
-      [$iface_master_1]
+      [(?<iface_timeTx_1>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_2]
+      [(?<iface_timeTx_2>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_3]
+      [(?<iface_timeTx_3>[[:alnum:]]+)]
       masterOnly 1
       [global]
       #

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundaryForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundaryForEvent.yaml
@@ -16,13 +16,13 @@ spec:
       logReduce: "true"
     ptp4lConf: |
       # The interface name is hardware-specific
-      [$iface_slave]
+      [(?<iface_timeRx>[[:alnum:]]+)]
       masterOnly 0
-      [$iface_master_1]
+      [(?<iface_timeTx_1>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_2]
+      [(?<iface_timeTx_2>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_3]
+      [(?<iface_timeTx_3>[[:alnum:]]+)]
       masterOnly 1
       [global]
       #

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
@@ -1,7 +1,7 @@
 # The grandmaster profile is provided for testing only
 # It is not installed on production clusters
-# In this example 2 cards $iface_master and $iface_master_1 are connected via SMA1 ports by a cable
-# and $iface_master_1 receives 1PPS signals from $iface_master
+# In this example 2 cards (?<iface_timeTx1>[[:alnum:]]+) and (?<iface_timeTx2>[[:alnum:]]+) are connected via SMA1 ports by a cable
+# and (?<iface_timeTx2>[[:alnum:]]+) receives 1PPS signals from (?<iface_timeTx1>[[:alnum:]]+)
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
@@ -14,7 +14,7 @@ spec:
   {{- range .spec.profile }}
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_master -n 24
+    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s (?<iface_timeTx1>[[:alnum:]]+) -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -28,12 +28,12 @@ spec:
           MaxInSpecOffset: 100
         pins:
           {{- .plugins.e810.pins | toYaml | nindent 10 }}
-        #  "$iface_master":
+        #  "(?<iface_timeTx1>[[:alnum:]]+)":
         #    "U.FL2": "0 2"
         #    "U.FL1": "0 1"
         #    "SMA2": "0 2"
         #    "SMA1": "2 1"
-        #  "$iface_master_1":
+        #  "(?<iface_timeTx2>[[:alnum:]]+)":
         #    "U.FL2": "0 2"
         #    "U.FL1": "0 1"
         #    "SMA2": "0 2"
@@ -109,23 +109,23 @@ spec:
       ts2phc.pulsewidth 100000000
       #cat /dev/GNSS to find available serial port
       #example value of gnss_serialport is /dev/ttyGNSS_1700_0
-      ts2phc.nmea_serialport $gnss_serialport
+      ts2phc.nmea_serialport (?<gnss_serialport>[/\w\s/]+)
       leapfile  /usr/share/zoneinfo/leap-seconds.list
-      [$iface_master]
+      [(?<iface_timeTx1>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0
-      [$iface_master_1]
+      [(?<iface_timeTx2>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |
-      [$iface_master]
+      [(?<iface_timeTx1>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_1]
+      [(?<iface_timeTx2>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_1_1]
+      [(?<iface_timeTx2_1>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_1_2]
+      [(?<iface_timeTx2_2>[[:alnum:]]+)]
       masterOnly 1
       [global]
       #

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
@@ -12,7 +12,7 @@ spec:
   {{- range .spec.profile }}
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_master -n 24
+    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s (?<iface_timeTx>[[:alnum:]]+) -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -26,7 +26,7 @@ spec:
           MaxInSpecOffset: 100
         pins:
           {{- .plugins.e810.pins | toYaml | nindent 10 }}
-        #  "$iface_master":
+        #  "(?<iface_timeTx>[[:alnum:]]+)":
         #    "U.FL2": "0 2"
         #    "U.FL1": "0 1"
         #    "SMA2": "0 2"
@@ -102,19 +102,19 @@ spec:
       ts2phc.pulsewidth 100000000
       #cat /dev/GNSS to find available serial port
       #example value of gnss_serialport is /dev/ttyGNSS_1700_0
-      ts2phc.nmea_serialport $gnss_serialport
+      ts2phc.nmea_serialport (?<gnss_serialport>[/\w\s/]+)
       leapfile  /usr/share/zoneinfo/leap-seconds.list
-      [$iface_master]
+      [(?<iface_timeTx>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0
     ptp4lConf: |
-      [$iface_master]
+      [(?<iface_timeTx>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_1]
+      [(?<iface_timeTx_1>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_2]
+      [(?<iface_timeTx_2>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_3]
+      [(?<iface_timeTx_3>[[:alnum:]]+)]
       masterOnly 1
       [global]
       #

--- a/ztp/source-crs/PtpConfigBoundary.yaml
+++ b/ztp/source-crs/PtpConfigBoundary.yaml
@@ -16,13 +16,13 @@ spec:
       logReduce: "true"
     ptp4lConf: |
       # The interface name is hardware-specific
-      [$iface_slave]
+      [(?<iface_timeRx>[[:alnum:]]+)]
       masterOnly 0
-      [$iface_master_1]
+      [(?<iface_timeTx_1>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_2]
+      [(?<iface_timeTx_2>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_3]
+      [(?<iface_timeTx_3>[[:alnum:]]+)]
       masterOnly 1
       [global]
       #

--- a/ztp/source-crs/PtpConfigBoundaryForEvent.yaml
+++ b/ztp/source-crs/PtpConfigBoundaryForEvent.yaml
@@ -16,13 +16,13 @@ spec:
       logReduce: "true"
     ptp4lConf: |
       # The interface name is hardware-specific
-      [$iface_slave]
+      [(?<iface_timeRx>[[:alnum:]]+)]
       masterOnly 0
-      [$iface_master_1]
+      [(?<iface_timeTx_1>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_2]
+      [(?<iface_timeTx_2>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_3]
+      [(?<iface_timeTx_3>[[:alnum:]]+)]
       masterOnly 1
       [global]
       #

--- a/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
@@ -1,7 +1,7 @@
 # The grandmaster profile is provided for testing only
 # It is not installed on production clusters
-# In this example 2 cards $iface_master and $iface_master_1 are connected via SMA1 ports by a cable
-# and $iface_master_1 receives 1PPS signals from $iface_master
+# In this example 2 cards (?<iface_timeTx1>[[:alnum:]]+) and (?<iface_timeTx2>[[:alnum:]]+) are connected via SMA1 ports by a cable
+# and (?<iface_timeTx2>[[:alnum:]]+) receives 1PPS signals from (?<iface_timeTx1>[[:alnum:]]+)
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
@@ -13,7 +13,7 @@ spec:
   profile:
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_master -n 24
+    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s (?<iface_timeTx1>[[:alnum:]]+) -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -27,12 +27,12 @@ spec:
           MaxInSpecOffset: 100
         pins:
           e810_pins: {}
-        #  "$iface_master":
+        #  "(?<iface_timeTx1>[[:alnum:]]+)":
         #    "U.FL2": "0 2"
         #    "U.FL1": "0 1"
         #    "SMA2": "0 2"
         #    "SMA1": "2 1"
-        #  "$iface_master_1":
+        #  "(?<iface_timeTx2>[[:alnum:]]+)":
         #    "U.FL2": "0 2"
         #    "U.FL1": "0 1"
         #    "SMA2": "0 2"
@@ -108,23 +108,23 @@ spec:
       ts2phc.pulsewidth 100000000
       #cat /dev/GNSS to find available serial port
       #example value of gnss_serialport is /dev/ttyGNSS_1700_0
-      ts2phc.nmea_serialport $gnss_serialport
+      ts2phc.nmea_serialport (?<gnss_serialport>[/\w\s/]+)
       leapfile  /usr/share/zoneinfo/leap-seconds.list
-      [$iface_master]
+      [(?<iface_timeTx1>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0
-      [$iface_master_1]
+      [(?<iface_timeTx2>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
       #this is a measured value in nanoseconds to compensate for SMA cable delay
       ts2phc.extts_correction -10
     ptp4lConf: |
-      [$iface_master]
+      [(?<iface_timeTx1>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_1]
+      [(?<iface_timeTx2>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_1_1]
+      [(?<iface_timeTx2_1>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_1_2]
+      [(?<iface_timeTx2_2>[[:alnum:]]+)]
       masterOnly 1
       [global]
       #

--- a/ztp/source-crs/PtpConfigGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigGmWpc.yaml
@@ -11,7 +11,7 @@ spec:
   profile:
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_master -n 24
+    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s (?<iface_timeTx>[[:alnum:]]+) -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -25,7 +25,7 @@ spec:
           MaxInSpecOffset: 100
         pins:
           e810_pins: {}
-        #  "$iface_master":
+        #  "(?<iface_timeTx>[[:alnum:]]+)":
         #    "U.FL2": "0 2"
         #    "U.FL1": "0 1"
         #    "SMA2": "0 2"
@@ -101,19 +101,19 @@ spec:
       ts2phc.pulsewidth 100000000
       #cat /dev/GNSS to find available serial port
       #example value of gnss_serialport is /dev/ttyGNSS_1700_0
-      ts2phc.nmea_serialport $gnss_serialport
+      ts2phc.nmea_serialport (?<gnss_serialport>[/\w\s/]+)
       leapfile  /usr/share/zoneinfo/leap-seconds.list
-      [$iface_master]
+      [(?<iface_timeTx>[[:alnum:]]+)]
       ts2phc.extts_polarity rising
       ts2phc.extts_correction 0
     ptp4lConf: |
-      [$iface_master]
+      [(?<iface_timeTx>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_1]
+      [(?<iface_timeTx_1>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_2]
+      [(?<iface_timeTx_2>[[:alnum:]]+)]
       masterOnly 1
-      [$iface_master_3]
+      [(?<iface_timeTx_3>[[:alnum:]]+)]
       masterOnly 1
       [global]
       #


### PR DESCRIPTION
This allows us to ignore customer-specified interfaces names in our PTP
configation testblobs, leading to better cluster-compare results.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
