### PR TITLE
cnf-tests: syscall deprecated; use sys/unix pkg

### DIFF
--- a/cnf-tests/pod-utils/cyclictest-runner/main.go
+++ b/cnf-tests/pod-utils/cyclictest-runner/main.go
@@ -3,13 +3,13 @@ package main
 import (
 	"flag"
 	"strconv"
-	"syscall"
 	"time"
 
 	"k8s.io/klog"
 	"k8s.io/utils/cpuset"
 
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/pod-utils/pkg/node"
+	"golang.org/x/sys/unix"
 )
 
 const cyclictestBinary = "/usr/bin/cyclictest"
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	klog.Infof("running cyclictest command with arguments %v", cyclictestArgs[1:])
-	err = syscall.Exec(cyclictestBinary, cyclictestArgs, []string{})
+	err = unix.Exec(cyclictestBinary, cyclictestArgs, []string{})
 	if err != nil {
 		klog.Fatalf("failed to run cyclictest command %v", err)
 	}

--- a/cnf-tests/pod-utils/hwlatdetect-runner/main.go
+++ b/cnf-tests/pod-utils/hwlatdetect-runner/main.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
-	"syscall"
 	"time"
 
+	"golang.org/x/sys/unix"
 	"k8s.io/klog"
 
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/pod-utils/pkg/node"
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	klog.Infof("running hwlatdetect command with arguments %v", hwlatdetectArgs[1:])
-	err = syscall.Exec(hwlatdetectBinary, hwlatdetectArgs, []string{})
+	err = unix.Exec(hwlatdetectBinary, hwlatdetectArgs, []string{})
 	if err != nil {
 		klog.Fatalf("failed to run hwlatdetect command %v", err)
 	}

--- a/cnf-tests/pod-utils/oslat-runner/main.go
+++ b/cnf-tests/pod-utils/oslat-runner/main.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"flag"
-	"syscall"
 	"time"
 
 	"k8s.io/klog"
 	"k8s.io/utils/cpuset"
 
 	"github.com/openshift-kni/cnf-features-deploy/cnf-tests/pod-utils/pkg/node"
+	"golang.org/x/sys/unix"
 )
 
 const oslatBinary = "/usr/bin/oslat"
@@ -71,7 +71,7 @@ func main() {
 	}
 
 	klog.Infof("running oslat command with arguments %v", oslatArgs[1:])
-	err = syscall.Exec(oslatBinary, oslatArgs, []string{})
+	err = unix.Exec(oslatBinary, oslatArgs, []string{})
 	if err != nil {
 		klog.Fatalf("failed to run oslat command %v", err)
 	}


### PR DESCRIPTION
[syscall](https://pkg.go.dev/syscall) has been previously marked as deprecated as of Go 1.11 (since un-deprecated) and new functionality has been moved/added into [golang.org/x/sys](https://pkg.go.dev/golang.org/x/sys).

This PR replaces the calls to `syscall` with corresponding calls to `sys/unix`.