### PR TITLE
ztp: Removing unnecessary lines into SriovOperatorConfigForSNO

### DIFF
--- a/ztp/source-crs/SriovOperatorConfigForSNO.yaml
+++ b/ztp/source-crs/SriovOperatorConfigForSNO.yaml
@@ -23,6 +23,3 @@ spec:
   #          openshift.io/<resource_name>:  "1"
   # Disable drain is needed for Single Node Openshift
   disableDrain: true
-  enableInjector: false
-  enableOperatorWebhook: false
-  logLevel: 0


### PR DESCRIPTION
Proposition to remove those lines in the SRIOV operator SNO config as it did create confusion, you can see the discussion here: https://issues.redhat.com/browse/OCPBUGS-53346 
Those fields are already set to those values by default