### PR TITLE
infra: sriov git submodule should point to `main`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export FEATURES?=sctp performance vrf container-mount-namespace metallb tuningcn
 export SKIP_TESTS?=
 export FOCUS_TESTS?=
 export METALLB_OPERATOR_TARGET_COMMIT?=main
-export SRIOV_NETWORK_OPERATOR_TARGET_COMMIT?=master
+export SRIOV_NETWORK_OPERATOR_TARGET_COMMIT?=main
 export CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT?=master
 IMAGE_BUILD_CMD ?= "docker"
 


### PR DESCRIPTION
Main sriov-network-operator branch has moved from `master` to `main`.

Update the `SRIOV_NETWORK_OPERATOR_TARGET_COMMIT` variable accordingly to fix errors like [1]:

```
+ cd ../sriov-network-operator/
+ git fetch --all
+ git checkout origin/master
error: pathspec 'origin/master' did not match any file(s) known to git
make: *** [Makefile:140: init-git-submodules] Error 1
```

[1] https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-kni_cnf-features-deploy/2148/pull-ci-openshift-kni-cnf-features-deploy-master-e2e-aws-ci-tests/1877360047533592576

cc @SchSeba @sshnaidm 