### PR TITLE
infra: Build images for `knmstate`

### DIFF
--- a/cnf-tests/testsuites/e2esuite/knmstate/knmstate_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/knmstate/knmstate_sriov.go
@@ -132,7 +132,6 @@ var _ = Describe("[knmstate] SR-IOV Network Operator Integration", func() {
 				out, err := ipAddrShow(node, testDevice.Name)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(out).To(ContainSubstring("192.0.2.2"))
-				g.Expect(out).To(ContainSubstring("UP"))
 			}).
 				WithPolling(5 * time.Second).
 				WithTimeout(1 * time.Minute).

--- a/cnf-tests/testsuites/pkg/namespaces/namespaces.go
+++ b/cnf-tests/testsuites/pkg/namespaces/namespaces.go
@@ -56,6 +56,8 @@ var SCTPTest string
 // Multus is the namespace where multus and multi-networkpolicy are installed
 var Multus = "openshift-multus"
 
+var KNMState = "openshift-nmstate"
+
 var OVSQOSTest string
 
 var namespaceLabels = map[string]string{

--- a/cnf-tests/testsuites/pkg/utils/consts.go
+++ b/cnf-tests/testsuites/pkg/utils/consts.go
@@ -164,6 +164,10 @@ const (
 )
 
 const (
+	KNMStateCRDName = "nmstates.nmstate.io"
+)
+
+const (
 	// MultiNetworkPolicyNamespaceX main namespace used for multi-networkpolicy tests
 	MultiNetworkPolicyNamespaceX = "sriov-conformance-testing-x"
 	// MultiNetworkPolicyNamespaceY ausiliary namespace used to validate cross namespace scenarios

--- a/cnf-tests/testsuites/validationsuite/cluster/validation.go
+++ b/cnf-tests/testsuites/validationsuite/cluster/validation.go
@@ -528,6 +528,21 @@ var _ = Describe("validation", func() {
 			Expect(daemonset.Status.DesiredNumberScheduled).To(Equal(daemonset.Status.NumberReady))
 		})
 	})
+
+	Context("[knmstate]", func() {
+		It("should have NMState CRD available in the cluster", func() {
+			crd := &apiext.CustomResourceDefinition{}
+			err := testclient.Client.Get(context.TODO(), goclient.ObjectKey{Name: utils.KNMStateCRDName}, crd)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should have the operator pod in running state", func() {
+			deployment, err := testclient.Client.Deployments(namespaces.KNMState).
+				Get(context.Background(), "nmstate-operator", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deployment.Status.ReadyReplicas).To(Equal(deployment.Status.Replicas))
+		})
+	})
 })
 
 type MCMatcher func(*igntypes.Config, *clientmachineconfigv1.MachineConfig) bool

--- a/feature-configs/ci/knmstate/operator_subscription.yaml
+++ b/feature-configs/ci/knmstate/operator_subscription.yaml
@@ -6,8 +6,7 @@ metadata:
   name: kubernetes-nmstate-operator
   namespace: openshift-nmstate
 spec:
-  channel: stable
-  installPlanApproval: Automatic
   name: kubernetes-nmstate-operator
-  source: art-nightly-operator-catalog
+  channel: alpha
+  source: ci-index
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Index image `quay.io/openshift-release-dev/ocp-release-nightly` contains
operator's nightly builds on Brew, which is not usually available on
Prow jobs.
    
These changes modify the `ci-index` CatalogSource, adding the knmstate operator
bundle, where the operator's image and operand image come from
promoted images in `registry.ci.openshift.org`.

depends on:
- https://github.com/openshift/release/pull/60779
- https://github.com/openshift-kni/cnf-features-deploy/pull/2165