### PR TITLE
infra: use multi-arch fedora

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,5 +1,5 @@
 # The fedora version used should provide the golang version that matches $GOVERSION
-FROM quay.io/fedora/fedora:41-x86_64
+FROM quay.io/fedora/fedora:41
 
 ENV GOPATH /go
 ENV GOBIN /go/bin


### PR DESCRIPTION
We want to support cnf-tests in aarch64 additionally to x86-x64, so far fedora specific x86-x64 was used. Use the multi arch tag to support building ARM images by openshift ci.

Quay image: https://quay.io/repository/fedora/fedora/manifest/sha256:811ab78abccb4376f4eb7d1c387165f5968a6cee0ed897800377fb79d210cf3c

The error we want to resolve:
```
Pulling image quay.io/fedora/fedora:41-x86_64 ...
Trying to pull quay.io/fedora/fedora:41-x86_64...
Getting image source signatures
Copying blob sha256:c47e6f71e1014f78efe620b6e419165ad1840d39e9bb6e69a2db43b0a5da4dd4
Copying config sha256:730f437472509e0d141824ba88a31f9d845a503a2d486f0a3e725c65a5993a7a
Writing manifest to image destination
WARNING: image platform (linux/amd64) does not match the expected
platform (linux/arm64)
```