### PR TITLE
OCPBUGS-47784: ztp: reference: Enable user customization of PTP priority1, priority2, and domainNumber fields

### DIFF
--- a/ztp/kube-compare-reference/default_value.yaml
+++ b/ztp/kube-compare-reference/default_value.yaml
@@ -67,11 +67,15 @@ optional_ptp_config_PtpConfigForHA:
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
+  captureGroup_defaults:
+    domainNumber: 24
 optional_ptp_config_PtpConfigForHAForEvent:
 - spec:
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
+  captureGroup_defaults:
+    domainNumber: 24
 optional_ptp_config_PtpConfigMaster:
 - spec:
     profile:
@@ -79,6 +83,10 @@ optional_ptp_config_PtpConfigMaster:
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
+  captureGroup_defaults:
+    priority1: 128
+    priority2: 128
+    domainNumber: 24
 optional_ptp_config_PtpConfigMasterForEvent:
 - spec:
     profile:
@@ -86,6 +94,10 @@ optional_ptp_config_PtpConfigMasterForEvent:
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
+  captureGroup_defaults:
+    priority1: 128
+    priority2: 128
+    domainNumber: 24
 optional_ptp_config_PtpConfigSlave:
 - spec:
     profile:
@@ -93,6 +105,10 @@ optional_ptp_config_PtpConfigSlave:
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
+  captureGroup_defaults:
+    priority1: 128
+    priority2: 128
+    domainNumber: 24
 optional_ptp_config_PtpConfigGmWpc:
 - spec:
     profile:
@@ -118,6 +134,10 @@ optional_ptp_config_PtpConfigSlaveForEvent:
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
+  captureGroup_defaults:
+    priority1: 128
+    priority2: 128
+    domainNumber: 24
 optional_ptp_config_PtpOperatorConfig:
 - spec:
     daemonNodeSelector:

--- a/ztp/kube-compare-reference/metadata.yaml
+++ b/ztp/kube-compare-reference/metadata.yaml
@@ -208,6 +208,8 @@ parts:
           - path: optional/ptp-config/PtpConfigBoundary.yaml
             config:
               perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
                 - pathToKey: spec.profile.0.ptp4lConf
                   inlineDiffFunc: capturegroups
           - path: optional/ptp-config/PtpConfigGmWpc.yaml
@@ -229,15 +231,49 @@ parts:
                 - pathToKey: spec.profile.0.ptp4lConf
                   inlineDiffFunc: capturegroups
           - path: optional/ptp-config/PtpConfigForHA.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
           - path: optional/ptp-config/PtpConfigMaster.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
           - path: optional/ptp-config/PtpConfigSlave.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
           # TODO: If one of these 4 is selected, they should be paired with 'PtpOperatorConfigForEvent.yaml' above
           - path: optional/ptp-config/PtpConfigSlaveForEvent.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
           - path: optional/ptp-config/PtpConfigForHAForEvent.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
           - path: optional/ptp-config/PtpConfigMasterForEvent.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.profile.0.ptp4lConf
+                  inlineDiffFunc: capturegroups
           - path: optional/ptp-config/PtpConfigBoundaryForEvent.yaml
             config:
               perField:
+                - pathToKey: spec.profile.0.phc2sysOpts
+                  inlineDiffFunc: capturegroups
                 - pathToKey: spec.profile.0.ptp4lConf
                   inlineDiffFunc: capturegroups
   - name: optional-console-disable

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundary.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundary.yaml
@@ -9,7 +9,7 @@ spec:
   profile:
   - name: "boundary"
     ptp4lOpts: "-2"
-    phc2sysOpts: "-a -r -n 24"
+    phc2sysOpts: "-a -r -n (?<domainNumber>[0-9]+)"
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundaryForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundaryForEvent.yaml
@@ -9,7 +9,7 @@ spec:
   profile:
   - name: "boundary"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16"
+    phc2sysOpts: "-a -r -m -n (?<domainNumber>[0-9]+) -N 8 -R 16"
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
@@ -14,7 +14,7 @@ spec:
   {{- range .spec.profile }}
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -N 8 -R 16 -s (?<iface_timeTx1>[[:alnum:]]+) -n 24
+    phc2sysOpts: -r -u 0 -m -N 8 -R 16 -s (?<iface_timeTx1>[[:alnum:]]+) -n (?<domainNumber>[0-9]+)
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHA.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHA.yaml
@@ -9,7 +9,7 @@ spec:
   profile:
     - name: "boundary-ha"
       ptp4lOpts: ""
-      phc2sysOpts: "-a -r -n 24"
+      phc2sysOpts: "-a -r -n (?<domainNumber>[0-9]+)"
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10
       ptpSettings:

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHAForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHAForEvent.yaml
@@ -9,7 +9,7 @@ spec:
   profile:
     - name: "boundary-ha"
       ptp4lOpts: ""
-      phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16"
+      phc2sysOpts: "-a -r -m -n (?<domainNumber>[0-9]+) -N 8 -R 16"
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10
       ptpSettings:

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
@@ -12,7 +12,7 @@ spec:
   {{- range .spec.profile }}
   - name: "grandmaster"
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: -r -u 0 -m -N 8 -R 16 -s (?<iface_timeTx>[[:alnum:]]+) -n 24
+    phc2sysOpts: -r -u 0 -m -N 8 -R 16 -s (?<iface_timeTx>[[:alnum:]]+) -n (?<domainNumber>[0-9]+)
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMaster.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMaster.yaml
@@ -14,7 +14,7 @@ spec:
     # The interface name is hardware-specific
     interface: {{ .interface }}
     ptp4lOpts: "-2"
-    phc2sysOpts: "-a -r -r -n 24"
+    phc2sysOpts: "-a -r -r -n (?<domainNumber>[0-9]+)"
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -26,9 +26,9 @@ spec:
       #
       twoStepFlag 1
       slaveOnly 0
-      priority1 128
-      priority2 128
-      domainNumber 24
+      priority1 (?<priority1>[0-9]+)
+      priority2 (?<priority2>[0-9]+)
+      domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37
       clockClass 255
       clockAccuracy 0xFE

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMasterForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMasterForEvent.yaml
@@ -14,7 +14,7 @@ spec:
     # The interface name is hardware-specific
     interface: {{ .interface }}
     ptp4lOpts: "-2 --summary_interval -4"
-    phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16"
+    phc2sysOpts: "-a -r -m -n (?<domainNumber>[0-9]+) -N 8 -R 16"
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -26,9 +26,9 @@ spec:
       #
       twoStepFlag 1
       slaveOnly 0
-      priority1 128
-      priority2 128
-      domainNumber 24
+      priority1 (?<priority1>[0-9]+)
+      priority2 (?<priority2>[0-9]+)
+      domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37
       clockClass 255
       clockAccuracy 0xFE

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlave.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlave.yaml
@@ -12,7 +12,7 @@ spec:
     # The interface name is hardware-specific
     interface: {{ .interface }}
     ptp4lOpts: "-2 -s"
-    phc2sysOpts: "-a -r -n 24"
+    phc2sysOpts: "-a -r -n (?<domainNumber>[0-9]+)"
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -24,9 +24,9 @@ spec:
       #
       twoStepFlag 1
       slaveOnly 1
-      priority1 128
-      priority2 128
-      domainNumber 24
+      priority1 (?<priority1>[0-9]+)
+      priority2 (?<priority2>[0-9]+)
+      domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37
       clockClass 255
       clockAccuracy 0xFE

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlaveForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlaveForEvent.yaml
@@ -12,7 +12,7 @@ spec:
     # The interface name is hardware-specific
     interface: {{ .interface }}
     ptp4lOpts: "-2 -s --summary_interval -4"
-    phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16"
+    phc2sysOpts: "-a -r -m -n (?<domainNumber>[0-9]+) -N 8 -R 16"
     ptpSchedulingPolicy: SCHED_FIFO
     ptpSchedulingPriority: 10
     ptpSettings:
@@ -24,9 +24,9 @@ spec:
       #
       twoStepFlag 1
       slaveOnly 1
-      priority1 128
-      priority2 128
-      domainNumber 24
+      priority1 (?<priority1>[0-9]+)
+      priority2 (?<priority2>[0-9]+)
+      domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37
       clockClass 255
       clockAccuracy 0xFE


### PR DESCRIPTION
Part 2: Include the phc2sys '-n' option for domainNumber, as well as all
configs missed in the 1st commit.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
