### PR TITLE
fix ztp-site-generate push tekton file

### DIFF
--- a/.tekton/ztp-site-generate-4-19-push.yaml
+++ b/.tekton/ztp-site-generate-4-19-push.yaml
@@ -123,7 +123,7 @@ spec:
       description: Build a source image.
       name: build-source-image
       type: string
-    - default: "false"
+    - default: "true"
       description: Add built image into an OCI image index
       name: build-image-index
       type: string

--- a/.tekton/ztp-site-generate-4-19-push.yaml
+++ b/.tekton/ztp-site-generate-4-19-push.yaml
@@ -78,9 +78,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      workspaces:
-      - name: workspace
-        workspace: workspace
     params:
     - description: Source Repository URL
       name: git-url

--- a/.tekton/ztp-site-generate-4-19-push.yaml
+++ b/.tekton/ztp-site-generate-4-19-push.yaml
@@ -645,9 +645,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      workspaces:
-      - name: workspace
-        workspace: workspace
     - name: rpms-signature-scan
       params:
       - name: image-url


### PR DESCRIPTION
Minor bug fix in ztp-site-generate 'push' tekton file
PR removes some missed references to 'workspace' in the push job, which is breaking 'Trusted Artifacts' pipeline on pr merge