### PR TITLE
infra: update `cluster-node-tuning` ref to `main`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export SKIP_TESTS?=
 export FOCUS_TESTS?=
 export METALLB_OPERATOR_TARGET_COMMIT?=main
 export SRIOV_NETWORK_OPERATOR_TARGET_COMMIT?=main
-export CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT?=master
+export CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT?=main
 IMAGE_BUILD_CMD ?= "docker"
 
 # The environment represents the kustomize patches to apply when deploying the features

--- a/cnf-tests/README.md
+++ b/cnf-tests/README.md
@@ -22,8 +22,8 @@ To specify the desired commit of the external repositories, we expose the follow
 
 ```
 export METALLB_OPERATOR_TARGET_COMMIT?=main
-export SRIOV_NETWORK_OPERATOR_TARGET_COMMIT?=master
-export CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT?=master
+export SRIOV_NETWORK_OPERATOR_TARGET_COMMIT?=main
+export CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT?=main
 ```
 
 And to set all three of them to a specfic release, use `TARGET_RELEASE`.


### PR DESCRIPTION
Job `periodic-ci-openshift-release-master-nightly-4.19-e2e-telco5g-cnftests` is failing [1] with the error:

```
+ cd ../cluster-node-tuning-operator/
+ git fetch --all
+ git checkout origin/master
error: pathspec 'origin/master' did not match any file(s) known to git
make: *** [Makefile:143: init-git-submodules] Error 1
```

Update the default reference for cluster-node-tuning submodule from `master` to `main`.

[1] https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.19-e2e-telco5g-cnftests/1902421134243008512

cc @shajmakh , @Tal-or 