### PR TITLE
ztp: CNF-15573: Add reboot manifests

### DIFF
--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/README.md
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/README.md
@@ -145,3 +145,11 @@ includes the statically generated Policy) or PolicyGenerator.
 ### Other
 
 The pgt2acmpg supports converting Policy Gen Templates to ACM Policy Generator templates. More details can be found at [link](https://github.com/openshift-kni/cnf-features-deploy/ztp/tools/pgt2acmpg/blob/main/README.md)
+
+## Controlled reboot a fleet of clusters
+
+Users are able to make tuning changes by applying tuned configurations on a running system. When the tuning change is done, the tuned process rollbacks all the configurations and reapplies them. In some cases, latency sensitive applications can't tolerate the removal/re-apply of the tuned profile. By adding `tuned.openshift.io/deferred` annotation to the `Tuned` CR, applying of the configuration can be deferred to the maintenance window. After rebooting the node the deferred tuning configuration will be applied to the node.
+
+PolicyGenerators `acm-example-multinode-reboot.yaml` and `acm-example-sno-reboot` can be used to reboot clusters. The policies generated contain a dummy `MachineConfig` and a `MachineConfigPool` that validates the `MachineConfigPool` is successfully updated. These policies can be rolled out using `CGU` to desired clusters. In case of multi-node clusters the `MCP` should match the `Tuned.spec.recommended`. Note that all the nodes belong to the `MCP` at the time of rolling out the policy will be rebooted.
+
+When there are multiple config changes, all the config changes can be deferred and use reboot policy to do a single reboot instead of rebooting for every config change. In this case, all the configuration changes can be put inside a `CGU` and put the reboot policy as the last item in the `CGU`'s `managedPolicies`. 

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-example-multinode-reboot.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-example-multinode-reboot.yaml
@@ -1,0 +1,54 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: example-multinode-reboot
+placementBindingDefaults:
+  name: example-multinode-reboot-placement-binding
+policyDefaults:
+  namespace: default
+  placement:
+    labelSelector:
+      site: "example-reboot"
+  remediationAction: inform
+  severity: low
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+    compliant: 10m
+    noncompliant: 10s
+policies:
+- name: example-reboot
+  policyAnnotations:
+    ran.openshift.io/soak-seconds: "120"
+  manifests:
+  - path: source-crs/RebootMachineConfig.yaml
+    complianceType: mustonlyhave
+    patches:
+    - spec:
+        config:
+          storage:
+            files:
+            - contents:
+              # content of file should change to trigger a reboot
+              # append a message for the reboot to the content of the file
+              # example: $ echo "$(date): applying tuned config" | base64
+                source: data:text/plain;charset=utf-8;base64,bWVzc2FnZQo=
+              mode: 420
+              path: "/etc/kubernetes/reboot-<mcp>"
+      metadata:
+        name: "95-reboot-<mcp>"
+        labels:
+          machineconfiguration.openshift.io/role: "<mcp>"
+  - path: source-crs/validatorCRs/rebootMachineConfigPoolValidator.yaml
+    patches:
+    - metadata:
+        name: "<mcp>"
+      status:
+        configuration:
+          source:
+            - apiVersion: machineconfiguration.openshift.io/v1
+              kind: MachineConfig
+              name: "95-reboot-<mcp>"

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-example-sno-reboot.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-example-sno-reboot.yaml
@@ -1,0 +1,55 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: example-sno-reboot-latest
+placementBindingDefaults:
+  name: example-sno-reboot-placement-binding
+policyDefaults:
+  namespace: default
+  placement:
+    labelSelector:
+      site: "example-sno"
+  remediationAction: inform
+  severity: low
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+    compliant: 10m
+    noncompliant: 10s
+policies:
+- name: example-sno-reboot
+  policyAnnotations:
+    ran.openshift.io/soak-seconds: "120"
+  manifests:
+  - path: source-crs/RebootMachineConfig.yaml
+    complianceType: mustonlyhave
+    patches:
+    - spec:
+        config:
+          storage:
+            files:
+            - contents:
+              # content of file should change to trigger a reboot
+              # append a message for the reboot to the content of the file
+              # example: $ echo "$(date): applying tuned config" | base64
+                source: data:text/plain;charset=utf-8;base64,bWVzc2FnZQo=
+              mode: 420
+              path: "/etc/kubernetes/reboot-master"
+      metadata:
+        name: "95-reboot-master"
+        labels:
+          machineconfiguration.openshift.io/role: master
+  - path: source-crs/validatorCRs/rebootMachineConfigPoolValidator.yaml
+    patches:
+    - metadata:
+        name: master
+      status:
+        configuration:
+          source:
+            - apiVersion: machineconfiguration.openshift.io/v1
+              kind: MachineConfig
+              name: "95-reboot-master"
+

--- a/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/kustomization.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/kustomization.yaml
@@ -22,6 +22,10 @@ generators:
 # This policy removes Cluster Logging operator 5.x artifacts after upgrading to 6.x
 - acm-group-du-clo5-cleanup.yaml
 
+# optional reboot policies
+# - acm-example-multinode-reboot.yaml
+# - acm-example-sno-reboot.yaml
+
 resources:
 - ns.yaml
 # The resources from below are only needed if policies from hub-side-templating are used.

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-multinode-reboot.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-multinode-reboot.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "example-multinode-reboot"
+  namespace: "default"
+spec:
+  bindingRules:
+    sites: "example-multinode"
+  sourceFiles:
+    - fileName: RebootMachineConfig.yaml
+      complianceType: mustonlyhave
+      policyName: "reboot"
+      spec:
+        config:
+          storage:
+            files:
+            - contents:
+              # content of file should change to trigger a reboot
+              # append a message for the reboot to the content of the file
+              # example: $ echo "$(date): applying tuned config" | base64
+                source: data:text/plain;charset=utf-8;base64,bWVzc2FnZQo=
+              mode: 420
+              path: "/etc/kubernetes/reboot-<mcp>"
+      metadata:
+        name: "95-reboot-<mcp>"
+        labels:
+          machineconfiguration.openshift.io/role: "<mcp>"
+    - fileName: validatorCRs/rebootMachineConfigPoolValidator.yaml
+      complianceType: musthave
+      policyName: "reboot-<mcp>-validator"
+      metadata:
+        name: "<mcp>"
+      status:
+        configuration:
+          source:
+            - apiVersion: machineconfiguration.openshift.io/v1
+              kind: MachineConfig
+              name: "95-reboot-<mcp>"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-reboot.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/example-sno-reboot.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "example-sno-reboot"
+  namespace: "default"
+spec:
+  bindingRules:
+    sites: "example-sno"
+  sourceFiles:
+    - fileName: RebootMachineConfig.yaml
+      complianceType: mustonlyhave
+      policyName: "reboot"
+      spec:
+        config:
+          storage:
+            files:
+            - contents:
+              # content of file should change to trigger a reboot
+              # append a message for the reboot to the content of the file
+              # example: $ echo "$(date): applying tuned config" | base64
+                source: data:text/plain;charset=utf-8;base64,bWVzc2FnZQo=
+              mode: 420
+              path: "/etc/kubernetes/reboot-master"
+      metadata:
+        name: "95-reboot-master"
+        labels:
+          machineconfiguration.openshift.io/role: "master"
+    - fileName: validatorCRs/rebootMachineConfigPoolValidator.yaml
+      complianceType: musthave
+      policyName: "reboot-mcp-validator"
+      metadata:
+        name: "master"
+      status:
+        configuration:
+          source:
+            - apiVersion: machineconfiguration.openshift.io/v1
+              kind: MachineConfig
+              name: "95-reboot-master"

--- a/ztp/gitops-subscriptions/argocd/example/policygentemplates/kustomization.yaml
+++ b/ztp/gitops-subscriptions/argocd/example/policygentemplates/kustomization.yaml
@@ -20,6 +20,10 @@ generators:
 - example-sno-site.yaml
 - example-multinode-site.yaml
 
+# optional reboot policies
+# - example-sno-reboot.yaml
+# - example-multinode-reboot.yaml
+
 resources:
 - ns.yaml
 # The resources from below are only needed if policies from hub-side-templating are used.
@@ -67,3 +71,22 @@ resources:
 #      # the policy name format is as {name}-{spec.sourceFiles[x].policyName}
 #      name: group-du-standard-validator-latest-du-policy
 #      namespace: ztp-group
+
+  # Patches to add soaking annotation for mcp validator of reboot policies
+  #
+  # - patch: |-
+  #     apiVersion: policy.open-cluster-management.io/v1
+  #     kind: Policy
+  #     metadata:
+  #       annotations:
+  #         ran.openshift.io/soak-seconds: "120"
+  #       name: example-sno-reboot-reboot-mcp-validator
+  #       namespace: default
+  # - patch: |-
+  #     apiVersion: policy.open-cluster-management.io/v1
+  #     kind: Policy
+  #     metadata:
+  #       annotations:
+  #         ran.openshift.io/soak-seconds: "120"
+  #       name: example-multinode-reboot-reboot-mcp-validator
+  #       namespace: default

--- a/ztp/kube-compare-reference/compare_ignore
+++ b/ztp/kube-compare-reference/compare_ignore
@@ -67,6 +67,10 @@ ImageSignature.yaml
 MachineConfigPool.yaml
 MachineConfigSctp.yaml
 
+# Reboot source-crs
+RebootMachineConfig.yaml
+validatorCRs/rebootMachineConfigPoolValidator.yaml
+
 # Not true CRs, but special site-config templates
 extra-manifest/disk-encryption.yaml.tmpl
 extra-manifest/image-registry-partition-mc.yaml.tmpl

--- a/ztp/source-crs/RebootMachineConfig.yaml
+++ b/ztp/source-crs/RebootMachineConfig.yaml
@@ -1,0 +1,25 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: $mcp 
+  name: 95-talm-initiated-reboot-$mcp
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.1.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,$data
+        mode: 420
+        path: /etc/kubernetes/reboot-$mcp
+  fips: false
+  kernelArguments: null
+  kernelType: ""
+  osImageURL: ""

--- a/ztp/source-crs/validatorCRs/rebootMachineConfigPoolValidator.yaml
+++ b/ztp/source-crs/validatorCRs/rebootMachineConfigPoolValidator.yaml
@@ -1,0 +1,15 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: "mcp"
+status:
+  configuration:
+    source:
+      - apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfig
+        name: 95-talm-initiated-reboot-$mcp
+  conditions:
+  - type: Updated
+    status: "True"
+  - type: Updating
+    status: "False"


### PR DESCRIPTION
Add reboot source CRs:
 - dummy MachineConfig that triggers a reboot on nodes of a
   MachineConifgPool
 - MachineConfigPool validator that checks all nodes are updated

Add reboot PolicyGenerator examples
Add reboot PGT examples

Example:
```
$ ./policy-generator ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/acm-example-multinode-reboot.yaml
---
apiVersion: policy.open-cluster-management.io/v1
kind: Policy
metadata:
    annotations:
        policy.open-cluster-management.io/categories: CM Configuration Management
        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
        policy.open-cluster-management.io/description: ""
        policy.open-cluster-management.io/standards: NIST SP 800-53
        ran.openshift.io/soak-seconds: "120"
    name: example-reboot
    namespace: default
spec:
    disabled: false
    policy-templates:
        - objectDefinition:
            apiVersion: policy.open-cluster-management.io/v1
            kind: ConfigurationPolicy
            metadata:
                name: example-reboot
            spec:
                evaluationInterval:
                    compliant: 10m
                    noncompliant: 10s
                namespaceSelector:
                    exclude:
                        - kube-*
                    include:
                        - '*'
                object-templates:
                    - complianceType: mustonlyhave
                      objectDefinition:
                        apiVersion: machineconfiguration.openshift.io/v1
                        kind: MachineConfig
                        metadata:
                            labels:
                                machineconfiguration.openshift.io/role: <mcp>
                            name: 95-reboot-<mcp>
                        spec:
                            baseOSExtensionsContainerImage: ""
                            config:
                                ignition:
                                    config: {}
                                    security:
                                        tls: {}
                                    timeouts: {}
                                    version: 3.1.0
                                storage:
                                    files:
                                        - contents:
                                            source: data:text/plain;charset=utf-8;base64,bWVzc2FnZQo=
                                          mode: 420
                                          path: /etc/kubernetes/reboot-<mcp>
                            fips: false
                            kernelArguments: null
                            kernelType: ""
                            osImageURL: ""
                    - complianceType: musthave
                      objectDefinition:
                        apiVersion: machineconfiguration.openshift.io/v1
                        kind: MachineConfigPool
                        metadata:
                            name: <mcp>
                        status:
                            conditions:
                                - status: "True"
                                  type: Updated
                                - status: "False"
                                  type: Updating
                            configuration:
                                source:
                                    - apiVersion: machineconfiguration.openshift.io/v1
                                      kind: MachineConfig
                                      name: 95-reboot-<mcp>
                remediationAction: inform
                severity: low
    remediationAction: inform
---
apiVersion: cluster.open-cluster-management.io/v1beta1
kind: Placement
metadata:
    name: placement-example-reboot
    namespace: default
spec:
    predicates:
        - requiredClusterSelector:
            labelSelector:
                matchExpressions:
                    - key: site
                      operator: In
                      values:
                        - example-reboot
    tolerations:
        - key: cluster.open-cluster-management.io/unavailable
          operator: Exists
        - key: cluster.open-cluster-management.io/unreachable
          operator: Exists
---
apiVersion: policy.open-cluster-management.io/v1
kind: PlacementBinding
metadata:
    name: binding-example-reboot
    namespace: default
placementRef:
    apiGroup: cluster.open-cluster-management.io
    kind: Placement
    name: placement-example-reboot
subjects:
    - apiGroup: policy.open-cluster-management.io
      kind: Policy
      name: example-reboot
```


/cc @imiller0 @sabbir-47 