### PR TITLE
include approvers to manage Konflux infra...

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -51,3 +51,6 @@ aliases:
     - sakhoury
     - sabbir-47
     - irinamihai
+  KONFLUX-approvers:
+    - fontivan
+    - rauhersu


### PR DESCRIPTION
Konflux engineers must have direct permission to merge tekton infra (.tekton dir),without waiting for external approval which greatly delays new pipeline runs.