### PR TITLE
OCPBUGS-42068: ztp: emptyfile in siteconfig and sitegen kustomize plugin backport 

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
@@ -601,7 +601,7 @@ func (scbuilder *SiteConfigBuilder) getExtraManifestMaps(roles map[string]bool, 
 							if err != nil {
 								errStr := fmt.Sprintf("Error could not read WorkloadManifest %s %s\n", clusterSpec.ClusterName, err)
 								return dataMap, doNotMerge, errors.New(errStr)
-							} else {
+							} else if v.(string) != "" {
 								data, err := addZTPAnnotationToManifest(v.(string))
 								if err != nil {
 									return dataMap, doNotMerge, err
@@ -670,11 +670,13 @@ func (scbuilder *SiteConfigBuilder) getExtraManifest(dataMap map[string]interfac
 				return dataMap, err
 			}
 
-			manifestFileStr, err := addZTPAnnotationToManifest(string(manifestFile))
-			if err != nil {
-				return dataMap, err
+			if len(manifestFile) != 0 {
+				manifestFileStr, err := addZTPAnnotationToManifest(string(manifestFile))
+				if err != nil {
+					return dataMap, err
+				}
+				dataMap[file.Name()] = manifestFileStr
 			}
-			dataMap[file.Name()] = manifestFileStr
 
 			// user provided CRs don't need to be merged
 			doNotMerge[file.Name()] = true

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder.go
@@ -574,12 +574,13 @@ func (scbuilder *SiteConfigBuilder) getExtraManifestMaps(roles map[string]bool, 
 				if err != nil {
 					return dataMap, doNotMerge, err
 				}
-
-				manifestFileStr, err := addZTPAnnotationToManifest(string(manifestFile))
-				if err != nil {
-					return dataMap, doNotMerge, err
+				if len(manifestFile) != 0 {
+					manifestFileStr, err := addZTPAnnotationToManifest(string(manifestFile))
+					if err != nil {
+						return dataMap, doNotMerge, err
+					}
+					dataMap[file.Name()] = manifestFileStr
 				}
-				dataMap[file.Name()] = manifestFileStr
 
 			}
 

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -574,6 +574,7 @@ func Test_siteConfigBuildExtraManifestPaths(t *testing.T) {
 
 	relativeManifestPath := "testdata/extra-manifest"
 	absoluteManifestPath, err := filepath.Abs(relativeManifestPath)
+	emptyFileManifestPath := filepath.Join(relativeManifestPath, "00-predefined-emptymanifest.yaml")
 	assert.Equal(t, err, nil)
 
 	// Test 1: Test with relative manifest path
@@ -592,6 +593,19 @@ func Test_siteConfigBuildExtraManifestPaths(t *testing.T) {
 	sc.Spec.Clusters[0].NetworkType = "OVNKubernetes"
 	_, err = scBuilder.Build(sc)
 	assert.NoError(t, err)
+
+	// Test 3: Test with empty file in path
+
+	scBuilder, _ = NewSiteConfigBuilder()
+	scBuilder.SetLocalExtraManifestPath(absoluteManifestPath)
+	file, err := os.OpenFile(emptyFileManifestPath, os.O_WRONLY|os.O_CREATE, 0644)
+	sc.Spec.Clusters[0].NetworkType = "OVNKubernetes"
+	_, err = scBuilder.Build(sc)
+	assert.NoError(t, err)
+	defer func() {
+		file.Close()
+		os.Remove(emptyFileManifestPath)
+	}()
 }
 
 func Test_siteConfigBuildExtraManifest(t *testing.T) {


### PR DESCRIPTION
This PR is a fix for the ZTP siteconfig-generator and sitegen kustomize plugin panic if an empty file exists in the extra-manifest directory.