### PR TITLE
ClusterLogSubscription to stable-6.2

### DIFF
--- a/ztp/source-crs/ClusterLogSubscription.yaml
+++ b/ztp/source-crs/ClusterLogSubscription.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "2"
 spec:
-  channel: "stable-6.1"
+  channel: "stable-6.2"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
stable-6.2 should be there now.

Not sure if it should go only to 4.18.