### PR TITLE
Allow source files without metadata

### DIFF
--- a/ztp/policygenerator/policyGen/policyBuilder.go
+++ b/ztp/policygenerator/policyGen/policyBuilder.go
@@ -241,6 +241,14 @@ func (pbuilder *PolicyBuilder) getCustomResource(sourceFile utils.SourceFile, so
 	if err != nil {
 		return resourceMap, err
 	}
+	if sourceFile.Metadata.Name != "" ||
+		sourceFile.Metadata.Namespace != "" ||
+		len(sourceFile.Metadata.Labels) != 0 ||
+		len(sourceFile.Metadata.Annotations) != 0 {
+		if _, exists := resourceMap["metadata"]; !exists {
+			resourceMap["metadata"] = make(map[string]interface{})
+		}
+	}
 	if sourceFile.Metadata.Name != "" {
 		resourceMap["metadata"].(map[string]interface{})["name"] = sourceFile.Metadata.Name
 	}

--- a/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericWithoutMetadata.yaml
+++ b/ztp/policygenerator/policyGen/testData/GenericSourceFiles/GenericWithoutMetadata.yaml
@@ -1,0 +1,2 @@
+kind: ConfigMap
+apiVersion: v1


### PR DESCRIPTION
Sometimes we would like to fill the metadata of a resource from a PGT patch. For example, when the PGT is constructed with an "overlay"  template and the metadata of a resource should come from the input values of the overlay template. In such cases the creation of the metadata in the source file with some placeholder values should not be necessary.

Moreover, if someone does not define metadata for the resource in the source file and then in the PGT they define metadata fields the current implementation panics, as the code accesses resourceMap["metadata"] without any check for the existence of the metadata field. A panic should not occur.

This is a proposal here to implement a solution that avoids the panic and that enables the creation of the metadata from the PGT.