### PR TITLE
ztp: modify ztp Containerfile for Konflux migration...

### DIFF
--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -1,5 +1,7 @@
+ARG ZTP_BUILD_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18
+ARG ZTP_RUNTIME_IMAGE=ubi8-minimal
 # Builder
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 as builder
+FROM ${ZTP_BUILD_IMAGE} as builder
 ARG IMAGE_REF
 USER root
 ENV PKG_ROOT=cnf-features-deploy
@@ -22,7 +24,7 @@ RUN make build
 RUN make build-pgt-plugin
 
 # Container image
-FROM ubi8-minimal
+FROM ${ZTP_RUNTIME_IMAGE}
 USER root
 ENV BUILDER_ZTP=/go/src/cnf-features-deploy/ztp
 ENV ZTP_HOME=/home/ztp


### PR DESCRIPTION
The value of ZTP_BUILD_IMAGE and ZTP_RUNTIME_IMAGE will be overriden                                                                                                                                                                              by Konflux, sharing this Containerfile with upstream                                                                                                                                                                                              
                                                       