### PR TITLE
ztp: Support the patching of stringData in Secret source files

### DIFF
--- a/ztp/policygenerator/policyGen/policyBuilder.go
+++ b/ztp/policygenerator/policyGen/policyBuilder.go
@@ -315,6 +315,15 @@ func (pbuilder *PolicyBuilder) getCustomResource(sourceFile utils.SourceFile, so
 		resourceMap["binaryData"] = pbuilder.setValues(resourceMap["binaryData"].(map[string]interface{}), sourceFile.BinaryData)
 	}
 
+	if resourceMap["stringData"] == nil && sourceFile.StringData != nil {
+		// If the user supplies a "stringData" section but the source CR does not have
+		// one, this will ensure we pull in the user content
+		resourceMap["stringData"] = make(map[string]interface{})
+	}
+	if resourceMap["stringData"] != nil {
+		resourceMap["stringData"] = pbuilder.setValues(resourceMap["stringData"].(map[string]interface{}), sourceFile.StringData)
+	}
+
 	return resourceMap, nil
 }
 

--- a/ztp/policygenerator/policyGen/policyBuilder_test.go
+++ b/ztp/policygenerator/policyGen/policyBuilder_test.go
@@ -1578,3 +1578,44 @@ spec:
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), `Failed to process the source file GenericWithoutMetadata.yaml: All source files must have the "metadata" field set`)
 }
+
+func TestStringDataPatch(t *testing.T) {
+	input := `
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "test"
+  namespace: "test"
+spec:
+  bindingRules:
+    justfortest: "true"
+  sourceFiles:
+    - fileName: GenericSecret.yaml
+      policyName: "gen-policy"
+      stringData:
+        stringkey: stringvalue
+`
+	// Read in the test PGT
+	pgt := utils.PolicyGenTemplate{}
+	_ = yaml.Unmarshal([]byte(input), &pgt)
+
+	// Set up the files handler to pick up local source-crs and skip any output
+	fHandler := utils.NewFilesHandler("./testData/GenericSourceFiles", "/dev/null", "/dev/null")
+
+	// Run the PGT through the generator
+	pBuilder := NewPolicyBuilder(fHandler)
+	policies, err := pBuilder.Build(pgt)
+
+	// Validate the run
+	assert.Nil(t, err)
+	assert.NotNil(t, policies)
+
+	assert.Contains(t, policies, "test/test-gen-policy")
+	assert.IsType(t, utils.AcmPolicy{}, policies["test/test-gen-policy"])
+	policy := policies["test/test-gen-policy"].(utils.AcmPolicy)
+	assert.Contains(t, policy.Spec.PolicyTemplates[0].ObjDef.Spec.ObjectTemplates[0].ObjectDefinition, "stringData")
+	assert.IsType(t, map[string]interface{}{}, policy.Spec.PolicyTemplates[0].ObjDef.Spec.ObjectTemplates[0].ObjectDefinition["stringData"])
+	stringData := policy.Spec.PolicyTemplates[0].ObjDef.Spec.ObjectTemplates[0].ObjectDefinition["stringData"].(map[string]interface{})
+	assert.Contains(t, stringData, "stringkey")
+	assert.Equal(t, "stringvalue", stringData["stringkey"])
+}

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericSecret.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericSecret.yaml
@@ -3,4 +3,3 @@ kind: Secret
 metadata:
   name: test
   namespace: test
-  

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericSecret.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericSecret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test
+  namespace: test
+  

--- a/ztp/policygenerator/utils/utils.go
+++ b/ztp/policygenerator/utils/utils.go
@@ -77,6 +77,7 @@ type SourceFile struct {
 	Data               map[string]interface{} `yaml:"data,omitempty"`
 	Status             map[string]interface{} `yaml:"status,omitempty"`
 	BinaryData         map[string]interface{} `yaml:"binaryData,omitempty"`
+	StringData         map[string]interface{} `yaml:"stringData,omitempty"`
 	EvaluationInterval EvaluationInterval     `yaml:"evaluationInterval,omitempty"`
 }
 


### PR DESCRIPTION
The purpose of this contribution is to implement the support of patching the stringData field in Secret source files via the PGT. 

It can be beneficial in the cases when the value of a secret is used to deliver a configuration file to the target application, and some parameters in the file should be collected from other secrets with the "fromSecret" template function.

Example:
The Secret definition in the policy should look like:

```yaml
kind: Secret
apiVersion: v1
metadata:
  name: name
  namespace: namespace
stringData:
  mySecretFile.yaml: |
    username: {{hub fromSecret "ns" "secretname" "username" | base64dec hub}}
    password: {{hub fromSecret "ns" "secretname" "password" | base64dec hub}}
    host: https://github.com
    port: 3445
```

    