### PR TITLE
CNF-13139: ztp: Add hardwareTuning to PerformanceProfile

### DIFF
--- a/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
+++ b/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
@@ -22,6 +22,10 @@ spec:
   cpu:
     isolated: {{ .spec.cpu.isolated }}
     reserved: {{ .spec.cpu.reserved }}
+  # hardwareTuning allows maximum CPU frequencies to be set for reserved and isolated CPUs
+  #hardwareTuning:
+  #  isolatedCpuFreq: <max frequency in kHz>
+  #  reservedCpuFreq: <max frequency in kHz>
   {{- if .spec.hardwareTuning }}
   {{- /* Require both isolatedCpuFreq and reservedCpuFreq are set (if this section is present), but allow any value */}}
   hardwareTuning:

--- a/ztp/source-crs/PerformanceProfile-SetSelector.yaml
+++ b/ztp/source-crs/PerformanceProfile-SetSelector.yaml
@@ -19,6 +19,10 @@ spec:
   cpu:
 #    isolated: $isolated
 #    reserved: $reserved
+  # hardwareTuning allows maximum CPU frequencies to be set for reserved and isolated CPUs
+  #hardwareTuning:
+  #  isolatedCpuFreq: <max frequency in kHz>
+  #  reservedCpuFreq: <max frequency in kHz>
   hugepages:
 #    defaultHugepagesSize: $defaultHugepagesSize
     pages:

--- a/ztp/source-crs/PerformanceProfile.yaml
+++ b/ztp/source-crs/PerformanceProfile.yaml
@@ -19,6 +19,10 @@ spec:
   cpu:
     isolated: $isolated
     reserved: $reserved
+  # hardwareTuning allows maximum CPU frequencies to be set for reserved and isolated CPUs
+  #hardwareTuning:
+  #  isolatedCpuFreq: <max frequency in kHz>
+  #  reservedCpuFreq: <max frequency in kHz>
   hugepages:
     defaultHugepagesSize: $defaultHugepagesSize
     pages:


### PR DESCRIPTION
Add example hardwareTuning section to PerformanceProfile CR to show how isolated and reserved CPU frequencies can be configured.