### PR TITLE
OCPBUGS-49786: ztp: Set up ptpClockThreshold in source-crs and reference templates

### DIFF
--- a/ztp/kube-compare-reference/default_value.yaml
+++ b/ztp/kube-compare-reference/default_value.yaml
@@ -23,6 +23,8 @@ optional_local_storage_operator_StorageSubscription:
     source: redhat-operators-disconnected
 optional_ptp_config_PtpConfigBoundary:
 - spec:
+    profile:
+    - placeholder: true
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
@@ -32,6 +34,11 @@ optional_ptp_config_PtpConfigBoundary:
     domainNumber: 24
 optional_ptp_config_PtpConfigBoundaryForEvent:
 - spec:
+    profile:
+    - ptpClockThreshold:
+        holdOverTimeout: 5
+        maxOffsetThreshold: 100
+        minOffsetThreshold: -100
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
@@ -55,6 +62,10 @@ optional_ptp_config_PtpConfigDualCardGmWpc:
               SMA2: 0 2
               U.FL1: 0 1
               U.FL2: 0 2
+      ptpClockThreshold:
+        holdOverTimeout: 5
+        maxOffsetThreshold: 100
+        minOffsetThreshold: -100
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
@@ -64,6 +75,8 @@ optional_ptp_config_PtpConfigDualCardGmWpc:
     domainNumber: 24
 optional_ptp_config_PtpConfigForHA:
 - spec:
+    profile:
+    - placeholder: true
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
@@ -71,6 +84,11 @@ optional_ptp_config_PtpConfigForHA:
     domainNumber: 24
 optional_ptp_config_PtpConfigForHAForEvent:
 - spec:
+    profile:
+    - ptpClockThreshold:
+        holdOverTimeout: 5
+        maxOffsetThreshold: 100
+        minOffsetThreshold: -100
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
@@ -91,6 +109,10 @@ optional_ptp_config_PtpConfigMasterForEvent:
 - spec:
     profile:
     - interface: $interface
+      ptpClockThreshold:
+        holdOverTimeout: 5
+        maxOffsetThreshold: 100
+        minOffsetThreshold: -100
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
@@ -120,6 +142,10 @@ optional_ptp_config_PtpConfigGmWpc:
               SMA2: 0 2
               U.FL1: 0 1
               U.FL2: 0 2
+      ptpClockThreshold:
+        holdOverTimeout: 5
+        maxOffsetThreshold: 100
+        minOffsetThreshold: -100
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
@@ -131,6 +157,10 @@ optional_ptp_config_PtpConfigSlaveForEvent:
 - spec:
     profile:
     - interface: $interface
+      ptpClockThreshold:
+        holdOverTimeout: 5
+        maxOffsetThreshold: 100
+        minOffsetThreshold: -100
     recommend:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundary.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundary.yaml
@@ -7,6 +7,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   profile:
+  {{- range .spec.profile }}
   - name: "boundary"
     ptp4lOpts: "-2"
     phc2sysOpts: "-a -r -n (?<domainNumber>[0-9]+)"
@@ -125,6 +126,11 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0xA0
+    {{- if .ptpClockThreshold }}
+    ptpClockThreshold:
+      {{- .ptpClockThreshold | toYaml | nindent 6 }}
+    {{- end }}
+  {{- end }}
   recommend:
   {{- range .spec.recommend }}
   - profile: "boundary"

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundaryForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundaryForEvent.yaml
@@ -7,6 +7,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   profile:
+  {{- range .spec.profile }}
   - name: "boundary"
     ptp4lOpts: "-2 --summary_interval -4"
     phc2sysOpts: "-a -r -m -n (?<domainNumber>[0-9]+) -N 8 -R 16"
@@ -125,6 +126,11 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0xA0
+    {{- if .ptpClockThreshold }}
+    ptpClockThreshold:
+      {{- .ptpClockThreshold | toYaml | nindent 6 }}
+    {{- end }}
+  {{- end }}
   recommend:
   {{- range .spec.recommend }}
   - profile: "boundary"

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
@@ -231,6 +231,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0x20
+    {{- if .ptpClockThreshold }}
+    ptpClockThreshold:
+      {{- .ptpClockThreshold | toYaml | nindent 6 }}
+    {{- end }}
   {{- end }}
   recommend:
   {{- range .spec.recommend }}

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHA.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHA.yaml
@@ -7,6 +7,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   profile:
+  {{- range .spec.profile }}
     - name: "boundary-ha"
       ptp4lOpts: ""
       phc2sysOpts: "-a -r -n (?<domainNumber>[0-9]+)"
@@ -15,6 +16,11 @@ spec:
       ptpSettings:
         logReduce: "true"
         haProfiles: "$profile1,$profile2"
+      {{- if .ptpClockThreshold }}
+      ptpClockThreshold:
+        {{- .ptpClockThreshold | toYaml | nindent 8 }}
+      {{- end }}
+  {{- end }}
   recommend:
   {{- range .spec.recommend }}
   - profile: "boundary-ha"

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHAForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigForHAForEvent.yaml
@@ -7,6 +7,7 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   profile:
+  {{- range .spec.profile }}
     - name: "boundary-ha"
       ptp4lOpts: ""
       phc2sysOpts: "-a -r -m -n (?<domainNumber>[0-9]+) -N 8 -R 16"
@@ -15,6 +16,11 @@ spec:
       ptpSettings:
         logReduce: "true"
         haProfiles: "$profile1,$profile2"
+      {{- if .ptpClockThreshold }}
+      ptpClockThreshold:
+        {{- .ptpClockThreshold | toYaml | nindent 8 }}
+      {{- end }}
+  {{- end }}
   recommend:
   {{- range .spec.recommend }}
   - profile: "boundary-ha"

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
@@ -216,6 +216,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0x20
+    {{- if .ptpClockThreshold }}
+    ptpClockThreshold:
+      {{- .ptpClockThreshold | toYaml | nindent 6 }}
+    {{- end }}
   {{- end }}
   recommend:
   {{- range .spec.recommend }}

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMaster.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMaster.yaml
@@ -121,6 +121,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0xA0
+    {{- if .ptpClockThreshold }}
+    ptpClockThreshold:
+      {{- .ptpClockThreshold | toYaml | nindent 6 }}
+    {{- end }}
   {{- end }}
   recommend:
   {{- range .spec.recommend }}

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMasterForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMasterForEvent.yaml
@@ -121,6 +121,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0xA0
+    {{- if .ptpClockThreshold }}
+    ptpClockThreshold:
+      {{- .ptpClockThreshold | toYaml | nindent 6 }}
+    {{- end }}
   {{- end }}
   recommend:
   {{- range .spec.recommend }}

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlave.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlave.yaml
@@ -119,6 +119,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0xA0
+    {{- if .ptpClockThreshold }}
+    ptpClockThreshold:
+      {{- .ptpClockThreshold | toYaml | nindent 6 }}
+    {{- end }}
   {{- end }}
   recommend:
   {{- range .spec.recommend }}

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlaveForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlaveForEvent.yaml
@@ -119,6 +119,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0xA0
+    {{- if .ptpClockThreshold }}
+    ptpClockThreshold:
+      {{- .ptpClockThreshold | toYaml | nindent 6 }}
+    {{- end }}
   {{- end }}
   recommend:
   {{- range .spec.recommend }}

--- a/ztp/source-crs/PtpConfigBoundaryForEvent.yaml
+++ b/ztp/source-crs/PtpConfigBoundaryForEvent.yaml
@@ -125,6 +125,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0xA0
+    ptpClockThreshold:
+      holdOverTimeout: 5
+      maxOffsetThreshold: 100
+      minOffsetThreshold: -100
   recommend:
   - profile: "boundary"
     priority: 4

--- a/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
@@ -239,6 +239,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0x20
+    ptpClockThreshold:
+      holdOverTimeout: 5
+      maxOffsetThreshold: 100
+      minOffsetThreshold: -100
   recommend:
   - profile: "grandmaster"
     priority: 4

--- a/ztp/source-crs/PtpConfigForHAForEvent.yaml
+++ b/ztp/source-crs/PtpConfigForHAForEvent.yaml
@@ -15,6 +15,10 @@ spec:
       ptpSettings:
         logReduce: "true"
         haProfiles: "$profile1,$profile2"
+      ptpClockThreshold:
+        holdOverTimeout: 5
+        maxOffsetThreshold: 100
+        minOffsetThreshold: -100
   recommend:
   - profile: "boundary-ha"
     priority: 4

--- a/ztp/source-crs/PtpConfigGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigGmWpc.yaml
@@ -219,6 +219,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0x20
+    ptpClockThreshold:
+      holdOverTimeout: 5
+      maxOffsetThreshold: 100
+      minOffsetThreshold: -100
   recommend:
   - profile: "grandmaster"
     priority: 4

--- a/ztp/source-crs/PtpConfigMasterForEvent.yaml
+++ b/ztp/source-crs/PtpConfigMasterForEvent.yaml
@@ -120,6 +120,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0xA0
+    ptpClockThreshold:
+      holdOverTimeout: 5
+      maxOffsetThreshold: 100
+      minOffsetThreshold: -100
   recommend:
   - profile: "grandmaster"
     priority: 4

--- a/ztp/source-crs/PtpConfigSlaveForEvent.yaml
+++ b/ztp/source-crs/PtpConfigSlaveForEvent.yaml
@@ -118,6 +118,10 @@ spec:
       manufacturerIdentity 00:00:00
       userDescription ;
       timeSource 0xA0
+    ptpClockThreshold:
+      holdOverTimeout: 5
+      maxOffsetThreshold: 100
+      minOffsetThreshold: -100
   recommend:
   - profile: "slave"
     priority: 4


### PR DESCRIPTION
This change allows ptpClockThreshold to be set in all PtpConfig
scenarios, and also provides default values for the *ForEvent examples in
source-crs.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
