### PR TITLE
cnf-tests: pointer deprecation: use 'ptr' instead

### DIFF
--- a/cnf-tests/testsuites/e2esuite/multinetworkpolicy/reachmatcher.go
+++ b/cnf-tests/testsuites/e2esuite/multinetworkpolicy/reachmatcher.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/pods"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const ipTablesDebugContainerName = "debug-iptable-container"
@@ -62,7 +62,7 @@ func AddIPTableDebugContainer(pod *corev1.Pod) *corev1.Pod {
 		Name:            ipTablesDebugContainerName,
 		Image:           images.For(images.TestUtils),
 		Command:         []string{"sh", "-c", "while true; do iptables -L -v -n; sleep 10; done"},
-		SecurityContext: &corev1.SecurityContext{Privileged: pointer.BoolPtr(true)}})
+		SecurityContext: &corev1.SecurityContext{Privileged: ptr.To(true)}})
 
 	return pod
 }

--- a/cnf-tests/testsuites/e2esuite/sctp/sctp.go
+++ b/cnf-tests/testsuites/e2esuite/sctp/sctp.go
@@ -27,7 +27,7 @@ import (
 	utilNodes "github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/nodes"
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/testsuites/pkg/pods"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const mcYaml = "../sctp/sctp_module_mc.yaml"
@@ -486,7 +486,7 @@ func setupIngress(namespace, fromPod, toPod string, port int32) error {
 					},
 					Ports: []networkv1.NetworkPolicyPort{
 						{
-							Protocol: (*corev1.Protocol)(pointer.StringPtr(string(corev1.ProtocolSCTP))),
+							Protocol: (*corev1.Protocol)(ptr.To(string(corev1.ProtocolSCTP))),
 							Port: &intstr.IntOrString{
 								Type:   intstr.Int,
 								IntVal: port,
@@ -527,7 +527,7 @@ func setupEgress(namespace, fromPod, toPod string, port int32) error {
 					},
 					Ports: []networkv1.NetworkPolicyPort{
 						{
-							Protocol: (*corev1.Protocol)(pointer.StringPtr(string(corev1.ProtocolSCTP))),
+							Protocol: (*corev1.Protocol)(ptr.To(string(corev1.ProtocolSCTP))),
 							Port: &intstr.IntOrString{
 								Type:   intstr.Int,
 								IntVal: port,

--- a/cnf-tests/testsuites/pkg/pods/pods.go
+++ b/cnf-tests/testsuites/pkg/pods/pods.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -133,14 +132,14 @@ func RedefineWithRestrictedPrivileges(pod *corev1.Pod) *corev1.Pod {
 		FSGroup:        ptr.To[int64](1001),
 	}
 	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].SecurityContext.RunAsNonRoot = pointer.BoolPtr(true)
+		pod.Spec.Containers[i].SecurityContext.RunAsNonRoot = ptr.To(true)
 		pod.Spec.Containers[i].SecurityContext.RunAsUser = ptr.To[int64](1001)
 		pod.Spec.Containers[i].SecurityContext.RunAsGroup = ptr.To[int64](1001)
-		pod.Spec.Containers[i].SecurityContext.Privileged = pointer.BoolPtr(false)
+		pod.Spec.Containers[i].SecurityContext.Privileged = ptr.To(false)
 		pod.Spec.Containers[i].SecurityContext.Capabilities.Drop = []corev1.Capability{"ALL"}
 
 		// Capabilities in binaries do not work if below is set to false.
-		pod.Spec.Containers[i].SecurityContext.AllowPrivilegeEscalation = pointer.BoolPtr(true)
+		pod.Spec.Containers[i].SecurityContext.AllowPrivilegeEscalation = ptr.To(true)
 	}
 
 	return pod
@@ -155,7 +154,7 @@ func RedefineAsPrivileged(pod *corev1.Pod, containerName string) (*corev1.Pod, e
 	if c.SecurityContext == nil {
 		c.SecurityContext = &corev1.SecurityContext{}
 	}
-	c.SecurityContext.Privileged = pointer.BoolPtr(true)
+	c.SecurityContext.Privileged = ptr.To(true)
 
 	return pod, nil
 }


### PR DESCRIPTION
https://pkg.go.dev/k8s.io/utils/pointer has been deprecated in favor of `k8s.io/utils/ptr`.