### PR TITLE
CNF-23433: ztp: simplify test-generator.sh script

### DIFF
--- a/ztp/resource-generator/tests/test-generator.sh
+++ b/ztp/resource-generator/tests/test-generator.sh
@@ -1,17 +1,31 @@
-#!/bin/bash
+#!/usr/bin/env bash
+IFS=$'\n\t'
 
 test_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 SRC="${test_script_dir}/../entrypoints"
-source ${SRC}/generator 2>/dev/null
 
-function pass() {
-    echo "PASS - $1"
-}
+# ensure generator is present
+if [[ ! -f "${SRC}/generator" ]]; then
+  echo "ERROR: generator script not found at ${SRC}/generator"
+  exit 1
+fi
+# shellcheck source=../entrypoints/generator
+source "${SRC}/generator"
 
-function fail() {
-    echo "FAIL - $1"
-    exit 1
+function pass() { echo "PASS - $1"; }
+function fail() { echo "FAIL - $1"; exit 1; }
+
+# helper for running a command and matching its output
+check_output() {
+  local tc="$1"; shift
+  local expected="$1"; shift
+  local output
+  output=$("$@" 2>&1) || true
+  if [[ "${output}" =~ ${expected} ]]; then
+    pass "${tc}"
+  else
+    fail "${tc} | expected '${expected}', got '${output}'"
+  fi
 }
 
 # Set up mocks
@@ -23,70 +37,12 @@ export -f is_dir_mounted
 # Execute test cases
 echo "Running tests in ${BASH_SOURCE[0]}:"
 
-# install test cases
-MOUNT_DIR="$test_script_dir/testData/siteconfigs"
-tc="test_install_with_non_exist_option"
-result=$(run_siteconfigGen --test example-sno.yaml 2>&1)
-[[ $result =~ "unrecognized option" ]] && pass $tc || fail $tc
-
-tc="test_install_with_invalid_option_extra_manifest_only_value"
-result=$(run_siteconfigGen --extra-manifest-only=yes example-sno.yaml 2>&1)
-[[ $result =~ "Expected value is true or false" ]] && pass $tc || fail $tc
-
-tc="test_install_src_path_does_not_exist"
-result=$(run_siteconfigGen example.yaml 2>&1)
-[[ $result =~ "is not found" ]] && pass $tc || fail $tc
-
-tc="test_install_obsolute_src_path"
-result=$(run_siteconfigGen ${MOUNT_DIR}/example-sno.yaml 2>/dev/null)
-[[ $result =~ "Processing SiteConfigs: ${MOUNT_DIR}/example-sno.yaml" ]] && pass $tc || fail $tc
-
-tc="test_install_relative_src_path"
-result=$(run_siteconfigGen example-sno.yaml 2>/dev/null)
-[[ $result =~ "Processing SiteConfigs: ${MOUNT_DIR}/example-sno.yaml" ]] && pass $tc || fail $tc
-
-tc="test_install_src_path_is_dir"
-result=$(run_siteconfigGen . 2>/dev/null)
-[[ $result =~ "Processing SiteConfigs: ${MOUNT_DIR}/example-sno.yaml" ]] && pass $tc || fail $tc
-
-tc="test_install_dest_dir_not_given"
-result=$(run_siteconfigGen example-sno.yaml 2>/dev/null)
-[[ $result =~ "Generating installation CRs into ${MOUNT_DIR}/out/generated_installCRs" ]] && pass $tc || fail $tc
-
-tc="test_install_dest_dir_is_given"
-result=$(run_siteconfigGen example-sno.yaml outDir/ 2>/dev/null)
-[[ $result =~ "Generating installation CRs into ${MOUNT_DIR}/outDir" ]] && pass $tc || fail $tc
-
-# config test cases
 MOUNT_DIR="$test_script_dir/testData/policygentemplates"
-tc="test_config_with_non_exist_option"
-result=$(run_policyGen --test common-pgt.yaml 2>&1)
-[[ $result =~ "unrecognized option" ]] && pass $tc || fail $tc
-
-tc="test_config_with_invalid_option_not_wrap_in_policy_value"
-result=$(run_policyGen --not-wrap-in-policy=no common-pgt.yaml 2>&1)
-[[ $result =~ "Expected value is true or false" ]] && pass $tc || fail $tc
-
-tc="test_config_src_path_does_not_exist"
-result=$(run_policyGen pgt.yaml 2>&1)
-[[ $result =~ "is not found" ]] && pass $tc || fail $tc
-
-tc="test_config_obsolute_src_path"
-result=$(run_policyGen ${MOUNT_DIR}/common-pgt.yaml 2>/dev/null)
-[[ $result =~ "Processing PolicyGenTemplates: ${MOUNT_DIR}/common-pgt.yaml" ]] && pass $tc || fail $tc
-
-tc="test_config_relative_src_path"
-result=$(run_policyGen common-pgt.yaml 2>/dev/null)
-[[ $result =~ "Processing PolicyGenTemplates: ${MOUNT_DIR}/common-pgt.yaml" ]] && pass $tc || fail $tc
-
-tc="test_config_src_path_is_dir"
-result=$(run_policyGen . 2>/dev/null)
-[[ $result =~ "Processing PolicyGenTemplates: ${MOUNT_DIR}/common-pgt.yaml" ]] && pass $tc || fail $tc
-
-tc="test_config_dest_dir_not_given"
-result=$(run_policyGen common-pgt.yaml 2>/dev/null)
-[[ $result =~ "Generating configuration CRs into ${MOUNT_DIR}/out/generated_configCRs" ]] && pass $tc || fail $tc
-
-tc="test_config_dest_dir_is_given"
-result=$(run_policyGen common-pgt.yaml outDir/ 2>/dev/null)
-[[ $result =~ "Generating configuration CRs into ${MOUNT_DIR}/outDir" ]] && pass $tc || fail $tc
+check_output "test_config_with_non_exist_option" "unrecognized option" run_policyGen --test common-pgt.yaml
+check_output "test_config_with_invalid_option_not_wrap_in_policy_value" "Expected value is true or false" run_policyGen --not-wrap-in-policy=no common-pgt.yaml
+check_output "test_config_src_path_does_not_exist" "is not found" run_policyGen pgt.yaml
+check_output "test_config_obsolute_src_path" "Processing PolicyGenTemplates: ${MOUNT_DIR}/common-pgt.yaml" run_policyGen "${MOUNT_DIR}/common-pgt.yaml"
+check_output "test_config_relative_src_path" "Processing PolicyGenTemplates: ${MOUNT_DIR}/common-pgt.yaml" run_policyGen common-pgt.yaml
+check_output "test_config_src_path_is_dir"    "Processing PolicyGenTemplates: ${MOUNT_DIR}/common-pgt.yaml" run_policyGen .
+check_output "test_config_dest_dir_not_given" "Generating configuration CRs into ${MOUNT_DIR}/out/generated_configCRs" run_policyGen common-pgt.yaml
+check_output "test_config_dest_dir_is_given"  "Generating configuration CRs into ${MOUNT_DIR}/outDir" run_policyGen common-pgt.yaml outDir/


### PR DESCRIPTION
Refactor and cleanup of the test-generator.sh script because I saw there was some repeated code.

### Script improvements:
* Updated the script shebang to use `/usr/bin/env bash` and added stricter shell settings (`set -euo pipefail` and `IFS`) for improved error handling and script safety.
* Added a check to ensure the `generator` script exists before sourcing it, with a clear error message if not found.

### Test structure refactoring:
* Introduced a `check_output` helper function to streamline test output validation and reduce repetitive code. This function runs a command, captures its output, and checks it against an expected pattern.
* Replaced repetitive test case logic with calls to the `check_output` function, simplifying test case definitions for both `run_siteconfigGen` and `run_policyGen` commands.