### PR TITLE
OCPBUGS-42945: Ensure BMH deletion before InfrEnv and NS

### DIFF
--- a/ztp/siteconfig-generator/siteConfig/clusterCRsV1.go
+++ b/ztp/siteconfig-generator/siteConfig/clusterCRsV1.go
@@ -108,7 +108,7 @@ metadata:
   name: "{{ .Node.HostName }}"
   namespace: "{{ .Cluster.ClusterName }}"
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "3"
     inspect.metal3.io: "{{ .Node.IronicInspect }}"
     bmac.agent-install.openshift.io.node-label: "{{ .Node.NodeLabels }}"
     bmac.agent-install.openshift.io/hostname: "{{ .Node.HostName }}"

--- a/ztp/siteconfig-generator/siteConfig/clusterCRsV2.go
+++ b/ztp/siteconfig-generator/siteConfig/clusterCRsV2.go
@@ -107,7 +107,7 @@ metadata:
   name: "{{ .Node.HostName }}"
   namespace: "{{ .Cluster.ClusterName }}"
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "3"
     inspect.metal3.io: "{{ .Node.IronicInspect }}"
     bmac.agent-install.openshift.io.node-label: "{{ .Node.NodeLabels }}"
     bmac.agent-install.openshift.io/hostname: "{{ .Node.HostName }}"

--- a/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
+++ b/ztp/siteconfig-generator/siteConfig/siteConfigBuilder_test.go
@@ -2554,3 +2554,54 @@ func Test_siteConfigMap(t *testing.T) {
 		})
 	}
 }
+
+func Test_bmhWaveOrder(t *testing.T) {
+	// Test that BMH is deleted before dependencies.
+	ManagedCluster := `
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "test-site"
+spec:
+  clusterImageSetNameRef: "openshift-v4.18.0"
+  clusters:
+  - clusterName: "cluster1"
+    clusterLabels:
+      group-du-sno: ""
+      common: true
+      sites : "test-site"
+    nodes:
+      - hostName: "node1"
+        nodeNetwork:
+          interfaces:
+            - name: "eno1"
+              macAddress: E4:43:4B:F6:12:E0
+          config:
+            interfaces:
+            - name: eno1
+              type: ethernet
+              state: up
+`
+	sc := SiteConfig{}
+	err := yaml.Unmarshal([]byte(ManagedCluster), &sc)
+	assert.Equal(t, err, nil)
+
+	scBuilder, _ := NewSiteConfigBuilder()
+	scBuilder.SetLocalExtraManifestPath("testdata/extra-manifest")
+	result, err := scBuilder.Build(sc)
+
+	bmh, err := getKind(result["test-site/cluster1"], "BareMetalHost")
+	metadata := bmh["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+	bmhWave := annotations["argocd.argoproj.io/sync-wave"]
+
+	infraenv, err := getKind(result["test-site/cluster1"], "InfraEnv")
+	metadata = infraenv["metadata"].(map[string]interface{})
+	annotations = metadata["annotations"].(map[string]interface{})
+	infraWave := annotations["argocd.argoproj.io/sync-wave"]
+
+	// The BMH must complete deletion prior to the infraenv,
+	// nmstateconfig, or namespace being deleted in order to complete
+	// cleanup. Ref OCPBUGS-42945
+	assert.Greater(t, bmhWave, infraWave)
+}

--- a/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride-badName.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride-badName.yaml
@@ -4,7 +4,7 @@ metadata:
   name: VERYVERYWRONG
   namespace: "{{ .Cluster.ClusterName }}"
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "3"
     inspect.metal3.io: enabled
     bmac.agent-install.openshift.io/hostname: "{{ .Node.HostName }}"
     bmac.agent-install.openshift.io/installer-args: "{{ .Node.InstallerArgs }}"

--- a/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride-badNamespace.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride-badNamespace.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ .Node.HostName }}"
   namespace: ALSOVERYWRONG
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "3"
     inspect.metal3.io: enabled
     bmac.agent-install.openshift.io/hostname: "{{ .Node.HostName }}"
     bmac.agent-install.openshift.io/installer-args: "{{ .Node.InstallerArgs }}"

--- a/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/BareMetalHostOverride.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ .Node.HostName }}"
   namespace: "{{ .Cluster.ClusterName }}"
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "3"
     inspect.metal3.io: enabled
     bmac.agent-install.openshift.io/hostname: "{{ .Node.HostName }}"
     bmac.agent-install.openshift.io/installer-args: "{{ .Node.InstallerArgs }}"

--- a/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/mergeMC.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/mergeMC.yaml
@@ -72,7 +72,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node1
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'

--- a/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/splitMC.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/SplitAndMergeMachineConfigExpected/splitMC.yaml
@@ -72,7 +72,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node1
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'

--- a/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/onlyUserCR.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/onlyUserCR.yaml
@@ -72,7 +72,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node1
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'

--- a/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/partialfilter.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/partialfilter.yaml
@@ -72,7 +72,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node1
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'

--- a/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/removeAll.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/filteredoutput/removeAll.yaml
@@ -72,7 +72,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node1
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningDeprecatedTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningDeprecatedTestOutput.yaml
@@ -94,7 +94,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node1
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningNewTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigCPUPartitioningNewTestOutput.yaml
@@ -93,7 +93,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node1
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigDualStackStandardClusterTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigDualStackStandardClusterTestOutput.yaml
@@ -141,7 +141,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node1
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'
@@ -160,7 +160,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node2
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'
@@ -179,7 +179,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node3
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterTestOutput.yaml
@@ -162,7 +162,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node1
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'
@@ -181,7 +181,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node2
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'
@@ -200,7 +200,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node3
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'
@@ -219,7 +219,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node4
         bmac.agent-install.openshift.io/role: worker
         ran.openshift.io/ztp-gitops-generated: '{}'
@@ -238,7 +238,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node5
         bmac.agent-install.openshift.io/role: worker
         ran.openshift.io/ztp-gitops-generated: '{}'

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterTestOutputWithZap.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigStandardClusterTestOutputWithZap.yaml
@@ -132,7 +132,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node1
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'
@@ -151,7 +151,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node2
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'
@@ -170,7 +170,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io/hostname: node3
         bmac.agent-install.openshift.io/role: master
         ran.openshift.io/ztp-gitops-generated: '{}'

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigTestOutput.yaml
@@ -110,7 +110,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io.node-label.node-role.kubernetes.io/infra: ""
         bmac.agent-install.openshift.io.node-label.node-role.kubernetes.io/master: ""
         bmac.agent-install.openshift.io/hostname: node1

--- a/ztp/siteconfig-generator/siteConfig/testdata/siteConfigV2TestOutput.yaml
+++ b/ztp/siteconfig-generator/siteConfig/testdata/siteConfigV2TestOutput.yaml
@@ -110,7 +110,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
     annotations:
-        argocd.argoproj.io/sync-wave: "1"
+        argocd.argoproj.io/sync-wave: "3"
         bmac.agent-install.openshift.io.node-label.node-role.kubernetes.io/infra: ""
         bmac.agent-install.openshift.io.node-label.node-role.kubernetes.io/master: ""
         bmac.agent-install.openshift.io/hostname: node1


### PR DESCRIPTION
OCPBUGS-42945, during node or cluster cleanup the BMH must complete deletion before the InfraEnv, NMStateConfig or Namespace are removed. This means the BMH must be in a higher wave (later for creation, earlier for deletion) than those other CRs.

The requirement comes from the cleanup phase of assisted installer/baremetal operator. If the BMH automatedCleanupMode is not disabled the node is rebooted into a new ISO image which cleans the disk. The creation of this ISO requires the Namespace to be not in the deleted state so that a new PreProvisioningImage CR can be created. The ISO creation also requires that the correct NMStateConfig CR be present (it is included in the ISO). The booting of the ISO requires the InfraEnv CR to be present.