### PR TITLE
cnf-tests: MultiNetworkPolicy `DiscoverSriov(...)` fix

### DIFF
--- a/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go
@@ -86,6 +86,8 @@ var _ = Describe("[multinetworkpolicy] MultiNetworkPolicy SR-IOV integration", f
 		Expect(namespaces.Create(nsY, client.Client)).ToNot(HaveOccurred())
 		Expect(namespaces.Create(nsZ, client.Client)).ToNot(HaveOccurred())
 
+		networks.CleanSriov(sriovclient)
+
 		sriovInfos, err := sriovcluster.DiscoverSriov(sriovclient, namespaces.SRIOVOperator)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sriovInfos).ToNot(BeNil())
@@ -108,8 +110,6 @@ var _ = Describe("[multinetworkpolicy] MultiNetworkPolicy SR-IOV integration", f
 
 		sriovDevice, err := sriovInfos.FindOneSriovDevice(testNodeNames[0])
 		Expect(err).ToNot(HaveOccurred())
-
-		networks.CleanSriov(sriovclient)
 
 		_, err = sriovNetwork.CreateSriovPolicy(sriovclient, "test-policy-", namespaces.SRIOVOperator,
 			sriovDevice.Name, testNodeNames[0], 10, SriovResource, "netdevice")


### PR DESCRIPTION
Run `networks.CleanSriov(sriovclient)` before invoking `DiscoverSriov(...)`, as the latter needs a stable cluster to work.

See failure at:
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.18-e2e-telco5g-cnftests/1887924564965462016

```
 Enter [BeforeEach] [multinetworkpolicy] MultiNetworkPolicy SR-IOV integration - /tmp/cnf-X9i6O/cnf-features-deploy/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go:67 @ 02/07/25 21:10:45.332
< Exit [BeforeEach] [multinetworkpolicy] MultiNetworkPolicy SR-IOV integration - /tmp/cnf-X9i6O/cnf-features-deploy/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go:67 @ 02/07/25 21:10:45.447 (115ms)
> Enter [BeforeEach] [multinetworkpolicy] MultiNetworkPolicy SR-IOV integration - /tmp/cnf-X9i6O/cnf-features-deploy/cnf-tests/testsuites/pkg/execute/ginkgo.go:9 @ 02/07/25 21:10:45.447
[FAILED] Unexpected error:
    <*errors.errorString | 0xc001534e40>: 
    sync status still in progress
    {
        s: "sync status still in progress",
    }
occurred
In [BeforeEach] at: /tmp/cnf-X9i6O/cnf-features-deploy/cnf-tests/testsuites/e2esuite/multinetworkpolicy/multinetworkpolicy_sriov.go:90 @ 02/07/25 21:10:57.256
< Exit [BeforeEach] [multinetworkpolicy] MultiNetworkPolicy SR-IOV integration - /tmp/cnf-X9i6O/cnf-features-deploy/cnf-tests/testsuites/pkg/execute/ginkgo.go:9 @ 02/07/25 21:10:57.256 (11.809s)
```

@SchSeba PTAL