### PR TITLE
OCPBUGS-48184: ztp: reference: Allow topolvm.io or kubernetes.io/no-provisioner for StorageClass provisioner

### DIFF
--- a/ztp/kube-compare-reference/default_value.yaml
+++ b/ztp/kube-compare-reference/default_value.yaml
@@ -8,6 +8,7 @@ optional_image_registry_ImageRegistryConfig:
 optional_local_storage_operator_StorageClass:
 - metadata:
     name: example-storage-class
+  provisioner: kubernetes.io/no-provisioner
 optional_local_storage_operator_StorageLV:
 - metadata:
     name: local-disks

--- a/ztp/kube-compare-reference/metadata.yaml
+++ b/ztp/kube-compare-reference/metadata.yaml
@@ -288,6 +288,7 @@ templateFunctionFiles:
   - validate_node_selector.tmpl
   - unordered_list.tmpl
   - version_match.tmpl
+  - must_match_one_of.tmpl
 
 fieldsToOmit:
   defaultOmitRef: all

--- a/ztp/kube-compare-reference/must_match_one_of.tmpl
+++ b/ztp/kube-compare-reference/must_match_one_of.tmpl
@@ -1,0 +1,11 @@
+{{- define "mustMatchOneOf" }}
+  {{- $currentValue := index . 0 | default "--empty--" }}
+  {{- $allowedValues := slice . 1 }}
+  {{- $result := print $currentValue " not in " $allowedValues }}
+  {{- range $allowed := $allowedValues }}
+    {{- if eq $currentValue $allowed }}
+      {{- $result = $currentValue }}
+    {{- end }}
+  {{- end }}
+  {{- $result }}
+{{- end }}

--- a/ztp/kube-compare-reference/optional/local-storage-operator/StorageClass.yaml
+++ b/ztp/kube-compare-reference/optional/local-storage-operator/StorageClass.yaml
@@ -4,5 +4,5 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"
   name: {{ .metadata.name }}
-provisioner: kubernetes.io/no-provisioner
+provisioner: {{ template "mustMatchOneOf" (list .provisioner "kubernetes.io/no-provisioner" "topolvm.io") }}
 reclaimPolicy: Delete


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
