### PR TITLE
CNF-15235: cnf-tests: move to rhel 9

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -22,6 +22,20 @@ WORKDIR $TESTER_PATH
 
 RUN go build -mod=vendor -o /sctptest
 
+# build hugepages-allocator's binary
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.19 AS builder-hugepages-allocator
+
+ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_PATH=/go/src/$PKG_NAME
+ENV TOOL_PATH=$PKG_PATH/cnf-tests/pod-utils/hugepages-allocator
+
+RUN mkdir -p $PKG_PATH
+
+COPY . $PKG_PATH/
+WORKDIR $TOOL_PATH
+
+RUN go build -mod=vendor -o /hugepages-allocator
+
 # build latency-test's runner binaries
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS builder-latency-test-runners
 
@@ -83,6 +97,8 @@ COPY --from=builder-latency-test-runners /hwlatdetect-runner /usr/bin/hwlatdetec
 COPY --from=builder-latency-test-tools /hwlatdetect /usr/bin/hwlatdetect
 
 COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
+
+COPY --from=builder-hugepages-allocator /hugepages-allocator /usr/bin//hugepages-allocator
 
 COPY --from=go-builder /app/cnf-tests/bin/mirror /usr/bin/mirror
 COPY --from=go-builder /app/cnf-tests/mirror/images.json /usr/local/etc/cnf

--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS builder-stresser
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder-stresser
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
 ENV TESTER_PATH=$PKG_PATH/cnf-tests/pod-utils/stresser
@@ -10,7 +10,7 @@ WORKDIR $TESTER_PATH
 
 RUN go build -mod=vendor -o /stresser
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS builder-sctptester
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder-sctptester
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
 ENV TESTER_PATH=$PKG_PATH/cnf-tests/pod-utils/sctptester
@@ -23,7 +23,7 @@ WORKDIR $TESTER_PATH
 RUN go build -mod=vendor -o /sctptest
 
 # build hugepages-allocator's binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.19 AS builder-hugepages-allocator
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder-hugepages-allocator
 
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
@@ -37,7 +37,7 @@ WORKDIR $TOOL_PATH
 RUN go build -mod=vendor -o /hugepages-allocator
 
 # build latency-test's runner binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS builder-latency-test-runners
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder-latency-test-runners
 
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
@@ -53,7 +53,7 @@ RUN go build -mod=vendor -o /oslat-runner oslat-runner/main.go && \
     go build -mod=vendor -o /hwlatdetect-runner hwlatdetect-runner/main.go
 
 # build latency testing suite
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS go-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS go-builder
 WORKDIR /app
 COPY . .
 RUN make test-bin
@@ -73,7 +73,7 @@ RUN yum install -y numactl-devel make gcc && \
     cp hwlatdetect /hwlatdetect && \
     cp cyclictest /cyclictest
 
-FROM quay.io/openshift/origin-oc-rpms:4.16 AS oc
+FROM quay.io/openshift/origin-oc-rpms:4.19 AS oc
 
 # Final image
 FROM centos:7

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # This dockerfile is specific to building the OpenShift CNF stresser image
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 as builder-stresser
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 as builder-stresser
 
 # Add everything
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
@@ -14,7 +14,7 @@ WORKDIR $STRESSER_PATH
 RUN go build -mod=vendor -o /stresser
 
 # This dockerfile is specific to building the OpenShift CNF sctp tester image
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 as builder-sctptester
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 as builder-sctptester
 
 # Add everything
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
@@ -29,7 +29,7 @@ WORKDIR $TESTER_PATH
 RUN go build -mod=vendor -o /sctptest
 
 # build latency-test's runner binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS builder-latency-test-runners
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder-latency-test-runners
 
 ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
 ENV PKG_PATH=/go/src/$PKG_NAME
@@ -45,13 +45,13 @@ RUN go build -mod=vendor -o /oslat-runner oslat-runner/main.go && \
     go build -mod=vendor -o /hwlatdetect-runner hwlatdetect-runner/main.go
 
 # build latency testing suite
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS go-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS go-builder
 WORKDIR /app
 COPY . .
 RUN make test-bin
 
 # Build latency-test binaries
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 as builder-latency-test-tools
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 as builder-latency-test-tools
 
 ENV RT_TESTS_URL=https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git/snapshot
 ENV RT_TESTS_PKG=rt-tests-2.0

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -71,7 +71,7 @@ FROM registry.ci.openshift.org/ocp/4.19:oc-rpms AS oc
 FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 
 # python3 is needed for hwlatdetect
-RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3 python3 nc iptables && \
+RUN yum install -y lksctp-tools iproute tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3 python3 nc iptables && \
     yum clean all
 
 RUN mkdir -p /usr/local/etc/cnf

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -65,7 +65,7 @@ RUN yum install -y numactl-devel make gcc && \
       cp hwlatdetect /hwlatdetect && \
       cp cyclictest /cyclictest
 
-FROM quay.io/openshift/origin-oc-rpms:4.16 AS oc
+FROM registry.ci.openshift.org/ocp/4.19:oc-rpms AS oc
 
 # Final image
 FROM openshift/origin-base

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -68,7 +68,7 @@ RUN yum install -y numactl-devel make gcc && \
 FROM registry.ci.openshift.org/ocp/4.19:oc-rpms AS oc
 
 # Final image
-FROM openshift/origin-base
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 
 # python3 is needed for hwlatdetect
 RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool iputils numactl-libs iptables kmod linuxptp iperf3 python3 nc iptables && \

--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -28,6 +28,20 @@ WORKDIR $TESTER_PATH
 
 RUN go build -mod=vendor -o /sctptest
 
+# build hugepages-allocator's binary
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder-hugepages-allocator
+
+ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_PATH=/go/src/$PKG_NAME
+ENV TOOL_PATH=$PKG_PATH/cnf-tests/pod-utils/hugepages-allocator
+
+RUN mkdir -p $PKG_PATH
+
+COPY . $PKG_PATH/
+WORKDIR $TOOL_PATH
+
+RUN go build -mod=vendor -o /hugepages-allocator
+
 # build latency-test's runner binaries
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder-latency-test-runners
 
@@ -89,6 +103,8 @@ COPY --from=builder-latency-test-runners /hwlatdetect-runner /usr/bin/hwlatdetec
 COPY --from=builder-latency-test-tools /hwlatdetect /usr/bin/hwlatdetect
 
 COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
+
+COPY --from=builder-hugepages-allocator /hugepages-allocator /usr/bin//hugepages-allocator
 
 COPY --from=go-builder /app/cnf-tests/bin/mirror /usr/bin/mirror
 COPY --from=go-builder /app/cnf-tests/mirror/images.json /usr/local/etc/cnf

--- a/cnf-tests/mirror/images.json
+++ b/cnf-tests/mirror/images.json
@@ -1,7 +1,7 @@
 [
     {
         "registry": "quay.io/openshift-kni/",
-        "image": "cnf-tests:4.16"
+        "image": "cnf-tests:4.18"
     },
     {
         "registry": "quay.io/openshift-kni/",

--- a/cnf-tests/pod-utils/hugepages-allocator/main.go
+++ b/cnf-tests/pod-utils/hugepages-allocator/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// MapHugeShift Shift for HugePage size
+	MapHugeShift = 26
+	// DefaultHugePageSize 1GB HugePage size
+	DefaultHugePageSize = 1 * 1024 * 1024 * 1024
+)
+
+// MAP_HUGE_1GB 1GB HugePage mmap flag
+const MAP_HUGE_1GB = 30 << MapHugeShift
+
+type Args struct {
+	TimeDuration time.Duration
+	HugePageSize int
+}
+
+func main() {
+	klog.InitFlags(nil)
+	args := &Args{}
+	flag.DurationVar(&args.TimeDuration, "time-duration", math.MaxInt64, "set the time duration for program to wait - wait forever by default")
+	flag.IntVar(&args.HugePageSize, "hugepage-size", DefaultHugePageSize, "hugepage size to allocate - allocate 1G by default")
+
+	flag.Parse()
+
+	// Flags for HugePage allocation
+	mmapFlags := syscall.MAP_PRIVATE | syscall.MAP_ANONYMOUS | syscall.MAP_HUGETLB | MAP_HUGE_1GB
+	// Use mmap to allocate memory
+	addr, _, errno := syscall.Syscall6(
+		syscall.SYS_MMAP,
+		0,                          // Let the kernel choose the address
+		uintptr(args.HugePageSize), // Size of the memory
+		uintptr(syscall.PROT_READ|syscall.PROT_WRITE), // Read/Write permissions
+		uintptr(mmapFlags), // mmap flags
+		0,                  // File descriptor (not used for anonymous memory)
+		0,                  // Offset
+	)
+	if errno != 0 {
+		klog.ErrorS(fmt.Errorf("errno=%v", errno), "Failed to allocate HugePage")
+		os.Exit(1)
+	}
+	memory := unsafe.Pointer(addr)
+	// Write a byte to the allocated memory
+	*(*byte)(memory) = 42
+
+	klog.InfoS("Successfully allocated 1GB HugePage memory", "address", fmt.Sprintf("%p", unsafe.Pointer(addr)))
+
+	// Cleanup: Unmap the memory
+	defer func() {
+		_, _, errno = syscall.Syscall(syscall.SYS_MUNMAP, addr, uintptr(args.HugePageSize), 0)
+		if errno != 0 {
+			klog.ErrorS(fmt.Errorf("errno=%v", errno), "Failed to unmap HugePage")
+			os.Exit(2)
+		}
+		klog.InfoS("1GB HugePage memory unmapped successfully")
+	}()
+	wait(args.TimeDuration)
+}
+
+func wait(timeout time.Duration) {
+	// Create a channel to listen for signals.
+	signalChan := make(chan os.Signal, 1)
+
+	// SIGINT handles Ctrl+C locally.
+	// SIGTERM handles Cloud Run termination signal.
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+
+	klog.InfoS("Waiting", "period", timeout.String())
+	select {
+	// Receive output from signalChan.
+	case sig := <-signalChan:
+		klog.InfoS("signal caught", "signal", sig)
+	case <-time.After(timeout):
+		klog.InfoS("Done")
+		return
+	}
+}

--- a/cnf-tests/testsuites/pkg/images/images.go
+++ b/cnf-tests/testsuites/pkg/images/images.go
@@ -29,7 +29,7 @@ func init() {
 
 	cnfTestsImage = os.Getenv("CNF_TESTS_IMAGE")
 	if cnfTestsImage == "" {
-		cnfTestsImage = "cnf-tests:4.16"
+		cnfTestsImage = "cnf-tests:4.18"
 	}
 
 	dpdkTestImage = os.Getenv("DPDK_TESTS_IMAGE")

--- a/cnf-tests/testsuites/pkg/pods/pods.go
+++ b/cnf-tests/testsuites/pkg/pods/pods.go
@@ -188,8 +188,7 @@ func DefineWithHugePages(namespace, nodeName string) *corev1.Pod {
 		RedefineWithCommand(
 			getDefinition(namespace),
 			[]string{"/bin/bash", "-c",
-				`tmux new -d 'LD_PRELOAD=libhugetlbfs.so HUGETLB_MORECORE=yes top -b > /dev/null'
-sleep INF`}, []string{},
+				`/usr/bin/hugepages-allocator > /dev/null`}, []string{},
 		),
 		corev1.RestartPolicyNever,
 	)


### PR DESCRIPTION
* move all builder to rhel9
* move cnf-tests image to rhel9
* replace `libhugetlbfs` ,which is not present in rhel9, with a local tool for allocating hugepages (more details in the commits)

Signed-off-by: Talor Itzhak <titzhak@redhat.com>