### PR TITLE
cnf-tests: switch to ocp/builder base for multi-arch support

### DIFF
--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -96,7 +96,7 @@ RUN yum install -y numactl-devel make gcc && \
 FROM registry.ci.openshift.org/ocp/4.19:oc-rpms AS oc
 
 # Final image
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-enterprise-base-multi-openshift-4.19
 
 ENV OCP_VERSION=4.19
 ENV IMAGE_REGISTRY=quay.io/openshift-kni/


### PR DESCRIPTION
To be able to support aarch64 cnf-tests build u/s, the base image need to be arm compatible, but `ocp/4.19` is not a good choice here so replace it with
`ocp/builder:rhel-9-enterprise-base-multi-openshift-4.19`.

ref: https://docs.ci.openshift.org/docs/architecture/images/; https://docs.ci.openshift.org/docs/how-tos/multi-architecture/; An `openshift/release` PR will follow to update the "from" directive.