### PR TITLE
OCPBUGS-49785: ztp: Default WPC-GM MaxInSpecOffset to 1500 and allow user configuration of all settings values

### DIFF
--- a/ztp/kube-compare-reference/default_value.yaml
+++ b/ztp/kube-compare-reference/default_value.yaml
@@ -44,6 +44,10 @@ optional_ptp_config_PtpConfigDualCardGmWpc:
     profile:
     - plugins:
         e810:
+          settings:
+            LocalMaxHoldoverOffSet: 1500
+            LocalHoldoverTimeout: 14400
+            MaxInSpecOffset: 1500
           pins:
             $iface_timeTx1:
               SMA1: 2 1
@@ -114,6 +118,10 @@ optional_ptp_config_PtpConfigGmWpc:
     profile:
     - plugins:
         e810:
+          settings:
+            LocalMaxHoldoverOffSet: 1500
+            LocalHoldoverTimeout: 14400
+            MaxInSpecOffset: 1500
           pins:
             $iface_timeTx:
               SMA1: 0 1

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
@@ -23,9 +23,7 @@ spec:
       e810:
         enableDefaultConfig: false
         settings:
-          LocalMaxHoldoverOffSet: 1500
-          LocalHoldoverTimeout: 14400
-          MaxInSpecOffset: 100
+          {{- .plugins.e810.settings | toYaml | nindent 10 }}
         pins:
           # Syntax guide:
           # - The 1st number in each pair must be one of:

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
@@ -21,9 +21,7 @@ spec:
       e810:
         enableDefaultConfig: false
         settings:
-          LocalMaxHoldoverOffSet: 1500
-          LocalHoldoverTimeout: 14400
-          MaxInSpecOffset: 100
+          {{- .plugins.e810.settings | toYaml | nindent 10 }}
         pins:
           # Syntax guide:
           # - The 1st number in each pair must be one of:

--- a/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigDualCardGmWpc.yaml
@@ -22,9 +22,9 @@ spec:
       e810:
         enableDefaultConfig: false
         settings:
-          LocalMaxHoldoverOffSet: 1500
           LocalHoldoverTimeout: 14400
-          MaxInSpecOffset: 100
+          LocalMaxHoldoverOffSet: 1500
+          MaxInSpecOffset: 1500
         pins:
           # Syntax guide:
           # - The 1st number in each pair must be one of:

--- a/ztp/source-crs/PtpConfigGmWpc.yaml
+++ b/ztp/source-crs/PtpConfigGmWpc.yaml
@@ -20,9 +20,9 @@ spec:
       e810:
         enableDefaultConfig: false
         settings:
-          LocalMaxHoldoverOffSet: 1500
           LocalHoldoverTimeout: 14400
-          MaxInSpecOffset: 100
+          LocalMaxHoldoverOffSet: 1500
+          MaxInSpecOffset: 1500
         pins:
           # Syntax guide:
           # - The 1st number in each pair must be one of:


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
