### PR TITLE
OCPBUGS-54517: ztp: reference: Ensure PtpOperatorConfig apiVersion is a string, and transportHost is optional

### DIFF
--- a/ztp/kube-compare-reference/default_value.yaml
+++ b/ztp/kube-compare-reference/default_value.yaml
@@ -226,7 +226,6 @@ optional_ptp_config_PtpOperatorConfigForEvent:
       node-role.kubernetes.io/$mcp: ""
     ptpEventConfig:
       apiVersion: $event_api_version
-      transportHost: "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
 optional_sriov_fec_operator_AcceleratorsSubscription:
 - spec:
     source: certified-operators

--- a/ztp/kube-compare-reference/optional/ptp-config/PtpOperatorConfigForEvent.yaml
+++ b/ztp/kube-compare-reference/optional/ptp-config/PtpOperatorConfigForEvent.yaml
@@ -13,7 +13,9 @@ spec:
   ptpEventConfig:
     {{- if .spec.ptpEventConfig.apiVersion }}
     # example "2.0", default to "1.0" if not set
-    apiVersion: {{ .spec.ptpEventConfig.apiVersion }}
+    apiVersion: {{ .spec.ptpEventConfig.apiVersion | toYaml }}
     {{- end }}
     enableEventPublisher: true
-    transportHost: {{ .spec.ptpEventConfig.transportHost }}
+    {{- if and .spec.ptpEventConfig .spec.ptpEventConfig.transportHost }}
+    transportHost: {{ .spec.ptpEventConfig.transportHost | toYaml }}
+    {{- end }}

--- a/ztp/source-crs/PtpOperatorConfigForEvent.yaml
+++ b/ztp/source-crs/PtpOperatorConfigForEvent.yaml
@@ -12,4 +12,3 @@ spec:
     # example "2.0", default to "1.0" if not set
     apiVersion: $event_api_version
     enableEventPublisher: true
-    transportHost: http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
