### PR TITLE
cnf-tests: Dump `openshift-multus` namespace on failure

### DIFF
--- a/cnf-tests/testsuites/pkg/utils/reporter.go
+++ b/cnf-tests/testsuites/pkg/utils/reporter.go
@@ -115,6 +115,7 @@ func NewReporter(reportPath string) (*k8sreporter.KubernetesReporter, error) {
 		namespaces.BondTestNamespace:            "bondcni",
 		namespaces.MetalLBOperator:              "metallb",
 		namespaces.TuningTest:                   "tuningcni",
+		namespaces.Multus:                       "multus",
 	}
 
 	crds := []k8sreporter.CRData{

--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -24,6 +24,10 @@ export LATENCY_TEST_RUN=${LATENCY_TEST_RUN:-false}
 
 export IS_OPENSHIFT="${IS_OPENSHIFT:-true}"
 
+# Read by sriov-network-operator confomrance test suite when dumping resource, on test failures.
+# https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/636
+export MULTUS_NAMESPACE=openshift-multus
+
 # The metallb tests cover both frr and frr-k8s, and we don't
 # currently deploy frr-k8s mode
 export BLACKLISTED_TESTS="frr-k8s"


### PR DESCRIPTION
Multus pod logs contains log entries from CNI instances, which  might be critical when debugging test failures.

Dump multus logs either on the SR-IOV conformance test suite and the integration test suite.