### PR TITLE
OCPBUGS-44603: [4.14] ztp: remove phc2sys -w option

### DIFF
--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
@@ -14,7 +14,7 @@ spec:
   {{- range .spec.profile }}
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s (?<iface_timeTx1>[[:alnum:]]+) -n 24
+    phc2sysOpts: -r -u 0 -m -N 8 -R 16 -s (?<iface_timeTx1>[[:alnum:]]+) -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
@@ -12,7 +12,7 @@ spec:
   {{- range .spec.profile }}
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s (?<iface_timeTx>[[:alnum:]]+) -n 24
+    phc2sysOpts: -r -u 0 -m -N 8 -R 16 -s (?<iface_timeTx>[[:alnum:]]+) -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:

--- a/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
@@ -13,7 +13,7 @@ spec:
   profile:
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s (?<iface_timeTx1>[[:alnum:]]+) -n 24
+    phc2sysOpts: -r -u 0 -m -N 8 -R 16 -s (?<iface_timeTx1>[[:alnum:]]+) -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:

--- a/ztp/source-crs/PtpConfigGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigGmWpc.yaml
@@ -11,7 +11,7 @@ spec:
   profile:
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s (?<iface_timeTx>[[:alnum:]]+) -n 24
+    phc2sysOpts: -r -u 0 -m -N 8 -R 16 -s (?<iface_timeTx>[[:alnum:]]+) -n 24
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:


### PR DESCRIPTION
This commit removes the `-w` option from T-GM ptp configuration. The option became obsolete in this configuration after the following upstream patches were introduced to the linuxptp project: https://lists.nwtime.org/sympa/arc/linuxptp-devel/2024-11/msg00026.html
/cc @aneeshkp 