### PR TITLE
cnf-tests: tekton: update on-cel-expression

### DIFF
--- a/.tekton/cnf-tests-4-20-pull-request.yaml
+++ b/.tekton/cnf-tests-4-20-pull-request.yaml
@@ -8,8 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      target_branch == "master" &&
+      (".tekton/cnf-tests-4-20-pull-request.yaml".pathChanged() ||
+      "cnf-tests/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cnf-tests-4-20

--- a/.tekton/cnf-tests-4-20-push.yaml
+++ b/.tekton/cnf-tests-4-20-push.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "master" &&
+      (".tekton/cnf-tests-4-20-push.yaml".pathChanged() ||
+      "cnf-tests/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cnf-tests-4-20


### PR DESCRIPTION
Define when to run the pipelines on the branch. We want to run them only if related tekton files changed or any change in `cnf-tests` directory.