### PR TITLE
[release-4.16] cnf-tests: switch to ocp/builder base for multi-arch support

### DIFF
--- a/cnf-tests/Dockerfile.openshift
+++ b/cnf-tests/Dockerfile.openshift
@@ -68,7 +68,7 @@ RUN yum install -y numactl-devel make gcc && \
 FROM quay.io/openshift/origin-oc-rpms:4.16 AS oc
 
 # Final image
-FROM openshift/origin-base
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-enterprise-base-multi-openshift-4.16
 
 ENV IMAGE_REGISTRY=quay.io/openshift-kni/
 ENV CNF_TESTS_IMAGE=cnf-tests:4.16


### PR DESCRIPTION
To be able to support aarch64 cnf-tests build u/s, the base image need to be arm compatible and using `ocp/builder:rhel-8-enterprise-base-multi-openshift-4.16` will provide a multi-arch build.