### PR TITLE
Elaborated instructions for branching

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,28 @@ This repository follows the same version numbering and release branching schedul
 
 ### Branching
 
-1. Create a new 'release-x.y' branch and push it into Git
-2. Advance the CI configuration in openshift/release to create new lanes for the release branch and move the master along to the next release version number
+1. Before creating a new `release-x.y` branch ensure the new `x.y`version is reflected in the following sources:
+   - `cnf-tests/Dockerfile.openshift`:
+     1. Check image tags used.
+     2. `OCP_VERSION`.
+
+   - `cnf-tests/.konflux/Dockerfile`:
+     1. Check image tags used.
+     2. `OCP_VERSION`.
+     3. Check the tags in the strings of `RUN sed` commands.
+
+    - `cnf-tests/mirror/images.json`
+    - `cnf-tests/testsuites/pkg/images/images.go`
+    - `hack/common.sh`
+
+2. If any sources require updates, create a pull request against the master branch with the necessary changes. Merge this PR before proceeding to the next steps.
+2. Create a new `release-x.y` branch and push it to git
+3. Advance the CI configuration in openshift/release to create new lanes for the release branch and move the master along to the next release version number
     - Example: https://github.com/openshift/release/pull/26172
-3. Change the ZTP templates examples label `du-profile: latest` under [gitops-subscriptions/argocd/example](https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/gitops-subscriptions/argocd/example) to match the branch release-x.y
+4. Change the ZTP templates examples label `du-profile: latest` under [gitops-subscriptions/argocd/example](https://github.com/openshift-kni/cnf-features-deploy/tree/master/ztp/gitops-subscriptions/argocd/example) to match the branch release-x.y
     - PGT Example: https://github.com/openshift-kni/cnf-features-deploy/pull/1063
     - SiteConfig Example: https://github.com/openshift-kni/cnf-features-deploy/pull/1064
-4. Pin all midstream branches to the new release branch, and create new midstream branches for the next release
+5. Pin all midstream branches to the new release branch, and create new midstream branches for the next release
    - [cnf-tests](https://code.engineering.redhat.com/gerrit/admin/repos/cnf-tests)
    - [ztp-site-generate](https://code.engineering.redhat.com/gerrit/admin/repos/ztp-site-generate)
+6. Create a PR to the master branch updating the references from the first step to version `x.y+1`


### PR DESCRIPTION
We've recently faced issues due to misaligned cnf-tests container images. Since it's easy to forget updating the image version across the repo, these changes to the branching guide are necessary to cover (hopefully) all required updates when creating a new release branch. The intention is for anyone creating the release-x.y branch to follow this, minimizing the chances of misalignments. Additionally, we implemented automation in the CI that will trigger a failure if these instructions are not followed: #2199.