### PR TITLE
ztp: Allow vfio kernel args to be optional

### DIFF
--- a/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
+++ b/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
@@ -3,7 +3,7 @@ kind: PerformanceProfile
 metadata:
   # if you change this name make sure the 'include' line in TunedPerformancePatch.yaml
   # matches this name: include=openshift-node-performance-${PerformanceProfile.metadata.name}
-  # Also in file 'validatorCRs/informDuValidator.yaml': 
+  # Also in file 'validatorCRs/informDuValidator.yaml':
   # name: 50-performance-${PerformanceProfile.metadata.name}
   name: openshift-node-performance-profile
   annotations:
@@ -12,10 +12,11 @@ metadata:
 spec:
   additionalKernelArgs:
     {{- template "unorderedList" (list .spec.additionalKernelArgs (list
-      "efi=runtime" 
-      "module_blacklist=irdma" 
-      "rcupdate.rcu_normal_after_boot=0" 
-      "vfio_pci.disable_idle_d3=1" 
+      "efi=runtime"
+      "module_blacklist=irdma"
+      "rcupdate.rcu_normal_after_boot=0"
+      ) (list
+      "vfio_pci.disable_idle_d3=1"
       "vfio_pci.enable_sriov=1"
     )) }}
   cpu:

--- a/ztp/kube-compare-reference/unordered_list.tmpl
+++ b/ztp/kube-compare-reference/unordered_list.tmpl
@@ -1,8 +1,13 @@
 {{- define "unorderedList" }}
+{{- /* compare two unordered lists: unorderedList <listToEval> <requiredValues> [optionalValues] */}}
 {{- $result := list }}
+{{- $optionalArgs := list }}
+{{- if gt (len .) 2 }}
+{{- $optionalArgs = concat $optionalArgs (index . 2) }}
+{{- end }}
 {{- $expectedArgs := index . 1 }}
 {{- range $value := (index . 0) }}
-  {{- if has $value $expectedArgs }}
+  {{- if or (has $value $expectedArgs) (has $value $optionalArgs) }}
     {{- $result = append $result $value }}
     {{- $expectedArgs = without $expectedArgs $value }}
   {{- end }}

--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -3,7 +3,7 @@ kind: PerformanceProfile
 metadata:
   # if you change this name make sure the 'include' line in TunedPerformancePatch.yaml
   # matches this name: include=openshift-node-performance-${PerformanceProfile.metadata.name}
-  # Also in file 'validatorCRs/informDuValidator.yaml': 
+  # Also in file 'validatorCRs/informDuValidator.yaml':
   # name: 50-performance-${PerformanceProfile.metadata.name}
   name: openshift-node-performance-profile
   annotations:


### PR DESCRIPTION
The vfio_pci kernel arguments are in support of the FEC accelerator. Allow these to be optional if not needed.
CNF-15761