### PR TITLE
OCPBUGS-47784: ztp: Enforce PTP priority1 field must be 128 for telco ABMCA

### DIFF
--- a/ztp/kube-compare-reference/default_value.yaml
+++ b/ztp/kube-compare-reference/default_value.yaml
@@ -29,7 +29,6 @@ optional_ptp_config_PtpConfigBoundary:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
   captureGroup_defaults:
-    priority1: 128
     priority2: 128
     domainNumber: 24
 optional_ptp_config_PtpConfigBoundaryForEvent:
@@ -43,7 +42,6 @@ optional_ptp_config_PtpConfigBoundaryForEvent:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
   captureGroup_defaults:
-    priority1: 128
     priority2: 128
     domainNumber: 24
 optional_ptp_config_PtpConfigDualCardGmWpc:
@@ -74,7 +72,6 @@ optional_ptp_config_PtpConfigDualCardGmWpc:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
   captureGroup_defaults:
-    priority1: 128
     priority2: 128
     domainNumber: 24
 optional_ptp_config_PtpConfigForHA:
@@ -106,7 +103,6 @@ optional_ptp_config_PtpConfigMaster:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
   captureGroup_defaults:
-    priority1: 128
     priority2: 128
     domainNumber: 24
 optional_ptp_config_PtpConfigMasterForEvent:
@@ -121,7 +117,6 @@ optional_ptp_config_PtpConfigMasterForEvent:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
   captureGroup_defaults:
-    priority1: 128
     priority2: 128
     domainNumber: 24
 optional_ptp_config_PtpConfigSlave:
@@ -132,7 +127,6 @@ optional_ptp_config_PtpConfigSlave:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
   captureGroup_defaults:
-    priority1: 128
     priority2: 128
     domainNumber: 24
 optional_ptp_config_PtpConfigGmWpc:
@@ -158,7 +152,6 @@ optional_ptp_config_PtpConfigGmWpc:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
   captureGroup_defaults:
-    priority1: 128
     priority2: 128
     domainNumber: 24
 optional_ptp_config_PtpConfigSlaveForEvent:
@@ -173,7 +166,6 @@ optional_ptp_config_PtpConfigSlaveForEvent:
     - match:
       - nodeLabel: "node-role.kubernetes.io/$mcp"
   captureGroup_defaults:
-    priority1: 128
     priority2: 128
     domainNumber: 24
 optional_ptp_config_PtpOperatorConfig:

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundary.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundary.yaml
@@ -31,7 +31,7 @@ spec:
       #
       twoStepFlag 1
       slaveOnly 0
-      priority1 (?<priority1>[0-9]+)
+      priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundaryForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigBoundaryForEvent.yaml
@@ -31,7 +31,7 @@ spec:
       #
       twoStepFlag 1
       slaveOnly 0
-      priority1 (?<priority1>[0-9]+)
+      priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigDualCardGmWpc.yaml
@@ -135,7 +135,7 @@ spec:
       # Default Data Set
       #
       twoStepFlag 1
-      priority1 (?<priority1>[0-9]+)
+      priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigGmWpc.yaml
@@ -120,7 +120,7 @@ spec:
       # Default Data Set
       #
       twoStepFlag 1
-      priority1 (?<priority1>[0-9]+)
+      priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMaster.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMaster.yaml
@@ -26,7 +26,7 @@ spec:
       #
       twoStepFlag 1
       slaveOnly 0
-      priority1 (?<priority1>[0-9]+)
+      priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMasterForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigMasterForEvent.yaml
@@ -26,7 +26,7 @@ spec:
       #
       twoStepFlag 1
       slaveOnly 0
-      priority1 (?<priority1>[0-9]+)
+      priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlave.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlave.yaml
@@ -24,7 +24,7 @@ spec:
       #
       twoStepFlag 1
       slaveOnly 1
-      priority1 (?<priority1>[0-9]+)
+      priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlaveForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigSlaveForEvent.yaml
@@ -24,7 +24,7 @@ spec:
       #
       twoStepFlag 1
       slaveOnly 1
-      priority1 (?<priority1>[0-9]+)
+      priority1 128
       priority2 (?<priority2>[0-9]+)
       domainNumber (?<domainNumber>[0-9]+)
       #utc_offset 37


### PR DESCRIPTION
For now we are supporting the G.8275.1 PTP profile for telco. The
priority1 field must be set to 128 for this profile and should not be
user-customizeable.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
