### PR TITLE
cnf-tests: set external frr-k8s namespace for MetalLB suite

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -22,6 +22,7 @@ export SRO_VERSION="${SRO_VERSION:-4.11}"
 
 # the metallb-operator deployment and test namespace
 export OO_INSTALL_NAMESPACE="${OO_INSTALL_NAMESPACE:-openshift-metallb-system}"
+export FRRK8S_EXTERNAL_NAMESPACE="${FRRK8S_EXTERNAL_NAMESPACE:-openshift-frr-k8s}"
 
 export TESTS_REPORTS_PATH="${TESTS_REPORTS_PATH:-/logs/artifacts/}"
 export JUNIT_TO_HTML="${JUNIT_TO_HTML:-false}"


### PR DESCRIPTION
When running on OCP the tests should be given the namespace CNO deploys frr-k8s on