### PR TITLE
typos: Adjust various typos

### DIFF
--- a/cnf-tests/GATEKEEPER.md
+++ b/cnf-tests/GATEKEEPER.md
@@ -1,7 +1,7 @@
 # Gatekeeper testing
 
 This document describes how to test set up and test Gatekeeper manually.
-It describes how to install Gatekeeper using the [gatekeeper-operator](https://github.com/openshift/gatekeeper-operator), setting up some basic mutations and how to validatate the mutations are applied correctly.
+It describes how to install Gatekeeper using the [gatekeeper-operator](https://github.com/openshift/gatekeeper-operator), setting up some basic mutations and how to validate the mutations are applied correctly.
 
 ## Gatekeeper setup
 

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -52,7 +52,7 @@ COPY --from=builder $BUILDER_ZTP/tools/pgt2acmpg/kustomize /kustomize-pgt2acmpg
 USER 1001
 CMD entrypoints
 
-# Note: any edits made to this file MUST be manually synchronised with the midstream build configuration:
+# Note: any edits made to this file MUST be manually synchronized with the midstream build configuration:
 # - please choose appropriate branch:
 # https://gitlab.cee.redhat.com/cpaas-midstream/telco-5g-ran/ztp-site-generate/-/blob/rhaos-4.16-rhel-9/distgit/containers/ztp-site-generate/Dockerfile.in?ref_type=heads
 # - include cpaas owners as reviewers: @Nishant Parekh , @rauherna

--- a/ztp/resource-generator/README.md
+++ b/ztp/resource-generator/README.md
@@ -21,7 +21,7 @@ out/
 ```
 
 ## Automatic upstream container builds
-The Red Hat Prow infractructure automatically pushes the head of this
+The Red Hat Prow infrastructure automatically pushes the head of this
 master branch to quay.io/openshift-kni/ztp-site-generator:latest
 
 ## Custom builds

--- a/ztp/resource-generator/entrypoints/generator
+++ b/ztp/resource-generator/entrypoints/generator
@@ -43,7 +43,7 @@ Environment variables:
 
 The SRC_PATH and DEST_DIR are paths in the container and they should be container volumes mounted from the host for you to access the generated resources on the host.
 Both SRC_PATH and DEST_DIR can be relative path to MOUNT_DIR. The SRC_PATH can be a SiteConfig yaml or a directory which contains SiteConfig instances.
-The DEST_DIR should be a directory and if DEST_DIR is not sepecified, by default the generated resources will be outputted to \$MOUNT_DIR/out/generated_installCRs.
+The DEST_DIR should be a directory and if DEST_DIR is not specified, by default the generated resources will be outputted to \$MOUNT_DIR/out/generated_installCRs.
 
 Usage: ${PROG} ${SUB_COMMAND} SRC_PATH [DEST_DIR] [options]
 
@@ -102,7 +102,7 @@ Environment variables:
 
 The SRC_PATH and DEST_DIR are paths in the container and they should be container volumes mounted from the host for you to access the generated resources on the host.
 Both SRC_PATH and DEST_DIR can be relative path to MOUNT_DIR. The SRC_PATH can be a PolicyGenTemplate yaml or a directory which contains PolicyGenTemplate instances.
-The DEST_DIR should be a directory and if DEST_DIR is not sepecified, by default the generated resources will be outputted to \$MOUNT_DIR/out/generated_configCRs.
+The DEST_DIR should be a directory and if DEST_DIR is not specified, by default the generated resources will be outputted to \$MOUNT_DIR/out/generated_configCRs.
 
 Usage: ${PROG} ${SUB_COMMAND} SRC_PATH [DEST_DIR] [options]
 
@@ -305,7 +305,7 @@ function verify_arguments {
         destDir=$2
         if [[ ! $destDir = /* ]]; then
             # given DEST_DIR is a relative path to MOUNT_DIR,
-            # set the obsolute path of the given DEST_DIR
+            # set the absolute path of the given DEST_DIR
             destDir="${MOUNT_DIR}/${destDir}"
         fi
     fi

--- a/ztp/resource-generator/tests/test-generator.sh
+++ b/ztp/resource-generator/tests/test-generator.sh
@@ -37,7 +37,7 @@ tc="test_install_src_path_does_not_exist"
 result=$(run_siteconfigGen example.yaml 2>&1)
 [[ $result =~ "is not found" ]] && pass $tc || fail $tc
 
-tc="test_install_obsolute_src_path"
+tc="test_install_absolute_src_path"
 result=$(run_siteconfigGen ${MOUNT_DIR}/example-sno.yaml 2>/dev/null)
 [[ $result =~ "Processing SiteConfigs: ${MOUNT_DIR}/example-sno.yaml" ]] && pass $tc || fail $tc
 
@@ -71,7 +71,7 @@ tc="test_config_src_path_does_not_exist"
 result=$(run_policyGen pgt.yaml 2>&1)
 [[ $result =~ "is not found" ]] && pass $tc || fail $tc
 
-tc="test_config_obsolute_src_path"
+tc="test_config_absolute_src_path"
 result=$(run_policyGen ${MOUNT_DIR}/common-pgt.yaml 2>/dev/null)
 [[ $result =~ "Processing PolicyGenTemplates: ${MOUNT_DIR}/common-pgt.yaml" ]] && pass $tc || fail $tc
 

--- a/ztp/resource-generator/tools/patchImageReference.sh
+++ b/ztp/resource-generator/tools/patchImageReference.sh
@@ -2,7 +2,7 @@
 #
 # This script finds and replaces all references to our upstream container with whatever is provided on the commandline.
 #
-# This can be uaed for personal builds or downstream builds to ensure the contents of the container always point at the right container image
+# This can be used for personal builds or downstream builds to ensure the contents of the container always point at the right container image
 set -e
 
 BASEDIR=$1


### PR DESCRIPTION
Changes: 
* Corrected a typo in `cnf-tests/GATEKEEPER.md` ("validatate" → "validate").
* Fixed a typo in `ztp/resource-generator/README.md` ("infractructure" → "infrastructure").
* Updated a comment in `ztp/resource-generator/Containerfile` to fix a spelling error ("synchronised" → "synchronized").
* Corrected multiple typos in `ztp/resource-generator/entrypoints/generator` ("sepecified" → "specified", "obsolute" → "absolute"). [[1]](diffhunk://#diff-217e13accee6a0af8606fb5df27ec525b84ab8752681ec54ac8985f180cef217L46-R46) [[2]](diffhunk://#diff-217e13accee6a0af8606fb5df27ec525b84ab8752681ec54ac8985f180cef217L105-R105) [[3]](diffhunk://#diff-217e13accee6a0af8606fb5df27ec525b84ab8752681ec54ac8985f180cef217L308-R308)
* Fixed a typo in `ztp/resource-generator/tools/patchImageReference.sh` ("uaed" → "used").
* Renamed test cases in `ztp/resource-generator/tests/test-generator.sh` to fix a typo ("obsolute" → "absolute"). [[1]](diffhunk://#diff-9e35678a086bedc291e1c996fa862290ea2744d065e2fd78160e2d0a185a9283L40-R40) [[2]](diffhunk://#diff-9e35678a086bedc291e1c996fa862290ea2744d065e2fd78160e2d0a185a9283L74-R74)