### PR TITLE
ztp: update certain ClusterLog CRs to wave 3

### DIFF
--- a/ztp/source-crs/ClusterLogServiceAccount.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccount.yaml
@@ -5,4 +5,4 @@ metadata:
   name: collector
   namespace: openshift-logging
   annotations:
-    ran.openshift.io/ztp-deploy-wave: "2"
+    ran.openshift.io/ztp-deploy-wave: "3"

--- a/ztp/source-crs/ClusterLogServiceAccountAuditBinding.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccountAuditBinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: logcollector-audit-logs-binding
   annotations:
-    ran.openshift.io/ztp-deploy-wave: "2"
+    ran.openshift.io/ztp-deploy-wave: "3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/ztp/source-crs/ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/ztp/source-crs/ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: logcollector-infrastructure-logs-binding
   annotations:
-    ran.openshift.io/ztp-deploy-wave: "2"
+    ran.openshift.io/ztp-deploy-wave: "3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
These CRs have dependency on namespace openshift-logging which will be created only after the operator is installed in wave 2. 

This PR is to update the wave to 3. for following CRs:
ServiceAccount in ClusterLogServiceAccount.yaml
ClusterRoleBinding in ClusterLogServiceAccountAuditBinding.yaml
ClusterRoleBinding in ClusterLogServiceAccountInfrastructureBinding.yaml