### PR TITLE
ztp: update golang builder image to 4.19 [release-4.19]

### DIFF
--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -1,4 +1,4 @@
-ARG ZTP_BUILD_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18
+ARG ZTP_BUILD_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.19
 ARG ZTP_RUNTIME_IMAGE=ubi8-minimal
 # Builder
 FROM ${ZTP_BUILD_IMAGE} as builder


### PR DESCRIPTION
This PR updates the builder image for ztp-site-generate to openshift-4.19