### PR TITLE
cnf-tests: tekton: tag konflux images as latest

### DIFF
--- a/.tekton/cnf-tests-4-19-push.yaml
+++ b/.tekton/cnf-tests-4-19-push.yaml
@@ -40,6 +40,8 @@ spec:
         params:
           - name: IMAGE_URL
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: ADDITIONAL_TAGS
+            value: ["latest"]
         taskRef:
           params:
             - name: name


### PR DESCRIPTION
Use the latest tag to tag last produced image.