### PR TITLE
cnf-test: konflux-tekton: support trusted-artifacts pipelines

### DIFF
--- a/.tekton/cnf-tests-4-19-pull-request.yaml
+++ b/.tekton/cnf-tests-4-19-pull-request.yaml
@@ -6,6 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
@@ -26,6 +27,9 @@ spec:
       value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-19:on-pr-{{revision}}
     - name: image-expires-after
       value: 5d
+    - name: build-platforms
+      value:
+        - linux/x86_64
     - name: dockerfile
       value: cnf-tests/.konflux/Dockerfile
     - name: prefetch-input
@@ -34,10 +38,10 @@ spec:
       value: "true"
   pipelineSpec:
     description: |
-      This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
+      This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
 
-      _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) if any tasks are added to the pipeline.
-      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+      _Uses `buildah` to create a multi-platform container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. This pipeline requires that the [multi platform controller](https://github.com/konflux-ci/multi-platform-controller) is deployed and configured on your Konflux instance. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta?tab=tags)_
     finally:
       - name: show-sbom
         params:
@@ -52,28 +56,6 @@ spec:
             - name: kind
               value: task
           resolver: bundles
-      - name: show-summary
-        params:
-          - name: pipelinerun-name
-            value: $(context.pipelineRun.name)
-          - name: git-url
-            value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
-          - name: image-url
-            value: $(params.output-image)
-          - name: build-task-status
-            value: $(tasks.build-image-index.status)
-        taskRef:
-          params:
-            - name: name
-              value: summary
-            - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:870d9a04d9784840a90b7bf6817cd0d0c4edfcda04b1ba1868cae625a3c3bfcc
-            - name: kind
-              value: task
-          resolver: bundles
-        workspaces:
-          - name: workspace
-            workspace: workspace
     params:
       - description: Source Repository URL
         name: git-url
@@ -119,7 +101,7 @@ spec:
         description: Build a source image.
         name: build-source-image
         type: string
-      - default: "false"
+      - default: "true"
         description: Add built image into an OCI image index
         name: build-image-index
         type: string
@@ -131,6 +113,12 @@ spec:
         description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
         name: build-args-file
         type: string
+      - default:
+          - linux/x86_64
+        description: List of platforms to build the container images on. The available
+          set of values is determined by the configuration of the multi-platform-controller.
+        name: build-platforms
+        type: array
     results:
       - description: ""
         name: IMAGE_URL
@@ -158,7 +146,7 @@ spec:
             - name: name
               value: init
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:737682d073a65a486d59b2b30e3104b93edd8490e0cd5e9b4a39703e47363f0f
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:2f59e9a3c20ce4509356389d327087213cc82c079b30811935837791da140f9f
             - name: kind
               value: task
           resolver: bundles
@@ -168,14 +156,18 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
         runAfter:
           - init
         taskRef:
           params:
             - name: name
-              value: git-clone
+              value: git-clone-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:92cf275b60f7bd23472acc4bc6e9a4bc9a9cbd78a680a23087fa4df668b85a34
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:3e171c1f3a9487a5764ebef629f93b3d2fc01cc8bad382dd8065cdfe42214148
             - name: kind
               value: task
           resolver: bundles
@@ -185,8 +177,6 @@ spec:
             values:
               - "true"
         workspaces:
-          - name: output
-            workspace: workspace
           - name: basic-auth
             workspace: git-auth
       - name: prefetch-dependencies
@@ -195,30 +185,34 @@ spec:
             value: $(params.prefetch-input)
           - name: dev-package-managers
             value: "true"
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: ociStorage
+            value: $(params.output-image).prefetch
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
         runAfter:
           - clone-repository
         taskRef:
           params:
             - name: name
-              value: prefetch-dependencies
+              value: prefetch-dependencies-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.2@sha256:6a4e6606ac3fa18ca6980f87a135526042833d4b7aaec2e1723272aa70a1d4c1
+              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:8398b3332f911b5b5244f8429adae4ec2982e7fb7ab8eecdc4e05a9fb05f60fd
             - name: kind
               value: task
           resolver: bundles
-        when:
-          - input: $(params.prefetch-input)
-            operator: notin
-            values:
-              - ""
         workspaces:
-          - name: source
-            workspace: workspace
           - name: git-basic-auth
             workspace: git-auth
           - name: netrc
             workspace: netrc
-      - name: build-container
+      - matrix:
+          params:
+            - name: PLATFORM
+              value:
+                - $(params.build-platforms)
+        name: build-images
         params:
           - name: IMAGE
             value: $(params.output-image)
@@ -239,14 +233,20 @@ spec:
               - $(params.build-args[*])
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: IMAGE_APPEND_PLATFORM
+            value: "true"
         runAfter:
           - prefetch-dependencies
         taskRef:
           params:
             - name: name
-              value: buildah
+              value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.4@sha256:c84e35a51c847af65e20e3c5c5b364d7e8ef03be8057a8a02fc2a1f6e86cfaf5
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:93f3e1ee128a56874a9e093a9e46a58639c10b8a86bae4c10363393045e3f76a
             - name: kind
               value: task
           resolver: bundles
@@ -255,9 +255,6 @@ spec:
             operator: in
             values:
               - "true"
-        workspaces:
-          - name: source
-            workspace: workspace
       - name: build-image-index
         params:
           - name: IMAGE
@@ -270,15 +267,15 @@ spec:
             value: $(params.build-image-index)
           - name: IMAGES
             value:
-              - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+              - $(tasks.build-images.results.IMAGE_REF[*])
         runAfter:
-          - build-container
+          - build-images
         taskRef:
           params:
             - name: name
               value: build-image-index
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:95be274b6d0432d4671e2c41294ec345121bdf01284b1c6c46b5537dc6b37e15
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:d34e4245b767c5b1b5edbbad9fc9cf8050cf19a69c8e55856479848405c596ec
             - name: kind
               value: task
           resolver: bundles
@@ -291,14 +288,18 @@ spec:
         params:
           - name: BINARY_IMAGE
             value: $(params.output-image)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - build-image-index
         taskRef:
           params:
             - name: name
-              value: source-build
+              value: source-build-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.2@sha256:e8c321b8a67e421a9c3975fd9a938ca4e838976064e14c7c0eb4e1f261900b1c
+              value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:66401e328c0036012112caad2ba02617954330689c9c590e9f53cad0256bb5ec
             - name: kind
               value: task
           resolver: bundles
@@ -311,9 +312,6 @@ spec:
             operator: in
             values:
               - "true"
-        workspaces:
-          - name: workspace
-            workspace: workspace
       - name: deprecated-base-image-check
         params:
           - name: IMAGE_URL
@@ -349,7 +347,7 @@ spec:
             - name: name
               value: clair-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:712afcf63f3b5a97c371d37e637efbcc9e1c7ad158872339d00adc6413cd8851
+              value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:03383b5a8674edef0ae184dd81f00386017624a5af255cb0b5803d7659483ba5
             - name: kind
               value: task
           resolver: bundles
@@ -384,14 +382,18 @@ spec:
             value: $(tasks.build-image-index.results.IMAGE_DIGEST)
           - name: image-url
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - build-image-index
         taskRef:
           params:
             - name: name
-              value: sast-snyk-check
+              value: sast-snyk-check-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.3@sha256:e0c1675c9813618910115f04fd6b3a9ff32d1bd4e2b9c975f1112aa1eae0d149
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:ba2c9c37a287a8220d8810c31211fc7c33f9b1576bcf5cacf2f050824624c9fd
             - name: kind
               value: task
           resolver: bundles
@@ -400,9 +402,6 @@ spec:
             operator: in
             values:
               - "false"
-        workspaces:
-          - name: workspace
-            workspace: workspace
       - name: clamav-scan
         params:
           - name: image-digest
@@ -416,7 +415,7 @@ spec:
             - name: name
               value: clamav-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:62c835adae22e36fce6684460b39206bc16752f1a4427cdbba4ee9afdd279670
+              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:c30c12681b02eb4b83aeb4021d0e714a72db4d1d3bb14579652f4d1a763473ab
             - name: kind
               value: task
           resolver: bundles
@@ -448,14 +447,18 @@ spec:
               - $(params.build-args[*])
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - coverity-availability-check
         taskRef:
           params:
             - name: name
-              value: sast-coverity-check
+              value: sast-coverity-check-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check:0.2@sha256:55e4c13c195034a3c86cb536de2500f8d2faedb907adf5065a772ced2b7cad45
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:b874e49385d8bdc27dfe273a4ec466f8b2a5b0076c64cef5e86b29ee7ca7c6f2
             - name: kind
               value: task
           resolver: bundles
@@ -468,9 +471,6 @@ spec:
             operator: in
             values:
               - success
-        workspaces:
-          - name: source
-            workspace: workspace
       - name: coverity-availability-check
         runAfter:
           - build-image-index
@@ -494,14 +494,18 @@ spec:
             value: $(tasks.build-image-index.results.IMAGE_DIGEST)
           - name: image-url
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - build-image-index
         taskRef:
           params:
             - name: name
-              value: sast-shell-check
+              value: sast-shell-check-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check:0.1@sha256:1b3d68c33a92dfc3da3975581cae80c99c8d1995cab519ae98c6331b5677ded0
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:371ba9d9f08c55c58e0c76d696644557b92ebff4c8f71facca3a81e0b92bb4f4
             - name: kind
               value: task
           resolver: bundles
@@ -510,21 +514,22 @@ spec:
             operator: in
             values:
               - "false"
-        workspaces:
-          - name: workspace
-            workspace: workspace
       - name: sast-unicode-check
         params:
           - name: image-url
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - build-image-index
         taskRef:
           params:
             - name: name
-              value: sast-unicode-check
+              value: sast-unicode-check-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check:0.1@sha256:b1a9af196a79baa75632ef494eb6db987f57e870d882d47f5b495e1441c01e3b
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.1@sha256:7ff6753af9bc30b1f1ae982abe174ee50d2467e3e33a8618fd858c64dea6167b
             - name: kind
               value: task
           resolver: bundles
@@ -533,9 +538,6 @@ spec:
             operator: in
             values:
               - "false"
-        workspaces:
-          - name: workspace
-            workspace: workspace
       - name: apply-tags
         params:
           - name: IMAGE
@@ -547,7 +549,7 @@ spec:
             - name: name
               value: apply-tags
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:61c90b1c94a2a11cb11211a0d65884089b758c34254fcec164d185a402beae22
+              value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:e1d365ce85d6448f6ebd0d0a000d0f45b694950b7545a2c34bfbcf992c80df61
             - name: kind
               value: task
           resolver: bundles
@@ -561,20 +563,19 @@ spec:
             value: $(params.dockerfile)
           - name: CONTEXT
             value: $(params.path-context)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         runAfter:
           - build-image-index
         taskRef:
           params:
             - name: name
-              value: push-dockerfile
+              value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:734dfcd63cc6f28ad022294497906bc6639926d8208cccd83f772690e3951050
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:7647ce9715c23e78a33663b88febe37279099c03f5a96191d0ce1aa4bfc9aa7b
             - name: kind
               value: task
           resolver: bundles
-        workspaces:
-          - name: workspace
-            workspace: workspace
       - name: rpms-signature-scan
         params:
           - name: image-url
@@ -588,7 +589,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7b80f5a319d4ff1817fa097cbdbb9473635562f8ea3022e64933e387d3b68715
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:d00d159c370e3c99447516970c316ef57dfd27c29e0ce3cff50727c9c40936d8
             - name: kind
               value: task
           resolver: bundles
@@ -598,24 +599,12 @@ spec:
             values:
               - "false"
     workspaces:
-      - name: workspace
       - name: git-auth
         optional: true
       - name: netrc
         optional: true
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'

--- a/.tekton/cnf-tests-4-19-push.yaml
+++ b/.tekton/cnf-tests-4-19-push.yaml
@@ -5,6 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/openshift-kni/cnf-features-deploy?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
@@ -23,6 +24,10 @@ spec:
       value: '{{revision}}'
     - name: output-image
       value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-19:{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
+        - linux/arm64
     - name: dockerfile
       value: cnf-tests/.konflux/Dockerfile
     - name: prefetch-input
@@ -31,10 +36,10 @@ spec:
       value: "true"
   pipelineSpec:
     description: |
-      This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
+      This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
 
-      _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) if any tasks are added to the pipeline.
-      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+      _Uses `buildah` to create a multi-platform container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. This pipeline requires that the [multi platform controller](https://github.com/konflux-ci/multi-platform-controller) is deployed and configured on your Konflux instance. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta?tab=tags)_
     finally:
       - name: show-sbom
         params:
@@ -49,28 +54,6 @@ spec:
             - name: kind
               value: task
           resolver: bundles
-      - name: show-summary
-        params:
-          - name: pipelinerun-name
-            value: $(context.pipelineRun.name)
-          - name: git-url
-            value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
-          - name: image-url
-            value: $(params.output-image)
-          - name: build-task-status
-            value: $(tasks.build-image-index.status)
-        taskRef:
-          params:
-            - name: name
-              value: summary
-            - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:870d9a04d9784840a90b7bf6817cd0d0c4edfcda04b1ba1868cae625a3c3bfcc
-            - name: kind
-              value: task
-          resolver: bundles
-        workspaces:
-          - name: workspace
-            workspace: workspace
     params:
       - description: Source Repository URL
         name: git-url
@@ -116,7 +99,7 @@ spec:
         description: Build a source image.
         name: build-source-image
         type: string
-      - default: "false"
+      - default: "true"
         description: Add built image into an OCI image index
         name: build-image-index
         type: string
@@ -128,6 +111,13 @@ spec:
         description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
         name: build-args-file
         type: string
+      - default:
+          - linux/x86_64
+          - linux/arm64
+        description: List of platforms to build the container images on. The available
+          set of values is determined by the configuration of the multi-platform-controller.
+        name: build-platforms
+        type: array
     results:
       - description: ""
         name: IMAGE_URL
@@ -155,7 +145,7 @@ spec:
             - name: name
               value: init
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:737682d073a65a486d59b2b30e3104b93edd8490e0cd5e9b4a39703e47363f0f
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:2f59e9a3c20ce4509356389d327087213cc82c079b30811935837791da140f9f
             - name: kind
               value: task
           resolver: bundles
@@ -165,14 +155,18 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
         runAfter:
           - init
         taskRef:
           params:
             - name: name
-              value: git-clone
+              value: git-clone-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:92cf275b60f7bd23472acc4bc6e9a4bc9a9cbd78a680a23087fa4df668b85a34
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:3e171c1f3a9487a5764ebef629f93b3d2fc01cc8bad382dd8065cdfe42214148
             - name: kind
               value: task
           resolver: bundles
@@ -182,8 +176,6 @@ spec:
             values:
               - "true"
         workspaces:
-          - name: output
-            workspace: workspace
           - name: basic-auth
             workspace: git-auth
       - name: prefetch-dependencies
@@ -192,30 +184,34 @@ spec:
             value: $(params.prefetch-input)
           - name: dev-package-managers
             value: "true"
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: ociStorage
+            value: $(params.output-image).prefetch
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
         runAfter:
           - clone-repository
         taskRef:
           params:
             - name: name
-              value: prefetch-dependencies
+              value: prefetch-dependencies-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.2@sha256:6a4e6606ac3fa18ca6980f87a135526042833d4b7aaec2e1723272aa70a1d4c1
+              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:8398b3332f911b5b5244f8429adae4ec2982e7fb7ab8eecdc4e05a9fb05f60fd
             - name: kind
               value: task
           resolver: bundles
-        when:
-          - input: $(params.prefetch-input)
-            operator: notin
-            values:
-              - ""
         workspaces:
-          - name: source
-            workspace: workspace
           - name: git-basic-auth
             workspace: git-auth
           - name: netrc
             workspace: netrc
-      - name: build-container
+      - matrix:
+          params:
+            - name: PLATFORM
+              value:
+                - $(params.build-platforms)
+        name: build-images
         params:
           - name: IMAGE
             value: $(params.output-image)
@@ -236,14 +232,20 @@ spec:
               - $(params.build-args[*])
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: IMAGE_APPEND_PLATFORM
+            value: "true"
         runAfter:
           - prefetch-dependencies
         taskRef:
           params:
             - name: name
-              value: buildah
+              value: buildah-remote-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.4@sha256:c84e35a51c847af65e20e3c5c5b364d7e8ef03be8057a8a02fc2a1f6e86cfaf5
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:93f3e1ee128a56874a9e093a9e46a58639c10b8a86bae4c10363393045e3f76a
             - name: kind
               value: task
           resolver: bundles
@@ -252,9 +254,6 @@ spec:
             operator: in
             values:
               - "true"
-        workspaces:
-          - name: source
-            workspace: workspace
       - name: build-image-index
         params:
           - name: IMAGE
@@ -267,15 +266,15 @@ spec:
             value: $(params.build-image-index)
           - name: IMAGES
             value:
-              - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+              - $(tasks.build-images.results.IMAGE_REF[*])
         runAfter:
-          - build-container
+          - build-images
         taskRef:
           params:
             - name: name
               value: build-image-index
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:95be274b6d0432d4671e2c41294ec345121bdf01284b1c6c46b5537dc6b37e15
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:d34e4245b767c5b1b5edbbad9fc9cf8050cf19a69c8e55856479848405c596ec
             - name: kind
               value: task
           resolver: bundles
@@ -288,14 +287,18 @@ spec:
         params:
           - name: BINARY_IMAGE
             value: $(params.output-image)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - build-image-index
         taskRef:
           params:
             - name: name
-              value: source-build
+              value: source-build-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.2@sha256:e8c321b8a67e421a9c3975fd9a938ca4e838976064e14c7c0eb4e1f261900b1c
+              value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:66401e328c0036012112caad2ba02617954330689c9c590e9f53cad0256bb5ec
             - name: kind
               value: task
           resolver: bundles
@@ -308,9 +311,6 @@ spec:
             operator: in
             values:
               - "true"
-        workspaces:
-          - name: workspace
-            workspace: workspace
       - name: deprecated-base-image-check
         params:
           - name: IMAGE_URL
@@ -346,7 +346,7 @@ spec:
             - name: name
               value: clair-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:712afcf63f3b5a97c371d37e637efbcc9e1c7ad158872339d00adc6413cd8851
+              value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:03383b5a8674edef0ae184dd81f00386017624a5af255cb0b5803d7659483ba5
             - name: kind
               value: task
           resolver: bundles
@@ -381,14 +381,18 @@ spec:
             value: $(tasks.build-image-index.results.IMAGE_DIGEST)
           - name: image-url
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - build-image-index
         taskRef:
           params:
             - name: name
-              value: sast-snyk-check
+              value: sast-snyk-check-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.3@sha256:e0c1675c9813618910115f04fd6b3a9ff32d1bd4e2b9c975f1112aa1eae0d149
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:ba2c9c37a287a8220d8810c31211fc7c33f9b1576bcf5cacf2f050824624c9fd
             - name: kind
               value: task
           resolver: bundles
@@ -397,9 +401,6 @@ spec:
             operator: in
             values:
               - "false"
-        workspaces:
-          - name: workspace
-            workspace: workspace
       - name: clamav-scan
         params:
           - name: image-digest
@@ -413,7 +414,7 @@ spec:
             - name: name
               value: clamav-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:62c835adae22e36fce6684460b39206bc16752f1a4427cdbba4ee9afdd279670
+              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:c30c12681b02eb4b83aeb4021d0e714a72db4d1d3bb14579652f4d1a763473ab
             - name: kind
               value: task
           resolver: bundles
@@ -445,14 +446,18 @@ spec:
               - $(params.build-args[*])
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - coverity-availability-check
         taskRef:
           params:
             - name: name
-              value: sast-coverity-check
+              value: sast-coverity-check-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check:0.2@sha256:55e4c13c195034a3c86cb536de2500f8d2faedb907adf5065a772ced2b7cad45
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:b874e49385d8bdc27dfe273a4ec466f8b2a5b0076c64cef5e86b29ee7ca7c6f2
             - name: kind
               value: task
           resolver: bundles
@@ -465,9 +470,6 @@ spec:
             operator: in
             values:
               - success
-        workspaces:
-          - name: source
-            workspace: workspace
       - name: coverity-availability-check
         runAfter:
           - build-image-index
@@ -491,14 +493,18 @@ spec:
             value: $(tasks.build-image-index.results.IMAGE_DIGEST)
           - name: image-url
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - build-image-index
         taskRef:
           params:
             - name: name
-              value: sast-shell-check
+              value: sast-shell-check-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check:0.1@sha256:1b3d68c33a92dfc3da3975581cae80c99c8d1995cab519ae98c6331b5677ded0
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:371ba9d9f08c55c58e0c76d696644557b92ebff4c8f71facca3a81e0b92bb4f4
             - name: kind
               value: task
           resolver: bundles
@@ -507,21 +513,22 @@ spec:
             operator: in
             values:
               - "false"
-        workspaces:
-          - name: workspace
-            workspace: workspace
       - name: sast-unicode-check
         params:
           - name: image-url
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - build-image-index
         taskRef:
           params:
             - name: name
-              value: sast-unicode-check
+              value: sast-unicode-check-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check:0.1@sha256:b1a9af196a79baa75632ef494eb6db987f57e870d882d47f5b495e1441c01e3b
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.1@sha256:7ff6753af9bc30b1f1ae982abe174ee50d2467e3e33a8618fd858c64dea6167b
             - name: kind
               value: task
           resolver: bundles
@@ -530,9 +537,6 @@ spec:
             operator: in
             values:
               - "false"
-        workspaces:
-          - name: workspace
-            workspace: workspace
       - name: apply-tags
         params:
           - name: IMAGE
@@ -544,7 +548,7 @@ spec:
             - name: name
               value: apply-tags
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:61c90b1c94a2a11cb11211a0d65884089b758c34254fcec164d185a402beae22
+              value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:e1d365ce85d6448f6ebd0d0a000d0f45b694950b7545a2c34bfbcf992c80df61
             - name: kind
               value: task
           resolver: bundles
@@ -558,20 +562,19 @@ spec:
             value: $(params.dockerfile)
           - name: CONTEXT
             value: $(params.path-context)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         runAfter:
           - build-image-index
         taskRef:
           params:
             - name: name
-              value: push-dockerfile
+              value: push-dockerfile-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:734dfcd63cc6f28ad022294497906bc6639926d8208cccd83f772690e3951050
+              value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:7647ce9715c23e78a33663b88febe37279099c03f5a96191d0ce1aa4bfc9aa7b
             - name: kind
               value: task
           resolver: bundles
-        workspaces:
-          - name: workspace
-            workspace: workspace
       - name: rpms-signature-scan
         params:
           - name: image-url
@@ -585,7 +588,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7b80f5a319d4ff1817fa097cbdbb9473635562f8ea3022e64933e387d3b68715
+              value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:d00d159c370e3c99447516970c316ef57dfd27c29e0ce3cff50727c9c40936d8
             - name: kind
               value: task
           resolver: bundles
@@ -595,24 +598,12 @@ spec:
             values:
               - "false"
     workspaces:
-      - name: workspace
       - name: git-auth
         optional: true
       - name: netrc
         optional: true
   taskRunTemplate: {}
   workspaces:
-    - name: workspace
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
As per konflux recomendations use TA pipelines for more secure data sharing:
https://konflux.pages.redhat.com/docs/users/building/using-trusted-artifacts.html#migrate-to-trusted-artifacts