### PR TITLE
cnf-tests: DNM test `[It] [sriov] Metrics Exporter When Prometheus operator is available Metrics should have the correct labels`

### DIFF
--- a/cnf-tests/hack/init-git-submodules.sh
+++ b/cnf-tests/hack/init-git-submodules.sh
@@ -20,8 +20,11 @@ git fetch --all
 git checkout origin/"${METALLB_OPERATOR_TARGET_COMMIT}"
 
 cd ../sriov-network-operator/
-git fetch --all
-git checkout origin/"${SRIOV_NETWORK_OPERATOR_TARGET_COMMIT}"
+#git fetch --all
+#git checkout origin/"${SRIOV_NETWORK_OPERATOR_TARGET_COMMIT}"
+git remote add ds-zeeke https://github.com/zeeke/sriov-network-operator
+git fetch ds-zeeke
+git checkout ds-zeeke/ds/417/debug-metrics-test
 
 cd ../cluster-node-tuning-operator/
 git fetch --all


### PR DESCRIPTION
…erator is available Metrics should have the correct labels`

Test commit to debug the flaking test case:

```
[It] [sriov] Metrics Exporter When Prometheus operator is available Metrics should have the correct labels
```

from branch https://github.com/zeeke/sriov-network-operator/tree/ds/417/debug-metrics-test