### PR TITLE
ztp: Adjust 3-card PTP T-GM reference to not rely on fallback behavior

### DIFF
--- a/ztp/kube-compare-reference/default_value.yaml
+++ b/ztp/kube-compare-reference/default_value.yaml
@@ -76,9 +76,7 @@ optional_ptp_config_PtpConfigDualCardGmWpc:
     priority2: 128
     domainNumber: 24
 optional_ptp_config_PtpConfigThreeCardGmWpc:
-- metadata:
-    name: grandmaster
-  spec:
+- spec:
     profile:
     - plugins:
         e810:

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpConfigThreeCardGmWpc.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpConfigThreeCardGmWpc.yaml
@@ -5,7 +5,7 @@
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
-  name: {{ .metadata.name }}
+  name: grandmaster
   namespace: openshift-ptp
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"


### PR DESCRIPTION
Until we fix OCPBUGS-53199, there's really no good way to mix different
match classes, since matches with an exact api/kind/namespace/name will
always trump api/kind/namespace/* even if the latter is a closer match.

This change works around that behavior but forces the PtpConfig to be
named "grandmaster".  We can either relax the reference all at once
(allowing all PtpConfig to be named anything), or wait until the bug is
fixed and released to just relax some of the PtpConfigs.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
