### PR TITLE
cnf-tests: konflux 4.15 onboarding

### DIFF
--- a/.tekton/cnf-tests-4-15-pull-request.yaml
+++ b/.tekton/cnf-tests-4-15-pull-request.yaml
@@ -1,0 +1,628 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift-kni/cnf-features-deploy?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression:  |
+      event == "pull_request" &&
+      target_branch == "release-4.15" &&
+      (".tekton/cnf-tests-4-15-pull-request.yaml".pathChanged() ||
+      "cnf-tests/***".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: cnf-tests-4-15
+    appstudio.openshift.io/component: cnf-tests-4-15
+    pipelines.appstudio.openshift.io/type: build
+  name: cnf-tests-4-15-on-pull-request
+  namespace: telco-5g-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-15:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: cnf-tests/.konflux/Dockerfile
+  - name: prefetch-input
+    value: '{"type": "rpm", "path": "cnf-tests/.konflux"}'
+  - name: hermetic
+    value: "true"
+  - name: build-source-image
+    value: "true"
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a multi-platform container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. This pipeline requires that the [multi platform controller](https://github.com/konflux-ci/multi-platform-controller) is deployed and configured on your Konflux instance. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta?tab=tags)_
+    finally:
+    - name: show-sbom
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      taskRef:
+        params:
+        - name: name
+          value: show-sbom
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:002f7c8c1d2f9e09904035da414aba1188ae091df0ea9532cd997be05e73d594
+        - name: kind
+          value: task
+        resolver: bundles
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Force rebuild image
+      name: rebuild
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "true"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    - default:
+      - linux/x86_64
+      description: List of platforms to build the container images on. The available
+        set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: image-url
+        value: $(params.output-image)
+      - name: rebuild
+        value: $(params.rebuild)
+      - name: skip-checks
+        value: $(params.skip-checks)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:7a24924417260b7094541caaedd2853dc8da08d4bb0968f710a400d3e8062063
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:8ecf57d5a6697ce709bee65b62781efe79a10b0c2b95e05576442b67fbd61744
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: dev-package-managers
+        value: "true"
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:3a1b3280d6300ebedb9923ddc441b91b6980512be5dae8da4b9d3be21feeb48e
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-remote-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:846e52e4a14da403fa0cbd0251eab8248ab9230372c96f0566068ed1ccac5c66
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-images.results.IMAGE_REF[*])
+      runAfter:
+      - build-images
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:56fa2cbfc04bad4765b7fe1fa8022587f4042d4e8533bb5f65311d46b43226ee
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:eb8136b543147b4a3e88ca3cc661ca6a11e303f35f0db44059f69151beea8496
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:7c73e2beca9b8306387efeaf775831440ec799b05a5f5c008a65bb941a1e91f6
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dea8d9b4bec3e99d612d799798acf132df48276164b5193ea68f9f3c25ae425b
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:89aead32dc21404e4e0913be9668bdd2eea795db3e4caa762fb619044e479cb8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:59094118aa07d5b0199565c4e0b2d0f4feb9a4741877c8716877572e2c4804f9
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:c8eb622d59019582f6f11ed656c0f04f388737f7dd6e47cd780ad0f34bb38bb2
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:8b58c4fae00c0dfe3937abfb8a9a61aa3c408cca4278b817db53d518428d944e
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:57b3262138eb06186ae7375f84ca53788bba2a66cfd03d39cb82c78df050aba5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:df185dbe4e2852668f9c46f938dd752e90ea9c79696363378435a6499596c319
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:3f89ba89cacf8547261b5ce064acce81bfe470c8ace127794d0e90aebc8c347d
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:278f84550844c1c050a65536799f4b54e7c203e0ac51393aa75379dd974c82e9
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7592da3c98a58a8990352e07272c28e7f9305395ee91ffc0dd7acdd32f0bc1e6
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cnf-tests-4-15
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/cnf-tests-4-15-push.yaml
+++ b/.tekton/cnf-tests-4-15-push.yaml
@@ -1,0 +1,627 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift-kni/cnf-features-deploy?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression:  |
+      event == "push" &&
+      target_branch == "release-4.15" &&
+      (".tekton/cnf-tests-4-15-push.yaml".pathChanged() ||
+      "cnf-tests/***".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: cnf-tests-4-15
+    appstudio.openshift.io/component: cnf-tests-4-15
+    pipelines.appstudio.openshift.io/type: build
+  name: cnf-tests-4-15-on-push
+  namespace: telco-5g-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-15:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: cnf-tests/.konflux/Dockerfile
+  - name: prefetch-input
+    value: '{"type": "rpm", "path": "cnf-tests/.konflux"}'
+  - name: hermetic
+    value: "true"
+  - name: build-source-image
+    value: "true"
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
+
+      _Uses `buildah` to create a multi-platform container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. This pipeline requires that the [multi platform controller](https://github.com/konflux-ci/multi-platform-controller) is deployed and configured on your Konflux instance. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta?tab=tags)_
+    finally:
+    - name: show-sbom
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value: ["latest"]
+      taskRef:
+        params:
+        - name: name
+          value: show-sbom
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:002f7c8c1d2f9e09904035da414aba1188ae091df0ea9532cd997be05e73d594
+        - name: kind
+          value: task
+        resolver: bundles
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Force rebuild image
+      name: rebuild
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "true"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote
+        VMs
+      name: privileged-nested
+      type: string
+    - default:
+      - linux/x86_64
+      description: List of platforms to build the container images on. The available
+        set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: image-url
+        value: $(params.output-image)
+      - name: rebuild
+        value: $(params.rebuild)
+      - name: skip-checks
+        value: $(params.skip-checks)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:7a24924417260b7094541caaedd2853dc8da08d4bb0968f710a400d3e8062063
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:8ecf57d5a6697ce709bee65b62781efe79a10b0c2b95e05576442b67fbd61744
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: dev-package-managers
+        value: "true"
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:3a1b3280d6300ebedb9923ddc441b91b6980512be5dae8da4b9d3be21feeb48e
+        - name: kind
+          value: task
+        resolver: bundles
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-remote-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:846e52e4a14da403fa0cbd0251eab8248ab9230372c96f0566068ed1ccac5c66
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-images.results.IMAGE_REF[*])
+      runAfter:
+      - build-images
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:56fa2cbfc04bad4765b7fe1fa8022587f4042d4e8533bb5f65311d46b43226ee
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:eb8136b543147b4a3e88ca3cc661ca6a11e303f35f0db44059f69151beea8496
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:7c73e2beca9b8306387efeaf775831440ec799b05a5f5c008a65bb941a1e91f6
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dea8d9b4bec3e99d612d799798acf132df48276164b5193ea68f9f3c25ae425b
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:89aead32dc21404e4e0913be9668bdd2eea795db3e4caa762fb619044e479cb8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:59094118aa07d5b0199565c4e0b2d0f4feb9a4741877c8716877572e2c4804f9
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:c8eb622d59019582f6f11ed656c0f04f388737f7dd6e47cd780ad0f34bb38bb2
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:8b58c4fae00c0dfe3937abfb8a9a61aa3c408cca4278b817db53d518428d944e
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:57b3262138eb06186ae7375f84ca53788bba2a66cfd03d39cb82c78df050aba5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:df185dbe4e2852668f9c46f938dd752e90ea9c79696363378435a6499596c319
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:3f89ba89cacf8547261b5ce064acce81bfe470c8ace127794d0e90aebc8c347d
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:278f84550844c1c050a65536799f4b54e7c203e0ac51393aa75379dd974c82e9
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7592da3c98a58a8990352e07272c28e7f9305395ee91ffc0dd7acdd32f0bc1e6
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cnf-tests-4-15
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/cnf-tests/.konflux/Dockerfile
+++ b/cnf-tests/.konflux/Dockerfile
@@ -1,0 +1,77 @@
+# the most updated rhel8-based cli image is 4.15
+FROM registry.redhat.io/openshift4/ose-cli:v4.15 AS oc
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.20 AS builder-stresser
+ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_PATH=/go/src/$PKG_NAME
+ENV TESTER_PATH=$PKG_PATH/cnf-tests/pod-utils/stresser
+RUN mkdir -p $PKG_PATH
+COPY . $PKG_PATH/
+WORKDIR $TESTER_PATH
+RUN go build -mod=vendor -o /stresser
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.20 AS builder-sctptester
+ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_PATH=/go/src/$PKG_NAME
+ENV TESTER_PATH=$PKG_PATH/cnf-tests/pod-utils/sctptester
+RUN mkdir -p $PKG_PATH
+COPY . $PKG_PATH/
+WORKDIR $TESTER_PATH
+RUN go build -mod=vendor -o /sctptest
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.20 AS builder-latency-test-runners
+ENV PKG_NAME=github.com/openshift-kni/cnf-features-deploy
+ENV PKG_PATH=/go/src/$PKG_NAME
+ENV TESTER_PATH=$PKG_PATH/cnf-tests/pod-utils
+RUN mkdir -p $PKG_PATH
+COPY . $PKG_PATH/
+WORKDIR $TESTER_PATH
+RUN go build -mod=vendor -o /oslat-runner oslat-runner/main.go && \
+    go build -mod=vendor -o /cyclictest-runner cyclictest-runner/main.go && \
+    go build -mod=vendor -o /hwlatdetect-runner hwlatdetect-runner/main.go
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.20 AS gobuilder
+WORKDIR /app
+COPY . .
+RUN make test-bin
+
+FROM registry.redhat.io/ubi8/ubi-minimal
+RUN mkdir -p /usr/local/etc/cnf
+RUN microdnf install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs \
+      tmux ethtool iputils procps-ng numactl-libs iptables \
+      kmod rt-tests linuxptp iperf3 nc findutils \
+      python3 # python3 is needed for hwlatdetect
+
+COPY --from=oc /usr/bin/oc /usr/bin/oc
+COPY --from=gobuilder /app/cnf-tests/submodules/cluster-node-tuning-operator/build/_output/bin/latency-e2e.test /usr/bin/latency-e2e.test
+COPY --from=gobuilder /app/cnf-tests/entrypoint/test-run.sh /usr/bin/test-run.sh
+COPY --from=gobuilder /app/cnf-tests/bin/mirror /usr/bin/mirror
+COPY --from=gobuilder /app/cnf-tests/mirror/images.json /usr/local/etc/cnf
+COPY --from=builder-latency-test-runners /oslat-runner /usr/bin/oslat-runner
+COPY --from=builder-latency-test-runners /cyclictest-runner /usr/bin/cyclictest-runner
+COPY --from=builder-latency-test-runners /hwlatdetect-runner /usr/bin/hwlatdetect-runner
+COPY --from=builder-stresser /stresser /usr/bin/stresser
+COPY --from=builder-sctptester /sctptest /usr/bin/sctptest
+
+RUN sed -i 's/quay.io\/openshift-kni\//registry.redhat.io\/openshift4\//g' /usr/local/etc/cnf/images.json
+RUN sed -i 's/cnf-tests:4.15/cnf-tests-rhel8:v4.15/g' /usr/local/etc/cnf/images.json
+RUN sed -i 's/dpdk:4.15/dpdk-base-rhel8:v4.15/g' /usr/local/etc/cnf/images.json
+
+ENV OCP_VERSION=4.15
+ENV IMAGE_REGISTRY=registry.redhat.io/openshift4/
+ENV CNF_TESTS_IMAGE=cnf-tests-rhel8:v${OCP_VERSION}
+ENV DPDK_TESTS_IMAGE=dpdk-base-rhel8:v${OCP_VERSION}
+
+CMD ["/usr/bin/test-run.sh"]
+
+LABEL com.redhat.component="cnf-tests-container" \
+      name="openshift4/cnf-tests" \
+      summary="Cluster verification tests image" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="data,images" \
+      io.k8s.display-name="cnf-tests" \
+      io.openshift.maintainer.component="Telco CNF tests image" \
+      io.openshift.maintainer.product="OpenShift Container Platform" \
+      io.k8s.description="Cluster verification tests image" \
+      maintainer="cnf-devel@redhat.com" \
+      description="Cluster verification tests image"

--- a/cnf-tests/.konflux/OWNERS
+++ b/cnf-tests/.konflux/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - konflux-approvers
+reviewers:
+  - konflux-reviewers

--- a/cnf-tests/.konflux/README.md
+++ b/cnf-tests/.konflux/README.md
@@ -1,0 +1,69 @@
+**Update RPMs dependencies**
+
+In this project (cnf-tests) we are following the hermetic builds flow to install RPM dependencies according to the Product Security requirements. For more info on why this is needed please follow the info in the following link:
+https://konflux.pages.redhat.com/docs/users/faq/hermetic.html.
+
+**RHEL8 base note**
+The process of getting the rpm lockfile for rhel8-based container images is a bit different due to a limitation in rpm-lockfile-prototype tool.
+An easy workaround goes like this:
+1. use a ubi8 container to set up the `.repo` files using the activation key with the supported repos.
+2. on another terminal, run a ubi9 container and do the needed installation for the required tools and subscribe with the same activation key used in 1.
+3. run `rpm-lockfile-prototype` from the ubi9 terminal but with an updated input file or repo files
+
+detailed process:
+1. mkdir ~/temp-el8
+2. cd ~/temp-el8
+3. `podman run --rm -it -v $(pwd):/source:Z --authfile $HOME/pull_secret.json registry.redhat.io/ubi8/ubi-minimal`
+4. `microdnf install subscription-manager`
+5. `subscription-manager register --activationkey=<..> --org=<...>`
+6. copy needed repos like this to the source directory: `cp /etc/yum.repos.d/redhat.repo /source/redhat.repo`; `cd /source`; `sed -i "s/$(uname -m)/\$basearch/g" redhat.repo`
+7. in new terminal apply the rest of the steps below:
+8. cd ~/temp-el8
+9. `podman run --rm -it -v $(pwd):/source:Z --authfile $HOME/pull_secret.json registry.redhat.io/ubi9/ubi-minimal:9.4` #any ubi9 image works
+10. `microdnf install subscription-manager`
+11. `microdnf install -y pip skopeo`
+12. `pip install --user https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/tags/v0.15.0.tar.gz`
+13. `subscription-manager register --activationkey=<..> --org=<...>`  # <- the same activation key as in (5)
+14. `skopeo login registry.redhat.io`
+15. Find entitlement ID from the new system - it's in the filename of the entitlement keys
+    `ls /etc/pki/entitlement/`
+16. Update sslclientkey and sslclientcert path in all entries in `.repo` files or input file references with the entitlement ID of this container
+17. run `rpm-lockfile-prototype -f Dockerfile rpms.in.yaml` and submit the repo files, input and lockfile.
+
+If you are backporting a change that was first done in a rhel9-based Dockerfile, please ensure that the packages are available in rhel8, if not they either are named differently (e.g rt-tests in rhel8 vs realtime-tests in rhel9) in that case you need to rename all occurrences, or they don't exist so you need to implement an alternative way. 
+
+
+
+To delete no longer needed dependencies you need to:
+1. remove the binary name from `rpms.in.yaml` and from `Dockerfile`.
+2. remove the matching section for this binary from `rpms.lock.yaml`.
+3. check if the RPM repo from which this binary is used to install other binaries via searching for same instances in `rpms.lock.yaml`. In case no instances are found, remove the repo section from the relevant `.repo` file or update repos section in `rpms.in.yaml`.
+4. submit the updated files
+
+Or regenerate the file following the procedure in https://konflux.pages.redhat.com/docs/users/how-tos/configuring/activation-keys-subscription.html#_configuring_an_rpm_lockfile_for_hermetic_builds.
+
+To add new dependencies or update binaries versions you need to follow the steps in the docs:
+https://konflux.pages.redhat.com/docs/users/how-tos/configuring/activation-keys-subscription.html#_configuring_an_rpm_lockfile_for_hermetic_builds.
+
+As part of the update, make sure that packages are updated in both `rpms.in.yaml` and `Dockerfile` files in order for the installation to be completely network isolated (hermetic).
+It is enough that the Dockerfile that is used to generate the lockfile contain the final base image and the command that installs the packages. For example:
+
+```azure
+FROM registry.redhat.io/ubi8/ubi-minimal
+RUN microdnf install -y lksctp-tools iproute \
+      ethtool iputils procps-ng numactl-libs iptables \
+      kmod rt-tests linuxptp iperf3 nc \
+      python3
+```
+
+**EUS RPM support**
+When an image version is out-of-maintenance (OOM) some versions has what's called extended-update-support (EUS) period where critical security and CVE fixes will still be shipped. The container image that us built on top of an EUS base should also prefetch the dependencies from corresponding EUS RPM repositories.
+As any other RPM repo, also EUS repos need to be enabled in the activation key. Once enabled, the lockfile will be generated with additional EUS packages. The version of the base images should anyhow align with those used for OCP for the same branch.   
+
+**Important**: 
+* When starting the container in which you will be generating the lockfile in, use a production image in order to get the GA RPM repos and not beta one. So use `registry.redhat.io/ubi8/ubi-minimal` and not `registry-proxy.engineering.redhat.com/rh-osbs/ubi8/ubi-minimal`.
+* Please make sure that the repos that you used to pull the RPMs from are found under the activation key that is associated to the konflux public instance.
+
+**RPM automatic updates**
+Konflux uses a mechanism to automatically file PRs to update RPM versions and generate the updated lockfile, and is called Mintmaker. However, this is supported only for repos that have the input file saved in the root of the project repository, which is not an ideal place for cnf-features-deploy considering it produces multiple images (cnf-tests, ztp,..).
+The support for multiple data sources (input files) is in progress at https://issues.redhat.com/browse/CWFHEALTH-3922.

--- a/cnf-tests/.konflux/rpms.in.yaml
+++ b/cnf-tests/.konflux/rpms.in.yaml
@@ -1,0 +1,58 @@
+contentOrigin:
+  # Define at least one source of packages, but you can have as many as you want.
+  repos:
+    - repoid: rhel-8-for-$basearch-appstream-eus-rpms
+      name: Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel8/{version}/$basearch/appstream/os
+      gpgcheck: 1
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: 1
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/2437305026857227172-key.pem
+      sslclientcert: /etc/pki/entitlement/2437305026857227172.pem
+      sslverifystatus: 1
+      varsFromContainerfile: Dockerfile
+      skip_if_unavailable: true
+    - repoid: rhel-8-for-$basearch-baseos-rpms
+      name: Red Hat Enterprise Linux 8 for $basearch - BaseOS (RPMs)
+      baseurl: https://cdn.redhat.com/content/dist/rhel8/{version}/$basearch/baseos/os
+      gpgcheck: 1
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: 1
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/2437305026857227172-key.pem
+      sslclientcert: /etc/pki/entitlement/2437305026857227172.pem
+      sslverifystatus: 1
+      varsFromContainerfile: Dockerfile
+    - repoid: rhel-8-for-$basearch-baseos-eus-rpms
+      name: Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel8/{version}/$basearch/baseos/os
+      gpgcheck: 1
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: 1
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/2437305026857227172-key.pem
+      sslclientcert: /etc/pki/entitlement/2437305026857227172.pem
+      sslverifystatus: 1
+      skip_if_unavailable: true
+      varsFromContainerfile: Dockerfile
+    - repoid: rhel-8-for-$basearch-appstream-rpms
+      name: Red Hat Enterprise Linux 8 for $basearch - AppStream (RPMs)
+      baseurl: https://cdn.redhat.com/content/dist/rhel8/{version}/$basearch/appstream/os
+      gpgcheck: 1
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: 1
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/2437305026857227172-key.pem
+      sslclientcert: /etc/pki/entitlement/2437305026857227172.pem
+      sslverifystatus: 1
+      varsFromContainerfile: Dockerfile
+
+packages:
+  [lksctp-tools, iproute, libhugetlbfs-utils, libhugetlbfs, tmux, ethtool, iputils, procps-ng, numactl-libs, iptables,kmod, rt-tests, linuxptp, iperf3, nc, findutils, python3]
+
+arches:
+  - x86_64
+
+context:
+  containerfile: Dockerfile

--- a/cnf-tests/.konflux/rpms.lock.yaml
+++ b/cnf-tests/.konflux/rpms.lock.yaml
@@ -1,0 +1,509 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+  - arch: x86_64
+    packages:
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/i/iperf3-3.5-11.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-appstream-rpms
+        size: 104944
+        checksum: sha256:00bd42bdb75fb873b5d3bf90c0eb8d1e5ff871d5493d14e279ac4c590cfd67c2
+        name: iperf3
+        evr: 3.5-11.el8_10
+        sourcerpm: iperf3-3.5-11.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/libxkbcommon-0.9.1-1.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-appstream-rpms
+        size: 118548
+        checksum: sha256:25b13ea50e21233dc5fccf42da344fbf24605dde38db9b94e49739ae39faa072
+        name: libxkbcommon
+        evr: 0.9.1-1.el8
+        sourcerpm: libxkbcommon-0.9.1-1.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/l/linuxptp-4.2-1.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-appstream-rpms
+        size: 280748
+        checksum: sha256:be0dfb83bfec3c4b3aa1047eed31cd5580b22c90bdda6a30199e1b278a8fb428
+        name: linuxptp
+        evr: 4.2-1.el8
+        sourcerpm: linuxptp-4.2-1.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/n/nmap-ncat-7.92-1.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-appstream-rpms
+        size: 248344
+        checksum: sha256:25210c1744dcf096a21397d064ea3223d7a06b626111ff9b3e770b2dad2e21ee
+        name: nmap-ncat
+        evr: 2:7.92-1.el8
+        sourcerpm: nmap-7.92-1.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/p/python3-pip-9.0.3-24.el8.noarch.rpm
+        repoid: rhel-8-for-x86_64-appstream-rpms
+        size: 20864
+        checksum: sha256:483d2fcaa3ff602bc9eacc6b6f12370212d4eff6c3cc5fbd6cbc3bb9774f7bc0
+        name: python3-pip
+        evr: 9.0.3-24.el8
+        sourcerpm: python-pip-9.0.3-24.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/p/python36-3.6.8-39.module+el8.10.0+20784+edafcd43.x86_64.rpm
+        repoid: rhel-8-for-x86_64-appstream-rpms
+        size: 20010
+        checksum: sha256:ae70c3563e01ae72274faa79215cd6b8d1aecec126a7ee598277998f64c4c804
+        name: python36
+        evr: 3.6.8-39.module+el8.10.0+20784+edafcd43
+        sourcerpm: python36-3.6.8-39.module+el8.10.0+20784+edafcd43.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/r/rt-tests-2.6-3.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-appstream-rpms
+        size: 227140
+        checksum: sha256:e87d36006dbd47cbf07395b74e86d17e31079be4f83f9a9e4956bec1ed4b32c3
+        name: rt-tests
+        evr: 2.6-3.el8
+        sourcerpm: rt-tests-2.6-3.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/Packages/x/xkeyboard-config-2.28-1.el8.noarch.rpm
+        repoid: rhel-8-for-x86_64-appstream-rpms
+        size: 801000
+        checksum: sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806
+        name: xkeyboard-config
+        evr: 2.28-1.el8
+        sourcerpm: xkeyboard-config-2.28-1.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/a/acl-2.2.53-3.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 83124
+        checksum: sha256:a22d3f42d7a49ab2e8e7d1c831a80fca159a649a8969ab0617ab93b24df5fa20
+        name: acl
+        evr: 2.2.53-3.el8
+        sourcerpm: acl-2.2.53-3.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/b/bc-1.07.1-5.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 131988
+        checksum: sha256:f6e357fc61da8981294493b05c1d81014f4f56c6f2dc22544234fc311f5fcd61
+        name: bc
+        evr: 1.07.1-5.el8
+        sourcerpm: bc-1.07.1-5.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/c/cracklib-2.9.6-15.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 95532
+        checksum: sha256:9cf2e24fdbe89f25b8283291fd3fcaf73ca60554bbf5767932c38882cdd0e3c4
+        name: cracklib
+        evr: 2.9.6-15.el8
+        sourcerpm: cracklib-2.9.6-15.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-15.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 4144880
+        checksum: sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d
+        name: cracklib-dicts
+        evr: 2.9.6-15.el8
+        sourcerpm: cracklib-2.9.6-15.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.3.7-7.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 500812
+        checksum: sha256:acb20a87af67ceb58dfa295e50c06674511c62d2499d3076a44390d7e3ce0f85
+        name: cryptsetup-libs
+        evr: 2.3.7-7.el8
+        sourcerpm: cryptsetup-2.3.7-7.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/d/dbus-1.12.8-26.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 43292
+        checksum: sha256:5426567ee5fe19e84dbe8c06c73602d588b193e6bb77b2becc31c773fafeb469
+        name: dbus
+        evr: 1:1.12.8-26.el8
+        sourcerpm: dbus-1.12.8-26.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/d/dbus-common-1.12.8-26.el8.noarch.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 48092
+        checksum: sha256:3093c5c1356bc92805a6821f9242a7fc947bbaa1ff427d310dc397f4ea38ef3e
+        name: dbus-common
+        evr: 1:1.12.8-26.el8
+        sourcerpm: dbus-1.12.8-26.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/d/dbus-daemon-1.12.8-26.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 247064
+        checksum: sha256:e2f321553b0a92fee5637e5837a35dbe7baf2b4b4f7fe9b2f1a9b66c8a6cdb85
+        name: dbus-daemon
+        evr: 1:1.12.8-26.el8
+        sourcerpm: dbus-1.12.8-26.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/d/dbus-libs-1.12.8-26.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 189528
+        checksum: sha256:57a38545641fdd14a7887d187fe147d2ca0a22e5a292b9ac5daa2018cc67ed7e
+        name: dbus-libs
+        evr: 1:1.12.8-26.el8
+        sourcerpm: dbus-1.12.8-26.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/d/dbus-tools-1.12.8-26.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 88560
+        checksum: sha256:373d4320fbcb4e823fdf5ad07dbb39805a71a249429e1eff0575bc336ae5634e
+        name: dbus-tools
+        evr: 1:1.12.8-26.el8
+        sourcerpm: dbus-1.12.8-26.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/d/device-mapper-1.02.181-15.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 388100
+        checksum: sha256:195756419b17c95c3e22bff3bf7e868ab98447c7ea10683e9cc33baa41da8b56
+        name: device-mapper
+        evr: 8:1.02.181-15.el8_10
+        sourcerpm: lvm2-2.03.14-15.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.181-15.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 421184
+        checksum: sha256:b929c1c109c892a6bc379bfd0afd8f117100950a9f3b9037ee43e7d9ba025dc8
+        name: device-mapper-libs
+        evr: 8:1.02.181-15.el8_10
+        sourcerpm: lvm2-2.03.14-15.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/d/diffutils-3.6-6.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 367420
+        checksum: sha256:f7fc94ac5b5df2051aa2811c0cebecd7e04353ac871f1a792bc6c68f2c2aa6ce
+        name: diffutils
+        evr: 3.6-6.el8
+        sourcerpm: diffutils-3.6-6.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.190-2.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 77672
+        checksum: sha256:51719dfe1f9b9bc7570beb4e47d79dec1d5307680adb2b0debd7c266604e4e8d
+        name: elfutils-debuginfod-client
+        evr: 0.190-2.el8
+        sourcerpm: elfutils-0.190-2.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.190-2.el8.noarch.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 53904
+        checksum: sha256:345728ee47941f7589211afbc839edb2101a4f2a584afd371c8dfb60c54aeeb3
+        name: elfutils-default-yama-scope
+        evr: 0.190-2.el8
+        sourcerpm: elfutils-0.190-2.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/e/elfutils-libs-0.190-2.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 312392
+        checksum: sha256:d04814c95b050f76d7f05bc2606b08f643c3b857637f5275ccfff445df505b7e
+        name: elfutils-libs
+        evr: 0.190-2.el8
+        sourcerpm: elfutils-0.190-2.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/e/ethtool-5.13-2.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 225972
+        checksum: sha256:e4f799b634299835dc1a8e79adcfb223d13b369bd033cbdb14170f845c9464ad
+        name: ethtool
+        evr: 2:5.13-2.el8
+        sourcerpm: ethtool-5.13-2.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/e/expat-2.2.5-17.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 117960
+        checksum: sha256:d01df6f542762d94bd73a87f61d19fb98a6304eb9a2eb114a872a91d3312ea34
+        name: expat
+        evr: 2.2.5-17.el8_10
+        sourcerpm: expat-2.2.5-17.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/f/findutils-4.6.0-23.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 540248
+        checksum: sha256:cb645de7da1bd495a6df969de4b0f84f10ccf8d299c26099f1cd9075ed9c32cb
+        name: findutils
+        evr: 1:4.6.0-23.el8_10
+        sourcerpm: findutils-4.6.0-23.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/g/gdbm-1.18-2.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 132820
+        checksum: sha256:a8e1839ca386b258656d4a4108049857a257fbd4cf7520d698e0bfa9edd9c4c1
+        name: gdbm
+        evr: 1:1.18-2.el8
+        sourcerpm: gdbm-1.18-2.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/g/gdbm-libs-1.18-2.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 61820
+        checksum: sha256:cfa6bd007cf38a40166de803c4aa0ccae2a6f5ffc756efa6e14a2cab228ec22b
+        name: gdbm-libs
+        evr: 1:1.18-2.el8
+        sourcerpm: gdbm-1.18-2.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/g/gzip-1.9-13.el8_5.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 170828
+        checksum: sha256:7f80be301cda8a6af027f15898058b1f62a0069f347a84aecb2a9c7b4c6d1ef7
+        name: gzip
+        evr: 1.9-13.el8_5
+        sourcerpm: gzip-1.9-13.el8_5.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/i/iproute-6.2.0-6.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 874788
+        checksum: sha256:76c1124b3198000d68be7e103f1572e049bbec83f47ec382a693f27a982d61aa
+        name: iproute
+        evr: 6.2.0-6.el8_10
+        sourcerpm: iproute-6.2.0-6.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/i/iptables-1.8.5-11.el8_9.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 606500
+        checksum: sha256:3326bb6ccfc1e387d7a5a7ba2fdde9d1766fbff8dfc084f9e77a650d10787980
+        name: iptables
+        evr: 1.8.5-11.el8_9
+        sourcerpm: iptables-1.8.5-11.el8_9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/i/iptables-libs-1.8.5-11.el8_9.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 105400
+        checksum: sha256:cb96a20e92ce8065f2ff0e954b1997714ba3b3dc14bdc951c034ccd5f8f2cf90
+        name: iptables-libs
+        evr: 1.8.5-11.el8_9
+        sourcerpm: iptables-1.8.5-11.el8_9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/i/iputils-20180629-11.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 152344
+        checksum: sha256:e40d7959186fdb1b734b75d0abdc2821d956d11ce0ad1117d1f11771781c94fd
+        name: iputils
+        evr: 20180629-11.el8
+        sourcerpm: iputils-20180629-11.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/k/kmod-25-20.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 129356
+        checksum: sha256:0d2ca4e3cdeb9929d40257e25d3be233a608bf4269a16be77a63503d78233ed2
+        name: kmod
+        evr: 25-20.el8
+        sourcerpm: kmod-25-20.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/k/kmod-libs-25-20.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 70224
+        checksum: sha256:4c586c86bdf99b69ce1c250069f53fceef5b5536b8c9e10018ac25e7e7758126
+        name: kmod-libs
+        evr: 25-20.el8
+        sourcerpm: kmod-25-20.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libbpf-0.5.0-1.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 140008
+        checksum: sha256:644529740fa2e3655ab2aea0f5622958c34a591c0d08ee033ecbe2fb40dd437c
+        name: libbpf
+        evr: 0.5.0-1.el8
+        sourcerpm: libbpf-0.5.0-1.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libevent-2.1.8-5.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 259580
+        checksum: sha256:7e95dc277991981a081f73f4410219a196b7b0d02dbe1ad2ebfce172c215669e
+        name: libevent
+        evr: 2.1.8-5.el8
+        sourcerpm: libevent-2.1.8-5.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libfdisk-2.32.1-46.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 260128
+        checksum: sha256:e7793c66af8f2cdd7893527bc81971e50f985f27c67dc22bbf118e3e0468f1a9
+        name: libfdisk
+        evr: 2.32.1-46.el8
+        sourcerpm: util-linux-2.32.1-46.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libhugetlbfs-2.21-17.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 91556
+        checksum: sha256:fa9c30c8545c9e824e112f3809eec38c27e9635a398cdfdb210e48a7c9451924
+        name: libhugetlbfs
+        evr: 2.21-17.el8
+        sourcerpm: libhugetlbfs-2.21-17.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libhugetlbfs-utils-2.21-17.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 74512
+        checksum: sha256:f1b1e8d2b635baa1b6801c77a9432a69a7b911f7593a6e15a2e54967f183517a
+        name: libhugetlbfs-utils
+        evr: 2.21-17.el8
+        sourcerpm: libhugetlbfs-2.21-17.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libibverbs-48.0-1.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 413376
+        checksum: sha256:718811c11e3e4de15e5b90e0bb79cb1b728e0f42cb4443f4111f0d4335040fce
+        name: libibverbs
+        evr: 48.0-1.el8
+        sourcerpm: rdma-core-48.0-1.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libmnl-1.0.4-6.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 31064
+        checksum: sha256:9c5594fcac97c0f8813d7a188e2368e3b1095025fc4a0ecbd5d17e54c0c93f97
+        name: libmnl
+        evr: 1.0.4-6.el8
+        sourcerpm: libmnl-1.0.4-6.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.6-5.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 66300
+        checksum: sha256:74d05cb72dc6740be73480e68b15b209d7e7a2bf7d7d54e0d3a2dc261ce64e4b
+        name: libnetfilter_conntrack
+        evr: 1.0.6-5.el8
+        sourcerpm: libnetfilter_conntrack-1.0.6-5.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libnfnetlink-1.0.1-13.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 33740
+        checksum: sha256:61cf7338e12188f787c7162e2cd669c895e4e2cf4ae86c9debcd56fd3b8a8322
+        name: libnfnetlink
+        evr: 1.0.1-13.el8
+        sourcerpm: libnfnetlink-1.0.1-13.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libnftnl-1.2.2-3.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 88868
+        checksum: sha256:6f9048df15facb5bdcc3951b683f9cb3f2b35c10149e90443cfddf7bb936792b
+        name: libnftnl
+        evr: 1.2.2-3.el8
+        sourcerpm: libnftnl-1.2.2-3.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libnl3-3.7.0-1.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 345436
+        checksum: sha256:7bd27606a99e17e49649a192743c0dd5e2849c48a05a8f025c9d342a16c6b8e9
+        name: libnl3
+        evr: 3.7.0-1.el8
+        sourcerpm: libnl3-3.7.0-1.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libnsl2-1.2.0-2.20180605git4a062cf.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 59120
+        checksum: sha256:f7e60c8a5eaf056a9c67834671561196b961fba7bc763568f1c01c3ab998bb46
+        name: libnsl2
+        evr: 1.2.0-2.20180605git4a062cf.el8
+        sourcerpm: libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libpcap-1.9.1-5.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 172780
+        checksum: sha256:7bff9ffead0f163e7790af3d9e3bb0a3a4a38bff4d1f3b6a183f9313faf00c83
+        name: libpcap
+        evr: 14:1.9.1-5.el8
+        sourcerpm: libpcap-1.9.1-5.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-6.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 109704
+        checksum: sha256:ae3dfbc6ca432681b137f76bee081735d61c65db986b1238ed7837e3112d3180
+        name: libpwquality
+        evr: 1.4.4-6.el8
+        sourcerpm: libpwquality-1.4.4-6.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-1.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 72932
+        checksum: sha256:cf08ceb39359d00f9da0abaf15e799725288f8cd3a54d075fb37b76967776949
+        name: libseccomp
+        evr: 2.5.2-1.el8
+        sourcerpm: libseccomp-2.5.2-1.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libsemanage-2.9-11.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 172936
+        checksum: sha256:2fbbded84101ff93c19bdaebf7b05c2950654b010c37ba5de13d7a0342bd634b
+        name: libsemanage
+        evr: 2.9-11.el8_10
+        sourcerpm: libsemanage-2.9-11.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libtirpc-1.1.4-12.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 116808
+        checksum: sha256:d35b01a79f17bcaca9a774fa78136acadabf6f627db43b7dca43a83a63afffa4
+        name: libtirpc
+        evr: 1.1.4-12.el8_10
+        sourcerpm: libtirpc-1.1.4-12.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/libutempter-1.1.6-14.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 32564
+        checksum: sha256:ebc4d394a251feba7e1025d7f8ba61e619c2a6fc14229482bf28096e49cef520
+        name: libutempter
+        evr: 1.1.6-14.el8
+        sourcerpm: libutempter-1.1.6-14.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/l/lksctp-tools-1.0.18-3.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 101924
+        checksum: sha256:68fac30590576a29d6308beed508e68b5a4b2175f539b1812cab20e83e9136d8
+        name: lksctp-tools
+        evr: 1.0.18-3.el8
+        sourcerpm: lksctp-tools-1.0.18-3.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/n/numactl-libs-2.0.16-4.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 38012
+        checksum: sha256:9332177a5259c40967c30371ab75b09c6e479fd56161c8e84f33876c389cda36
+        name: numactl-libs
+        evr: 2.0.16-4.el8
+        sourcerpm: numactl-2.0.16-4.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/pam-1.3.1-36.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 765548
+        checksum: sha256:92bb7478c5945f4c83f748197ffb3ead918ba55e2d08448be6bafdbafbc2c821
+        name: pam
+        evr: 1.3.1-36.el8_10
+        sourcerpm: pam-1.3.1-36.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/platform-python-3.6.8-69.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 90592
+        checksum: sha256:43e2eac6440b86c1ec9eec337abed72a2878adc0ec11aecc506de59963c47fb9
+        name: platform-python
+        evr: 3.6.8-69.el8_10
+        sourcerpm: python3-3.6.8-69.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/platform-python-pip-9.0.3-24.el8.noarch.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 1633024
+        checksum: sha256:a9104ca3388b74f665c2648cde81043cc7748bf1ca5a7f2a4148b86013206fc8
+        name: platform-python-pip
+        evr: 9.0.3-24.el8
+        sourcerpm: python-pip-9.0.3-24.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/platform-python-setuptools-39.2.0-8.el8_10.noarch.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 647476
+        checksum: sha256:8f330a8602613473b6e4c0bc57cb3012932a9a9399ea7a3fa65175453a6580ab
+        name: platform-python-setuptools
+        evr: 39.2.0-8.el8_10
+        sourcerpm: python-setuptools-39.2.0-8.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/procps-ng-3.3.15-14.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 337976
+        checksum: sha256:04ecbee4e131df365e8beadc54b4610ccaecf445d9541ebb5e40a2394a6bb023
+        name: procps-ng
+        evr: 3.3.15-14.el8
+        sourcerpm: procps-ng-3.3.15-14.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/psmisc-23.1-5.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 154388
+        checksum: sha256:e22840ee14aa1993e75fd690749c01dbb7d4419c2b210fef173ff99a76f61ff6
+        name: psmisc
+        evr: 23.1-5.el8
+        sourcerpm: psmisc-23.1-5.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/python3-libs-3.6.8-69.el8_10.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 8251108
+        checksum: sha256:6dcf5dcbb3000fe90877bafbb4e8bb9f9a170b262c12f7ae8033e649227cf1b0
+        name: python3-libs
+        evr: 3.6.8-69.el8_10
+        sourcerpm: python3-3.6.8-69.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/python3-pip-wheel-9.0.3-24.el8.noarch.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 886996
+        checksum: sha256:9bf511b12174637c1163f224deb28a0ea7f8f4565231e3a0e8eb64f37ce27d08
+        name: python3-pip-wheel
+        evr: 9.0.3-24.el8
+        sourcerpm: python-pip-9.0.3-24.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/python3-setuptools-39.2.0-8.el8_10.noarch.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 166796
+        checksum: sha256:6bc3a23645fe60bcd5d1ec3072ac521b54f2bc18652e35e91acf56ade1722a26
+        name: python3-setuptools
+        evr: 39.2.0-8.el8_10
+        sourcerpm: python-setuptools-39.2.0-8.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-39.2.0-8.el8_10.noarch.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 296040
+        checksum: sha256:833dcb68b1eea48bfb8853886236753647743258fd74cc538ffa72408aab9213
+        name: python3-setuptools-wheel
+        evr: 39.2.0-8.el8_10
+        sourcerpm: python-setuptools-39.2.0-8.el8_10.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/s/shadow-utils-4.6-22.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 1292332
+        checksum: sha256:ea73ee201451bbca0d6d14ca434c93800f01c8fb1b9daef727a5af1a27356d07
+        name: shadow-utils
+        evr: 2:4.6-22.el8
+        sourcerpm: shadow-utils-4.6-22.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/s/systemd-239-82.el8_10.5.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 3825744
+        checksum: sha256:116ad89ce7a4368e19e1a22f07fb5e6d1c5227fc8eee708f2df697b68c77d6e5
+        name: systemd
+        evr: 239-82.el8_10.5
+        sourcerpm: systemd-239-82.el8_10.5.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/s/systemd-pam-239-82.el8_10.5.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 526292
+        checksum: sha256:35fe48ea4c2fc1b364b901b42a432b9fd1fb4edece973aca8a6e4773b04cf0a3
+        name: systemd-pam
+        evr: 239-82.el8_10.5
+        sourcerpm: systemd-239-82.el8_10.5.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/t/tmux-2.7-3.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 324120
+        checksum: sha256:191cbb5eab15d89d6cd949e96e862ec8330a83bfb15f6bb79bdd46ea69ffc93f
+        name: tmux
+        evr: 2.7-3.el8
+        sourcerpm: tmux-2.7-3.el8.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/baseos/os/Packages/u/util-linux-2.32.1-46.el8.x86_64.rpm
+        repoid: rhel-8-for-x86_64-baseos-rpms
+        size: 2597616
+        checksum: sha256:1accef88d06655139903a7b4aa6a01cab62b3c899a93d297cb7ac92a476abed6
+        name: util-linux
+        evr: 2.32.1-46.el8
+        sourcerpm: util-linux-2.32.1-46.el8.src.rpm
+    source: []
+    module_metadata:
+      - url: https://cdn.redhat.com/content/dist/rhel8/8.10/x86_64/appstream/os/repodata/7614a29cf6d58dd3569a454f4b02baa50d832c5325e7b131e97b719656a583a2-modules.yaml.gz
+        repoid: rhel-8-for-x86_64-appstream-rpms
+        size: 730550
+        checksum: sha256:7614a29cf6d58dd3569a454f4b02baa50d832c5325e7b131e97b719656a583a2


### PR DESCRIPTION
* Add tekton files to configure pipeline jobs
* Add konflux dedicated Dockerfile and RPM lockfile
* Add owners for tekton files
* update cnf-tests/.konflux/README.md to specify the different flow for lockfile generation when using rhel8-based image.