### PR TITLE
ztp: backport ztp konflux to release-4.16

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - konflux-approvers
+reviewers:
+  - konflux-reviewers

--- a/.tekton/ztp-site-generate-4-16-pull-request.yaml
+++ b/.tekton/ztp-site-generate-4-16-pull-request.yaml
@@ -1,0 +1,682 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift-kni/cnf-features-deploy?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "release-4.16" &&
+      (".tekton/ztp-site-generate-4-16-pull-request.yaml".pathChanged() ||
+      "ztp/***".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ztp-site-generate-4-16
+    appstudio.openshift.io/component: ztp-site-generate-4-16
+    pipelines.appstudio.openshift.io/type: build
+  name: ztp-site-generate-4-16-on-pull-request
+  namespace: telco-5g-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/ztp-site-generate-4-16:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+      - linux/x86_64
+  - name: dockerfile
+    value: ztp/resource-generator/Containerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "rpm", "path": "ztp/resource-generator/.konflux"}'
+  - name: build-source-image
+    value: "true"
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
+
+      _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) if any tasks are added to the pipeline.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+    finally:
+    - name: show-sbom
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      taskRef:
+        params:
+        - name: name
+          value: show-sbom
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:002f7c8c1d2f9e09904035da414aba1188ae091df0ea9532cd997be05e73d594
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: show-summary
+      params:
+      - name: pipelinerun-name
+        value: $(context.pipelineRun.name)
+      - name: git-url
+        value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+      - name: image-url
+        value: $(params.output-image)
+      - name: build-task-status
+        value: $(tasks.build-image-index.status)
+      taskRef:
+        params:
+        - name: name
+          value: summary
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:76075b709fa06ed824cbc84f41448b397b85bfde1cf9809395ba6d286f5b7cbd
+        - name: kind
+          value: task
+        resolver: bundles
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Force rebuild image
+      name: rebuild
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "true"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote VMs
+      name: privileged-nested
+      type: string
+    - default:
+        - linux/x86_64
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: image-url
+        value: $(params.output-image)
+      - name: rebuild
+        value: $(params.rebuild)
+      - name: skip-checks
+        value: $(params.skip-checks)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:7a24924417260b7094541caaedd2853dc8da08d4bb0968f710a400d3e8062063
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:8ecf57d5a6697ce709bee65b62781efe79a10b0c2b95e05576442b67fbd61744
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: generate-labels
+      params:
+          - name: label-templates
+            value:
+              - "build-date=$SOURCE_DATE"
+              - "short-commit=$(tasks.clone-repository.results.short-commit)"
+              - "version=v4.16-$SOURCE_DATE_EPOCH"
+          - name: source-date-epoch
+            value: '$(tasks.clone-repository.results.commit-timestamp)'
+      runAfter:
+          - clone-repository
+      taskRef:
+          params:
+            - name: name
+              value: generate-labels
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:2eea900077190535c4dbb30e9bcc2da357bd53c408613485fb3af53484afdcbd
+            - name: kind
+              value: task
+          resolver: bundles
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: dev-package-managers
+        value: "true"
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:d48c621ae828a3cbca162e12ec166210d2d77a7ba23b0e5d60c4a1b94491adeb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.prefetch-input)
+        operator: notin
+        values:
+        - ""
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
+      - name: PLATFORM
+        value: linux/x86_64
+      - name: LABELS
+        value:
+          - $(tasks.generate-labels.results.labels[*])
+          - "com.redhat.component=ztp-site-generate-container"
+          - "description=Container Image for Argo CD integration with ACM"
+          - "distribution-scope=public"
+          - "io.k8s.description=ztp-site-generate"
+          - "name=openshift4/ztp-site-generate"
+          - "release=4.16"
+          - "url=https://github.com/openshift-kni/cnf-features-deploy"
+          - "vendor=Red Hat, Inc."
+          - "io.k8s.display-name=ztp-site-generate"
+          - "io.openshift.tags=data,images"
+          - "summary=Container Image for Argo CD integration with ACM"
+          - "maintainer=rauherna@redhat.com,sskeard@redhat.com"
+      runAfter:
+      - prefetch-dependencies
+      - generate-labels
+      taskRef:
+        params:
+        - name: name
+          value: buildah-remote-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:6a5f714dd0c301ac421c232d2658e336b862681cf0bcbcbf01ef38d8969664e0
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:56fa2cbfc04bad4765b7fe1fa8022587f4042d4e8533bb5f65311d46b43226ee
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:eb8136b543147b4a3e88ca3cc661ca6a11e303f35f0db44059f69151beea8496
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:7c73e2beca9b8306387efeaf775831440ec799b05a5f5c008a65bb941a1e91f6
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dea8d9b4bec3e99d612d799798acf132df48276164b5193ea68f9f3c25ae425b
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:89aead32dc21404e4e0913be9668bdd2eea795db3e4caa762fb619044e479cb8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:59094118aa07d5b0199565c4e0b2d0f4feb9a4741877c8716877572e2c4804f9
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:87af64576088ba68f2a5b89998b7ae9e92d7e4f039274e4be6000eff6ce0d95d
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:8b58c4fae00c0dfe3937abfb8a9a61aa3c408cca4278b817db53d518428d944e
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:57b3262138eb06186ae7375f84ca53788bba2a66cfd03d39cb82c78df050aba5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:df185dbe4e2852668f9c46f938dd752e90ea9c79696363378435a6499596c319
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:3f89ba89cacf8547261b5ce064acce81bfe470c8ace127794d0e90aebc8c347d
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:278f84550844c1c050a65536799f4b54e7c203e0ac51393aa75379dd974c82e9
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:297c2d8928aa3b114fcb1ba5d9da8b10226b68fed30706e78a6a5089c6cd30e3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ztp-site-generate-4-16
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/ztp-site-generate-4-16-push.yaml
+++ b/.tekton/ztp-site-generate-4-16-push.yaml
@@ -1,0 +1,679 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift-kni/cnf-features-deploy?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "release-4.16" &&
+      (".tekton/ztp-site-generate-4-16-push.yaml".pathChanged() ||
+      "ztp/***".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: ztp-site-generate-4-16
+    appstudio.openshift.io/component: ztp-site-generate-4-16
+    pipelines.appstudio.openshift.io/type: build
+  name: ztp-site-generate-4-16-on-push
+  namespace: telco-5g-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/ztp-site-generate-4-16:{{revision}}
+  - name: build-platforms
+    value:
+      - linux/x86_64
+  - name: dockerfile
+    value: ztp/resource-generator/Containerfile
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "rpm", "path": "ztp/resource-generator/.konflux"}'
+  - name: build-source-image
+    value: "true"
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
+
+      _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) if any tasks are added to the pipeline.
+      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+    finally:
+    - name: show-sbom
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      taskRef:
+        params:
+        - name: name
+          value: show-sbom
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:002f7c8c1d2f9e09904035da414aba1188ae091df0ea9532cd997be05e73d594
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: show-summary
+      params:
+      - name: pipelinerun-name
+        value: $(context.pipelineRun.name)
+      - name: git-url
+        value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+      - name: image-url
+        value: $(params.output-image)
+      - name: build-task-status
+        value: $(tasks.build-image-index.status)
+      taskRef:
+        params:
+        - name: name
+          value: summary
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:76075b709fa06ed824cbc84f41448b397b85bfde1cf9809395ba6d286f5b7cbd
+        - name: kind
+          value: task
+        resolver: bundles
+    params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+    - description: Fully Qualified Output Image
+      name: output-image
+      type: string
+    - default: .
+      description: Path to the source code of an application's component from where
+        to build image.
+      name: path-context
+      type: string
+    - default: Dockerfile
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
+      name: dockerfile
+      type: string
+    - default: "false"
+      description: Force rebuild image
+      name: rebuild
+      type: string
+    - default: "false"
+      description: Skip checks against built image
+      name: skip-checks
+      type: string
+    - default: "false"
+      description: Execute the build with network isolation
+      name: hermetic
+      type: string
+    - default: ""
+      description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+    - default: ""
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
+      name: image-expires-after
+    - default: "false"
+      description: Build a source image.
+      name: build-source-image
+      type: string
+    - default: "true"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
+    - default: ""
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      name: build-args-file
+      type: string
+    - default: "false"
+      description: Whether to enable privileged mode, should be used only with remote VMs
+      name: privileged-nested
+      type: string
+    - default:
+        - linux/x86_64
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    tasks:
+    - name: init
+      params:
+      - name: image-url
+        value: $(params.output-image)
+      - name: rebuild
+        value: $(params.rebuild)
+      - name: skip-checks
+        value: $(params.skip-checks)
+      taskRef:
+        params:
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:7a24924417260b7094541caaedd2853dc8da08d4bb0968f710a400d3e8062063
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: clone-repository
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
+      taskRef:
+        params:
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:8ecf57d5a6697ce709bee65b62781efe79a10b0c2b95e05576442b67fbd61744
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: generate-labels
+      params:
+          - name: label-templates
+            value:
+              - "build-date=$SOURCE_DATE"
+              - "short-commit=$(tasks.clone-repository.results.short-commit)"
+              - "version=v4.16-$SOURCE_DATE_EPOCH"
+          - name: source-date-epoch
+            value: '$(tasks.clone-repository.results.commit-timestamp)'
+      runAfter:
+          - clone-repository
+      taskRef:
+          params:
+            - name: name
+              value: generate-labels
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:2eea900077190535c4dbb30e9bcc2da357bd53c408613485fb3af53484afdcbd
+            - name: kind
+              value: task
+          resolver: bundles
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: dev-package-managers
+        value: "true"
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:d48c621ae828a3cbca162e12ec166210d2d77a7ba23b0e5d60c4a1b94491adeb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.prefetch-input)
+        operator: notin
+        values:
+        - ""
+      workspaces:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - name: build-container
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
+      - name: PLATFORM
+        value: linux/x86_64
+      - name: LABELS
+        value:
+          - $(tasks.generate-labels.results.labels[*])
+          - "com.redhat.component=ztp-site-generate-container"
+          - "description=Container Image for Argo CD integration with ACM"
+          - "distribution-scope=public"
+          - "io.k8s.description=ztp-site-generate"
+          - "name=openshift4/ztp-site-generate"
+          - "release=4.16"
+          - "url=https://github.com/openshift-kni/cnf-features-deploy"
+          - "vendor=Red Hat, Inc."
+          - "io.k8s.display-name=ztp-site-generate"
+          - "io.openshift.tags=data,images"
+          - "summary=Container Image for Argo CD integration with ACM"
+          - "maintainer=rauherna@redhat.com,sskeard@redhat.com"
+      runAfter:
+      - prefetch-dependencies
+      - generate-labels
+      taskRef:
+        params:
+        - name: name
+          value: buildah-remote-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:6a5f714dd0c301ac421c232d2658e336b862681cf0bcbcbf01ef38d8969664e0
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:462ecbf94ec44a8b770d6ef8838955f91f57ee79795e5c18bdc0fcb0df593742
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:56fa2cbfc04bad4765b7fe1fa8022587f4042d4e8533bb5f65311d46b43226ee
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:eb8136b543147b4a3e88ca3cc661ca6a11e303f35f0db44059f69151beea8496
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:7c73e2beca9b8306387efeaf775831440ec799b05a5f5c008a65bb941a1e91f6
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dea8d9b4bec3e99d612d799798acf132df48276164b5193ea68f9f3c25ae425b
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:89aead32dc21404e4e0913be9668bdd2eea795db3e4caa762fb619044e479cb8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:59094118aa07d5b0199565c4e0b2d0f4feb9a4741877c8716877572e2c4804f9
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-coverity-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - coverity-availability-check
+      taskRef:
+        params:
+        - name: name
+          value: sast-coverity-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:87af64576088ba68f2a5b89998b7ae9e92d7e4f039274e4be6000eff6ce0d95d
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+      - input: $(tasks.coverity-availability-check.results.STATUS)
+        operator: in
+        values:
+        - success
+    - name: coverity-availability-check
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: coverity-availability-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:8b58c4fae00c0dfe3937abfb8a9a61aa3c408cca4278b817db53d518428d944e
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-shell-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-shell-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:57b3262138eb06186ae7375f84ca53788bba2a66cfd03d39cb82c78df050aba5
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-unicode-check
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-unicode-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.2@sha256:df185dbe4e2852668f9c46f938dd752e90ea9c79696363378435a6499596c319
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:3f89ba89cacf8547261b5ce064acce81bfe470c8ace127794d0e90aebc8c347d
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:278f84550844c1c050a65536799f4b54e7c203e0ac51393aa75379dd974c82e9
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:297c2d8928aa3b114fcb1ba5d9da8b10226b68fed30706e78a6a5089c6cd30e3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    workspaces:
+    - name: git-auth
+      optional: true
+    - name: netrc
+      optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ztp-site-generate-4-16
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -51,3 +51,13 @@ aliases:
     - sakhoury
     - sabbir-47
     - irinamihai
+  konflux-approvers:
+    - yanirq
+    - shajmakh
+    - fontivan
+    - rauhersu
+  konflux-reviewers:
+    - yanirq
+    - shajmakh
+    - fontivan
+    - rauhersu

--- a/ztp/resource-generator/.konflux/OWNERS
+++ b/ztp/resource-generator/.konflux/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - konflux-approvers
+reviewers:
+  - konflux-reviewers

--- a/ztp/resource-generator/.konflux/README.md
+++ b/ztp/resource-generator/.konflux/README.md
@@ -1,0 +1,46 @@
+# RPM lock files in Konflux
+
+## Overview
+When installing external software via RPMs in Konflux builds, we need to integrate a RPM lock file management in our workflow: the primary goal is to ensure that hermetic builds ,required by Konflux Conforma, can pre-fetch RPM dependencies before building the Docker image. A hermetic build without lock files, relying on dynamic downloads exclusively, would fail due to no internet access otherwise.
+
+More information about the hermetic builds in the [Konflux Hermetic Builds FAQ](https://konflux.pages.redhat.com/docs/users/faq/hermetic.html)
+
+## RPM lock file management
+
+### Generate a rpm lock file
+
+We will be using a generator named `rpm-lock-file-prototype` according to the directions provided by that project on the [rpm-lockfile-prototype README](https://github.com/konflux-ci/rpm-lockfile-prototype?tab=readme-ov-file#installation)
+
+The `rpms.lock.yaml` has been generated from the input provided by `rpms.in.yaml: this file must be manually created from scratch by Konflux developers with the following fields:
+
+1. `repofiles`: the .repo file extracted from the runtime base image for ztp (a `ubi.repo` file from ubi8 so far)
+2. `packages`: the rpms we depend on
+3. `arches`: the supported architectures for building
+4. `Containerfile`: the Containerfile used to build the ztp image.
+
+
+### Introduce rpms based on new subscriptions
+
+So far, no additional subscription-manager/activation-key config has been carried out,as the RPMs we currently depend on don't require a Red Hat subscription. In case future development requires to subscribe to new rpm repos, see this [Konflux activation key doc](https://konflux.pages.redhat.com/docs/users/how-tos/configuring/activation-keys-subscription.html#_configuring_an_rpm_lockfile_for_hermetic_builds).
+
+### Configure the .tekton yaml files
+
+The push/pull tekton yaml files in `.tekton` have been configured to setup a hermetic build workflow according to the [Konflux prefetch doc](https://konflux.pages.redhat.com/docs/users/how-tos/configuring/prefetching-dependencies.html#_procedure)
+
+1. Enable hermetic builds
+```yaml
+   - name: hermetic
+     value: "true"
+
+2. Enable rpm pre-fetch
+```yaml
+   - name: prefetch-input
+     value: '{"type": "rpm", "path": "ztp/resource-generator/.konflux"}'
+
+3. Enable dev package managers
+```yaml
+   - name: dev-package-managers
+     value: "true"
+
+### Update  rpms
+Konflux provides a mechanism (Mintmaker) to automatically file PRs to update RPM versions and generate the updated lockfile. At time of writing, this is limited to a `rpm.locks.yaml` file present in the project root, which in the case of ztp (a multicomponent project: ztp-site-generate and cnf-tests) is not viable so we will have to re-generate the `rpm.locks.yaml` using our own tools in the interim (scripts/automation)

--- a/ztp/resource-generator/.konflux/redhat.repo
+++ b/ztp/resource-generator/.konflux/redhat.repo
@@ -1,0 +1,17751 @@
+[rhocp-4.17-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.8-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/dirsrv/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-8-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat build of Quarkus 2 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2-for-rhel-8-$basearch-rpms]
+name = Red Hat AMQ Clients 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Devworkspace 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Builds 1.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Directory Server 11.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4.6-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat OpenShift Container Storage 4.6 Server EUS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Extended Update Support (Source RPMS)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.14-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.14 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - 4 years of updates (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/certsys/10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.2-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.2 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Devworkspace 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Directory Server 11.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-samba-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Gluster Storage 3 Samba for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-samba/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Storage 4 Server (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat build of Quarkus 2.2 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-8-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift distributed tracing 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-mon-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage MON 4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-mon/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.11 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.1-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nmo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.8-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.8 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-8-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-1-for-rhel-8-$basearch-source-rpms]
+name = JBoss AMQ Interconnect 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq-interconnect/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-tech-preview-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Automation Services Catalog 1 Tech Preview for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-services-catalog-tech-preview/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.6-for-rhel-8-$basearch-rpms]
+name = Red Hat Directory Server 11.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-rhui-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat CloudForms Management Engine 5.11 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/cfme/5.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.5-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.5 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.10-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.10 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-tus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-0-for-rhel-8-$basearch-rpms]
+name = Red Hat Discovery 0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16 Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-manager-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization Manager 4 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-manager/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-snr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-source-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-textonly-1-for-middleware-rpms]
+name = Red Hat AMQ Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq-interconnect/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-source-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-cinderlib-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16 Cinderlib for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-rhui-source-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-rhui-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat CloudForms Management Engine 5.11 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/cfme/5.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Data Foundation (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhodf/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-4.10-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability 4.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.7-for-rhel-8-$basearch-debug-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert-manager/1.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-4-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-10-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat build of Quarkus 2 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16 Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/satellite/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.15-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.11 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.1 Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-source-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.24-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Jaeger 1.24 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.24/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-textonly-1-for-middleware-rpms]
+name = OpenJDK Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openjdk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.9-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.9 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-debug-rpms]
+name = Red Hat Container Development Kit 2.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Automation Services Catalog 1 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-services-catalog/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-s390x-source-rpms]
+name = Fast Datapath Beta for RHEL 8 IBM z Systems (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/s390x/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-8-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-for-rhel-8-$basearch-textonly-rpms]
+name = Red Hat Ceph Storage 6 Text-Only Advisories for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-textonly/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-8-$basearch-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.20-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Jaeger 1.20.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.5-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Tools and Services 4.5 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoss-1.29-for-rhel-8-$basearch-rpms]
+name = Red Hat Openshift Serverless 1.29 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1.29/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Directory Server 11.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-source-rpms]
+name = JBoss Core Services (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbcs/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.3-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Enterprise Application Platform Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbeap/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-ember-0.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Ember-CSI 0.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-ember/0.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-cinderlib-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.2 Cinderlib for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-beta-for-rhel-8-$basearch-rpms]
+name = Advanced Virtualization CodeReady Builder Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt-crb/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-nfs-for-rhel-8-$basearch-rpms]
+name = Red Hat Gluster Storage 3 NFS for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-nfs/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-8-$basearch-rhui-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel8/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.2 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.17-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Jaeger 1.17 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhvh-4-build-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization Host Build for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhvh-build/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Management Agents Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-mgmt-agent/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.9-for-rhel-8-$basearch-rpms]
+name = Red Hat Directory Server 11.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Certificate System 10.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhvh-4-build-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization Host Build for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhvh-build/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rhui-rpms]
+name = Single Sign-On Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.1 Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4.4-manager-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization Manager 4.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-manager/4.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-capsule/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.6-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.6 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.4-for-rhel-8-$basearch-rpms]
+name = Red Hat Certificate System 10.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift distributed tracing 3 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-devtools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 15 Developer Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.12-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-8-$basearch-rpms]
+name = JBoss Web Server 5 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/beta/layered/rhui/rhel8/$basearch/sat-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.11-rpms]
+name = Red Hat Container Development Kit 3.11 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.11-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.11 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 2.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Update Services SAP Solutions (RPMS)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.2-for-rhel-8-$basearch-rpms]
+name = Red Hat Migration Toolkit 1.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-8-$basearch-rpms]
+name = Red Hat Discovery 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhceph-tools/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat build of Quarkus 3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Quay 3.11 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quay/3.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.22-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Jaeger 1.22.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.22/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-tus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack-deployment-tools/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.11-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.11 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-rhui-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Directory Server 11.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[interconnect-2-for-rhel-8-$basearch-rpms]
+name = JBoss Interconnect 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/interconnect/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fsw-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Fuse Service Works Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/fsw/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-8-$basearch-rpms]
+name = Kernel Module Management 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.22-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Jaeger 1.22.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.22/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.10-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.10 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/dirsrv/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-mdr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Core Services (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbcs/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-8-$basearch-source-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/network-observability/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Application Interconnect for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhai/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhose-textonly-1-for-middleware-rpms]
+name = Red Hat Middleware Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhose-middleware/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nhc/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-8-$basearch-source-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rodoo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1-for-rhel-8-$basearch-textonly-rpms]
+name = Red Hat OpenShift Builds for RHEL 8 $basearch Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-aus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-aus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.7-rpms]
+name = Red Hat Container Development Kit 3.7 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.19/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[interconnect-2-for-rhel-8-$basearch-source-rpms]
+name = JBoss Interconnect 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/interconnect/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.4-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Tools and Services 4.4 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.9-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.3-for-rhel-8-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.3 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-tus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.15 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-for-rhel-8-$basearch-rpms]
+name = Red Hat CloudForms Management Engine for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cfme/5.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-8-$basearch-debug-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/network-observability/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certificate System 10.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-$basearch-rpms]
+name = Fast Datapath Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.17-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Jaeger 1.17 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/certsys/10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.7 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Gluster Storage 3 Server for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.10 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat AMQ Clients 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-mon-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage MON 4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-mon/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-ee-textonly-rpms]
+name = Red Hat Ansible Automation Platform EE Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform-textonly/ee/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-1-for-rhel-8-$basearch-source-rpms]
+name = mirror registry for Red Hat OpenShift (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.7-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 15 Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.12-for-rhel-8-$basearch-source-rpms]
+name = Logical Volume Manager Storage (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-0.1.3-for-rhel-8-$basearch-files]
+name = Network Observability (Files)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/NETOBSERV/1.0/files
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.16-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.16 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-cinderlib-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.2 Cinderlib for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.6-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat build of Quarkus 1 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-far/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-debug-rpms]
+name = Red Hat Container Development Kit 3.4 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMS)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.12-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.12 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-8-$basearch-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.12-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.12 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certificate System 10.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.14-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.14 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-8-$basearch-rpms]
+name = Red Hat Service Interconnect for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-source-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.15-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[wfk-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Framework Kit Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/wfk/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.12 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.13-for-rhel-8-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4.2-for-rhel-8-$basearch-rpms]
+name = Red Hat Automation Hub 4.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-hub/4.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhceph-tools/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-2.0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Jaeger 2.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/2.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Storage 4 Server (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.2 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-8-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/satellite/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 2.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.17-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.17 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds 1.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1.0-for-rhel-8-$basearch-rpms]
+name = Kernel Module Management 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4.6-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat OpenShift Container Storage 4.6 Server EUS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-8-$basearch-debug-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rodoo/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhgs-client/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-maintenance/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certificate System 10.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1.20-for-rhel-8-$basearch-files]
+name = Red Hat OpenShift Data Science 1.20 for RHEL 8 $basearch (Files)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1.20/files
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.9 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.1-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat build of Quarkus 2.2 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-mdr/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.5-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.11-for-rhel-8-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4.6-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat OpenShift Container Storage 4.6 Server EUS (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-7.3-for-rhel-8-$basearch-rpms]
+name = Red Hat JBoss Data Grid 7.3 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/7.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/dirsrv/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization 4 Management Agents for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-mgmt-agent/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1.20-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Data Science 1.20 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhceph-tools/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.7-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.7 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Management Agents for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-mgmt-agent/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.24-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Jaeger 1.24 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.24/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-nfv-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time for NFV (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/nfv/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Management Agents Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-mgmt-agent/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Builds 1.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.17-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.17 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Kernel Module Management 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.16 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-far/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[custom-metrics-autoscaler-2-for-rhel-8-$basearch-source-rpms]
+name = Custom Metrics Autoscaler 2 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/custom-metrics-autoscaler/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-for-rhel-8-$basearch-rpms]
+name = Red Hat Gluster Storage 3 Server for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.9-rpms]
+name = Red Hat Container Development Kit 3.9 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/certsys/10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-rhui-source-rpms]
+name = JBoss Core Services (RHEL 8) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbcs/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-for-rhel-8-$basearch-rpms]
+name = Red Hat Update Infrastructure 4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhui/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.6-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.6 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat build of Quarkus 3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch (RPMS)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[interconnect-2-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Interconnect 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/interconnect/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.17-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.17 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Migration Toolkit 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.4-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Tools and Services 4.4 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 15 Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoai-2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift AI 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoai/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss AMQ Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/amq/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-utils/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhgs-client/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Gluster Storage 3 Server for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.6-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.6 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.4 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-aus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Advanced Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-rpms]
+name = Red Hat Container Development Kit 3.5 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.8-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.8 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-8-$basearch-debug-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 8 for Red Hat OpenShift (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/osso/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-cinderlib-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.1 Cinderlib for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.0-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Pipelines 1.0 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1-for-rhel-8-$basearch-files]
+name = Red Hat OpenShift Data Science 1 for RHEL 8 $basearch (Files)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1/files
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2.9-for-rhel-8-$basearch-rpms]
+name = Red Hat AMQ Clients 2.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Builds 1.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.10-rpms]
+name = Red Hat Container Development Kit 3.10 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Discovery 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Grid Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jb-datagrid/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-8-$basearch-rpms]
+name = Fast Datapath for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3.62-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3.62 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3.62/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Data Science 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.18/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4.4-manager-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization Manager 4.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-manager/4.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-rhui-debug-rpms]
+name = JBoss Core Services (RHEL 8) (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbcs/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-8-$basearch-source-rpms]
+name = JBoss Web Server 5 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-8-$basearch-source-rpms]
+name = JBoss Web Server 6 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-rhui-source-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.13-for-rhel-8-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Data Science 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-4.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability 4.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa/4.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-beta-for-rhel-8-$basearch-debug-rpms]
+name = Advanced Virtualization Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.18/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.17-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.17 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nhc/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMS)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.14-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.14 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift distributed tracing 3 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-utils/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.8 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-8-$basearch-debug-rpms]
+name = Single Sign-On 7.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.5-for-rhel-8-$basearch-rpms]
+name = Single Sign-On 7.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-debug-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Discovery 0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.12-rpms]
+name = Red Hat Container Development Kit 3.12 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-1-for-rhel-8-$basearch-rpms]
+name = Red Hat build of Quarkus 1 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.14-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.14 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-utils/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Extended Update Support (RPMS)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.9-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.9 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.12-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.12 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[soa-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss SOA Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/soa/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.17-rpms]
+name = Red Hat Container Development Kit 3.17 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.17/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-mon-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage MON 4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-mon/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoai-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift AI 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoai/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Extended Update Support (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.10 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat CloudForms Management Engine for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cfme/5.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.16-rpms]
+name = Red Hat Container Development Kit 3.16 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Management Agents for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-mgmt-agent/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift distributed tracing 3 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-8-$basearch-rhui-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel8/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Migration Toolkit 1.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-1-for-rhel-8-$basearch-debug-rpms]
+name = JBoss AMQ Interconnect 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq-interconnect/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.2-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-debug-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 2.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.6 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-mgmt-agent-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization 4 Management Agents Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-mgmt-agent/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16 Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.4-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.3 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat build of Quarkus 1 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Application Interconnect for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhai/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-textonly-1-for-middleware-rpms]
+name = Red Hat build of Quarkus Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/quarkus/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmtc-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Migration Toolkit for Containers for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmtc/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-8-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Update Infrastructure 4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhui/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 15 Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cluster-observability-operator-1-for-rhel-8-$basearch-textonly-debug-rpms]
+name = Cluster Observability Operator (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cluster-observability-operator/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3.62-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3.62 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3.62/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.17-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Jaeger 1.17 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-rpms]
+name = JBoss Core Services (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbcs/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-8-$basearch-source-rpms]
+name = Single Sign-On 7.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-s390x-debug-rpms]
+name = Fast Datapath Beta for RHEL 8 IBM z Systems (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/s390x/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-1-for-rhel-8-$basearch-rpms]
+name = mirror registry for Red Hat OpenShift (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.5 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-8-$basearch-debug-rpms]
+name = Fast Datapath for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-for-rhel-8-$basearch-rpms]
+name = Advanced Virtualization CodeReady Builder for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt-crb/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-1-for-rhel-8-$basearch-rhui-rpms]
+name = JBoss Core Services (RHEL 8) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbcs/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Service Interconnect for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.7-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.7 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2-for-rhel-8-$basearch-rpms]
+name = Red Hat build of Quarkus 2 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoss-1.29-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Openshift Serverless 1.29 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1.29/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[3scale-amp-2-rpms-for-rhel-8-$basearch-source-rpms]
+name = Red Hat 3scale API Management Platform 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/3scale-amp/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.0-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Pipelines 1.0 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-rt-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/rt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.17/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.2 Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.13-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.12-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.12 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.1 Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosds-textonly-3-for-middleware-rpms]
+name = Red Hat OpenShift Dev Spaces 3 Container Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhosds/3.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.22-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Jaeger 1.22.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.22/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-devtools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 15 Developer Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.10-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.10 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.6-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/codeready-builder/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1506298485616549519-key.pem
+sslclientcert = /etc/pki/entitlement/1506298485616549519.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[rhel-atomic-7-cdk-3.4-source-rpms]
+name = Red Hat Container Development Kit 3.4 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds 1.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.16 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-tech-preview-for-rhel-8-$basearch-rpms]
+name = Red Hat Automation Services Catalog 1 Tech Preview for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-services-catalog-tech-preview/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-8-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.1-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Pipelines 1.1 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.5-for-rhel-8-$basearch-source-rpms]
+name = Single Sign-On 7.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-ocs-4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Storage 4 Server (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocs-server/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certificate System 10.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.0-early-access-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.0 Early Access for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.11-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat CloudForms Management Engine for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cfme/5.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Builds for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jpp-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Portal Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jpp/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat AMQ Clients 2.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-tech-preview-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Automation Services Catalog 1 Tech Preview for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-services-catalog-tech-preview/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.15-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhvh-4-build-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization Host Build for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhvh-build/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Migration Toolkit 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Automation Hub 4.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-hub/4.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 2.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-2-for-rhel-8-$basearch-rpms]
+name = mirror registry for Red Hat OpenShift for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.3-for-rhel-8-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.3 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-devtools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16 Developer Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.7 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.6-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.6 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Automation Services Catalog 1 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-services-catalog/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.17-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.17 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.17/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-8-$basearch-source-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel8/$basearch/openjdk/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4.4-manager-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization Manager 4.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-manager/4.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[custom-metrics-autoscaler-2-for-rhel-8-$basearch-rpms]
+name = Custom Metrics Autoscaler 2 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/custom-metrics-autoscaler/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.11-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certificate System 10.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.12-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/dirsrv/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-rpms]
+name = Red Hat Container Development Kit 3.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-3-for-rhel-8-$basearch-rpms]
+name = Red Hat AMQ Clients 3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.8-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.8 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Update Infrastructure 4 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhui/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.1-for-rhel-8-$basearch-rpms]
+name = OpenShift Pipelines 1.1 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/certsys/10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-5-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.13-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.13 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-s390x-rpms]
+name = Fast Datapath Beta for RHEL 8 IBM z Systems (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/s390x/fast-datapath/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-client/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/certsys/10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-0.1.3-for-rhel-8-$basearch-source-rpms]
+name = Network Observability (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/NETOBSERV/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMS)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-2-for-rhel-8-$basearch-source-rpms]
+name = mirror registry for Red Hat OpenShift for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Directory Server 11.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-source-rpms]
+name = Red Hat Container Development Kit 2.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack-deployment-tools/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Discovery 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/supplementary/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.9 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Migration Toolkit 1.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-tus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-8-$basearch-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/baseos/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[custom-metrics-autoscaler-2-for-rhel-8-$basearch-debug-rpms]
+name = Custom Metrics Autoscaler 2 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/custom-metrics-autoscaler/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMS)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-rt-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/rt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/17.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Directory Server 11.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nmo/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-snr/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-samba-for-rhel-8-$basearch-rpms]
+name = Red Hat Gluster Storage 3 Samba for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-samba/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certificate System 10.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.18-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.18 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Builds 1.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-cinderlib-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.1 Cinderlib for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Update Infrastructure 4 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhui/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Automation Hub 4 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-hub/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Virtualization 4 Tools Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-tools/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Data Foundation (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhodf/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - 4 years of updates (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/dirsrv/11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhsi-textonly-1-for-middleware-rpms]
+name = Red Hat Service Interconnect Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhsi/1/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 8.4 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-capsule/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-capsule/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.13 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/resilientstorage/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-debug-rpms]
+name = Red Hat Container Development Kit 3.5 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhbop-textonly-1-for-middleware-rpms]
+name = Red Hat Build of OptaPlanner Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/6/6Server/$basearch/rhbop-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-1.0-for-rhel-8-$basearch-source-rpms]
+name = Kernel Module Management 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 2.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-client/3.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/ansible/2.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-7.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 7.3 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/7.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.5-for-rhel-8-$basearch-debug-rpms]
+name = Single Sign-On 7.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-0.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Devworkspace 0.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/0.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Tools Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.11-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.11-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.11 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/beta/layered/rhui/rhel8/$basearch/sat-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmtc-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Migration Toolkit for Containers for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmtc/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.19/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/appstream/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1506298485616549519-key.pem
+sslclientcert = /etc/pki/entitlement/1506298485616549519.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[pipelines-1.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.5 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Automation Hub 4.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/automation-hub/4.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmtc-for-rhel-8-$basearch-rpms]
+name = Red Hat Migration Toolkit for Containers for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmtc/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1.20-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Science 1.20 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1.20/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Quay 3.11 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quay/3.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.0-early-access-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.0 Early Access for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-beta-for-rhel-8-$basearch-rpms]
+name = Advanced Virtualization Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Migration Toolkit 1.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.11-for-rhel-8-$basearch-debug-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.19-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.19 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.19/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.9-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.9 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nmo-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Maintenance Operator 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nmo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-cinderlib-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.1 Cinderlib for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-textonly-1-for-middleware-rpms]
+name = Single Sign-On Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/rh-sso/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-8-$basearch-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel8/$basearch/openjdk/11/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.15-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.15 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cfme-5.11-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat CloudForms Management Engine 5.11 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/cfme/5.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-devtools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16 Developer Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-tus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.2-for-rhel-8-$basearch-source-rpms]
+name = JBoss Enterprise Application Platform 7.2 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.13-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.13 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.18-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.18 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.18/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Utils 6.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jon-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Operations Network Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jon/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Automation Hub 4 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-hub/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-aus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Advanced Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-aus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.2-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Developer 1.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-4.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Workload Availability 4.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa/1.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-manager-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization Manager 4 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-manager/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch (Source RPMS)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client-2/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoss-1.29-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Openshift Serverless 1.29 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1.29/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-8-$basearch-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.24-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Jaeger 1.24 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.24/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.5-for-rhel-8-$basearch-rpms]
+name = OpenShift Tools and Services 4.5 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.16-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.3 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-8-$basearch-rpms]
+name = Red Hat Certification for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Service Interconnect 1.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[3scale-amp-2-rpms-for-rhel-8-$basearch-rpms]
+name = Red Hat 3scale API Management Platform 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/3scale-amp/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-services-catalog-1-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Automation Services Catalog 1 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-services-catalog/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rh-sso/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.7-for-rhel-8-$basearch-rpms]
+name = Red Hat Directory Server 11.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.4-rpms]
+name = Red Hat Container Development Kit 3.4 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-tus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Science 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.20-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Jaeger 1.20.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-tus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Virtualization 4 Tools Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhv-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-for-rhel-8-$basearch-debug-rpms]
+name = Advanced Virtualization CodeReady Builder for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt-crb/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.1-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.10-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-0.10-for-rhel-8-$basearch-rpms]
+name = Red Hat Devworkspace 0.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/0.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.0-for-rhel-8-$basearch-rpms]
+name = JBoss Enterprise Application Platform 8.0 (RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.3 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Data Science 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cluster-observability-operator-1-for-rhel-8-$basearch-textonly-rpms]
+name = Cluster Observability Operator (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cluster-observability-operator/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-odf-4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Foundation (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhodf/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/sap-solutions/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.4-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-1-textonly-rpms]
+name = Red Hat Discovery 1 Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery-textonly/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.12-for-rhel-8-$basearch-debug-rpms]
+name = Logical Volume Manager Storage (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-maintenance/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-tus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.5-source-rpms]
+name = Red Hat Container Development Kit 3.5 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-aus-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.9-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.9 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.10-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.10 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[application-interconnect-1-for-rhel-8-$basearch-rpms]
+name = Red Hat Application Interconnect for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhai/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-cinderlib-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16 Cinderlib for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-2-for-rhel-8-$basearch-debug-rpms]
+name = mirror registry for Red Hat OpenShift for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-8-$basearch-debug-rpms]
+name = Kernel Module Management 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-8-$basearch-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 8 for Red Hat OpenShift (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/osso/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.8-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-2.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Jaeger 2.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/2.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-snr-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Self Node Remediation 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-snr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.3-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Tools and Services 4.3 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[discovery-0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Discovery 0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/discovery/0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/codeready-builder/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rodoo-1-for-rhel-8-$basearch-rpms]
+name = Run Once Duration Override Operator (RODOO) 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rodoo/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.7-for-rhel-8-$basearch-source-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert-manager/1.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-osd-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage OSD 4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-osd/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.1-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Pipelines 1.1 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Builds 1.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[kmm-2-for-rhel-8-$basearch-source-rpms]
+name = Kernel Module Management 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/kmm/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-debug-rpms]
+name = Red Hat Container Development Kit 3.3 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-6-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[source-to-image-1-for-rhel-8-$basearch-rpms]
+name = OpenShift Source-to-Image 1 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/source-to-image/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Service Interconnect 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Directory Server 11.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.15 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-cinderlib-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.2 Cinderlib for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16 Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-mdr-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Machine Deletion Remediation Operator 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-mdr/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.7-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Directory Server 11.7 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Web Server 6 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Telecommunications Update Service (RPMS)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-client-2/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.0-early-access-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.0 Early Access for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.11-for-rhel-8-$basearch-source-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-source-rpms]
+name = Red Hat Container Development Kit 3.6 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.16-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-beta-for-rhel-8-$basearch-source-rpms]
+name = Advanced Virtualization Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[3scale-amp-2-rpms-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat 3scale API Management Platform 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/3scale-amp/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.3-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Tools and Services 4.3 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-source-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/resilientstorage/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-nfv-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time for NFV (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/nfv/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.7-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-ironic-4.12-for-rhel-8-$basearch-rpms]
+name = Ironic content for Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp-ironic/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-8-$basearch-rhui-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/els/layered/rhui/rhel8/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.10-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/highavailability/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Service Interconnect 1.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-3-for-rhel-8-$basearch-rpms]
+name = Red Hat build of Quarkus 3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/17.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-12-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-2.3-rpms]
+name = Red Hat Container Development Kit 2.3 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/2.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-eus-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.16 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-8-$basearch-debug-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.11-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.11 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.14-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-client/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-clients-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat AMQ Clients 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-0.1.3-for-rhel-8-$basearch-debug-rpms]
+name = Network Observability (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/NETOBSERV/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-aus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Advanced Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.6-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.15-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Update Infrastructure 4 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/rhui/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certification for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-eus-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/advanced-virt/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Pipelines 1.14 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certificate System 10.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.16-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.16 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.16/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-far-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Workload Availability - Fence Agents Remediation Operator 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-far/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-eus-debug-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/advanced-virt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.13-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.13 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jdv-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Data Virtualization Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jdv/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Data Science 1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.13-for-rhel-8-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Directory Server 11 for RHEL 8 $basearch - 4 years of updates (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/dirsrv/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-serverless-1-for-rhel-8-$basearch-rpms]
+name = Red Hat Openshift Serverless 1 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoss/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Migration Toolkit 1.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-e4s-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Update Services for SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/appstream/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.4-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.4 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.16-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.0-for-rhel-8-$basearch-rpms]
+name = OpenShift Pipelines 1.0 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 8.1 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.10-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.10 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-manager-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization Manager 4 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.9-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack-deployment-tools/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.2-for-rhel-8-$basearch-rpms]
+name = JBoss Enterprise Application Platform 7.2 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-rhui-source-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbeap/7.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-rhui-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/beta/layered/rhui/rhel8/$basearch/sat-tools/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-beta-for-rhel-8-$basearch-source-rpms]
+name = Advanced Virtualization CodeReady Builder Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt-crb/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-7.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat JBoss Data Grid 7.3 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/7.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[service-interconnect-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Service Interconnect for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhsi/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-devtools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16 Developer Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 2.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.15-rpms]
+name = Red Hat Container Development Kit 3.15 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 1.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-$basearch-debug-rpms]
+name = Fast Datapath Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/fast-datapath/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.3-for-rhel-8-$basearch-rpms]
+name = OpenShift Tools and Services 4.3 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-0.1.3-for-rhel-8-$basearch-rpms]
+name = Network Observability (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/NETOBSERV/0.1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Devworkspace 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.5-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Tools and Services 4.5 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.14-rpms]
+name = Red Hat Container Development Kit 3.14 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.4-for-rhel-8-$basearch-debug-rpms]
+name = Single Sign-On 7.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-nfs-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Gluster Storage 3 NFS for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-nfs/3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift distributed tracing 2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/codeready-builder/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoar-nodejs-12-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Application Runtimes Node.js v12 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoar-nodejs/12/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-osd-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage OSD 4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-osd/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.13-for-rhel-8-$basearch-rpms]
+name = Logical Volume Manager Storage 4.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.12-for-rhel-8-$basearch-rpms]
+name = Logical Volume Manager Storage (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-beta-for-rhel-8-$basearch-debug-rpms]
+name = Advanced Virtualization CodeReady Builder Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/advanced-virt-crb/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.8 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-aus-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Advanced Mission Critical Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacs-3.62-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Security for Kubernetes 3.62 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacs/3.62/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-7-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage Tools 7 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[dirsrv-11.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Directory Server 11.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/dirsrv/11.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-coreservices-textonly-1-for-middleware-rhui-rpms]
+name = Red Hat JBoss Core Services Text-Only Advisories from RHUI
+baseurl = https://cdn.redhat.com/content/dist/middleware/rhui/jbcs/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[network-observability-1-for-rhel-8-$basearch-rpms]
+name = Network Observability (NETOBSERV) 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/network-observability/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-tus-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Telecommunications Update Service (RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-client/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-devtools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 15 Developer Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-devtools/15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16-cinderlib-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 16 Cinderlib for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-cinderlib/16/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.15-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.15 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.4-for-rhel-8-$basearch-rpms]
+name = OpenShift Tools and Services 4.4 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat Ceph Storage Tools 4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openliberty-textonly-1-for-middleware-rpms]
+name = Open Liberty Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/openliberty/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file://
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[mirror-registry-1-for-rhel-8-$basearch-debug-rpms]
+name = mirror registry for Red Hat OpenShift (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/mirror-registry/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-rpms]
+name = Red Hat Container Development Kit 3.6 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[codeready-builder-for-rhel-8-$basearch-eus-rhui-source-rpms]
+name = Red Hat CodeReady Linux Builder for RHEL 8 $basearch - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Capsule 6.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[source-to-image-1-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Source-to-Image 1 (for RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/source-to-image/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.6-for-rhel-8-$basearch-tus-source-rpms]
+name = Red Hat Satellite Tools 6.6 for RHEL 8 $basearch - Telecommunications Update Service (Source RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.2 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-for-rhel-8-$basearch-source-rpms]
+name = Fast Datapath for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.12 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Container Platform 4.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.1-for-rhel-8-$basearch-rpms]
+name = Red Hat JBoss Data Grid 8.1 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Service Mesh 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[amq-interconnect-1-for-rhel-8-$basearch-rpms]
+name = JBoss AMQ Interconnect 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/amq-interconnect/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/sap-solutions/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.12-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 4.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.13-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.13 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-8.1-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 8.1 (RHEL 8 $basearch) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/8.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-beta-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6 Beta for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/satellite/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[source-to-image-1-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Source-to-Image 1 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/source-to-image/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-tools-for-rhel-8-$basearch-rhui-debug-rpms]
+name = Red Hat OpenStack Platform 15 Tools for RHEL 8 $basearch (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/openstack-tools/15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Engine 2.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/baseos/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/1506298485616549519-key.pem
+sslclientcert = /etc/pki/entitlement/1506298485616549519.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 1
+
+[rhel-8-for-$basearch-sap-netweaver-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.14-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.14 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.14/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosdt-2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift distributed tracing 2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosdt/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.5-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.5 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Capsule 6.13 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/supplementary/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 2.2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.6-debug-rpms]
+name = Red Hat Container Development Kit 3.6 /(Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.4-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.4 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.7-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Pipelines 1.7 (for RHEL 8 $basearch) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Automation Platform 2.1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh 1.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-tools/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhwa-nhc-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Workload Availability - Node Healthcheck Operator 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhwa-nhc/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-e4s-source-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch - Update Services SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.2-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds 1.2 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openjdk-11-els-for-rhel-8-$basearch-debug-rpms]
+name = OpenJDK Java 11 Extended Life Cycle Support for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/els/layered/rhel8/$basearch/openjdk/11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.1-for-rhel-8-$basearch-rpms]
+name = Red Hat Migration Toolkit 1.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhv-4-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Virtualization 4 Tools for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhv-tools/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cluster-observability-operator-1-for-rhel-8-$basearch-textonly-source-rpms]
+name = Cluster Observability Operator (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cluster-observability-operator/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Data Science 1 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Service Mesh for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-samba-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Gluster Storage 3 Samba for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-samba/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-ember-0.9-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Ember-CSI 0.9 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-ember/0.9/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/16.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Certificate System 10 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/certsys/10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-capsule-6.12-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Capsule 6.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-capsule/6.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.6-for-rhel-8-$basearch-rpms]
+name = Red Hat Certificate System 10.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[fast-datapath-beta-for-rhel-8-$basearch-source-rpms]
+name = Fast Datapath Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/fast-datapath/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-tools/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhui-4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Update Infrastructure 4 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhui/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.13-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.13 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.13/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-eus-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Extended Update Support (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sap/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.4-for-rhel-8-$basearch-rhui-rpms]
+name = JBoss Enterprise Application Platform 7.4 (RHEL 8) (RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/jbeap/7.4/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.9-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 16.2 Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.2/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-e4s-debug-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Update Services SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.7/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.5-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.5 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-e4s-rhui-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Update Services for SAP Solutions from RHUI (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/highavailability/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-1.20-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Jaeger 1.20.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/1.20/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.5-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-manager-1.7-for-rhel-8-$basearch-rpms]
+name = Cert Manager support for Red Hat OpenShift 1.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert-manager/1.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.4-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.4 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhosj-2.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Jaeger 2.0 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhosj/2.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Developer 1.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhods-1.20-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Data Science 1.20 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhods/1.20/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-15-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform 15 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack/15/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-nfv-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time for NFV (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/nfv/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-client/3.5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-resilientstorage-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Resilient Storage (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/resilientstorage/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.7-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.7 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-textonly-1-for-middleware-rpms]
+name = Red Hat JBoss Web Server Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/middleware/jws/1.0/$basearch/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.2-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-e4s-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Update Services for SAP Solutions (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.3-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.3 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/appstream/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-6-for-rhel-8-$basearch-rpms]
+name = JBoss Web Server 6 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 4.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-8-tools-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ceph Storage Tools 8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-tools/8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite 6.11 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-client-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Storage Native Client for RHEL 8 (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/rhgs-client/3.5/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-datagrid-8.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat JBoss Data Grid 8.1 (RHEL 8) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jdg/8.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2-for-rhel-8-$basearch-textonly-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2 Text-Only Advisories
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm-textonly/2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[lvms-4.14-for-rhel-8-$basearch-source-rpms]
+name = Logical Volume Manager Storage 4.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/lvms/4.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-developer-1.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Developer 1.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-developer/1.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1.3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.15-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite 6.15 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.15/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.12-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.6 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-highavailability-eus-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - High Availability - Extended Update Support from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/highavailability/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.3-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Certificate System 10.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-client-6-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Client 6 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-client/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.0 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.4-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Container Native Virtualization 2.4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhceph-4-osd-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ceph Storage OSD 4 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhceph-osd/4/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.5-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Container Platform 4.5 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.5/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.7-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift GitOps 1.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quarkus-2.2-for-rhel-8-$basearch-rpms]
+name = Red Hat build of Quarkus 2.2 (RHEL 8) (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quarkus/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6.16-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite 6.16 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/satellite/6.16/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-eus-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Extended Update Support from RHUI (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/rhui/8/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-stf-1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform Service Telemetry Framework 1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-stf/1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jb-eap-7.3-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Enterprise Application Platform 7.3 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jbeap/7.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.14-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Maintenance 6.14 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.14/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-aus-debug-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Advanced Mission Critical Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/aus/rhel8/8/$basearch/sat-tools/6.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.6-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.6 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-tools/6.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-4.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Container Native Virtualization 4.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/4.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.8-rpms]
+name = Red Hat Container Development Kit 3.8 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.8/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-2.9-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Ansible Engine 2.9 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible/2.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-eus-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.9-for-rhel-8-$basearch-eus-debug-rpms]
+name = Red Hat Satellite Tools 6.9 for RHEL 8 $basearch - Extended Update Support (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/sat-tools/6.9/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.8-for-rhel-8-$basearch-source-rpms]
+name = OpenShift Developer Tools and Services 4.8 (RHEL 8) ($basearch Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.2-for-rhel-8-$basearch-rpms]
+name = Red Hat Ansible Automation Platform 2.2 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenStack Platform Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/openstack/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-appstream-eus-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - AppStream - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-6-client-2-for-rhel-8-$basearch-tus-debug-rpms]
+name = Red Hat Satellite 6 Client 2 for RHEL 8 $basearch - Telecommunications Update Service (Debug RPMS)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/sat-client-2/6/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ansible-automation-platform-2.1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Ansible Automation Platform 2.1 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ansible-automation-platform/2.1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhoai-2-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift AI 2 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhoai/2/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.3-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Builds 1.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-rhui-source-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions from RHUI (Source RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/rhui/8/$basearch/sap/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-solutions-rhui-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP Solutions (Debug RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/rhel8/rhui/8/$basearch/sap-solutions/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-utils-6.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Utils 6.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-utils/6.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-baseos-tus-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - BaseOS - Telecommunications Update Service (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/tus/rhel8/8/$basearch/baseos/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-gluster-3-nfs-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Gluster Storage 3 NFS for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhgs-server-nfs/3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.13-rpms]
+name = Red Hat Container Development Kit 3.13 /(RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.3-for-rhel-8-$basearch-debug-rpms]
+name = Single Sign-On 7.3 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.3/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.8/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.7-for-rhel-8-$basearch-rhui-source-rpms]
+name = Red Hat Satellite Tools 6.7 for RHEL 8 $basearch (Source RPMs) from RHUI
+baseurl = https://cdn.redhat.com/content/dist/layered/rhui/rhel8/$basearch/sat-tools/6.7/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cert-1-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Certification for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cert/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-17.1-deployment-tools-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenStack Platform 17.1 Director Deployment Tools for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/17.1/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.10-for-rhel-8-$basearch-e4s-rpms]
+name = Red Hat Satellite Tools 6.10 for RHEL 8 $basearch - Update Services SAP Solutions (RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sat-tools/6.10/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[osso-1-for-rhel-8-$basearch-source-rpms]
+name = Secondary Scheduler Operator 1 for RHEL 8 for Red Hat OpenShift (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/osso/1/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.12-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.12 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.12/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[automation-hub-4-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Automation Hub 4 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/automation-hub/4/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[quay-3.11-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Quay 3.11 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/quay/3.11/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[jws-5-for-rhel-8-$basearch-debug-rpms]
+name = JBoss Web Server 5 (RHEL 8) (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/jws/5/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.0-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Builds for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.0/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-16.2-deployment-tools-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform 16.2 Director Deployment Tools for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-deployment-tools/16.2/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ossm-2.1-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenShift Service Mesh 2.1 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ossm/2.1/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[devworkspace-0.10-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Devworkspace 0.10 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/devworkspace/0.10/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-crb-for-rhel-8-$basearch-source-rpms]
+name = Advanced Virtualization CodeReady Builder for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/advanced-virt-crb/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.13/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.12-for-rhel-8-$basearch-rpms]
+name = Red Hat Satellite Maintenance 6.12 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.12/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.11-for-rhel-8-$basearch-debug-rpms]
+name = OpenShift Developer Tools and Services 4.11 (RHEL 8) ($basearch Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.11/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-rt-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Real Time (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/rt/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-atomic-7-cdk-3.3-source-rpms]
+name = Red Hat Container Development Kit 3.3 /(Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/cdk/3.3/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhmt-1.0-for-rhel-8-$basearch-rpms]
+name = Red Hat Migration Toolkit 1.0 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhmt/1.0/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-supplementary-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - Supplementary (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/8/$basearch/supplementary/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[pipelines-1.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift Pipelines 1.14 (for RHEL 8 $basearch) (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[gitops-1.6-for-rhel-8-$basearch-source-rpms]
+name = Red Hat OpenShift GitOps 1.6 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/gitops/1.6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6.14-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6.14 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-maintenance/6.14/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rh-sso-7.6-for-rhel-8-$basearch-rpms]
+name = Single Sign-On 7.6 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rh-sso/7.6/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[certsys-10.3-for-rhel-8-$basearch-rpms]
+name = Red Hat Certificate System 10.3 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/certsys/10.3/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[ocp-tools-4.15-for-rhel-8-$basearch-rpms]
+name = OpenShift Developer Tools and Services 4.15 (RHEL 8) ($basearch RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/ocp-tools/4.15/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-8-for-$basearch-sap-netweaver-e4s-debug-rpms]
+name = Red Hat Enterprise Linux 8 for $basearch - SAP NetWeaver - Update Services for SAP Solutions (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/e4s/rhel8/8/$basearch/sap/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhacm-2.13-for-rhel-8-$basearch-rpms]
+name = Red Hat Advanced Cluster Management for Kubernetes 2.13 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhacm/2.13/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-tools-6.8-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Tools 6.8 for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/sat-tools/6.8/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[advanced-virt-for-rhel-8-$basearch-eus-source-rpms]
+name = Advanced Virtualization for RHEL 8 $basearch - Extended Update Support (Source RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel8/8/$basearch/advanced-virt/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openshift-builds-1.0-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Builds for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openshift-builds/1.0/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[satellite-maintenance-6-beta-for-rhel-8-$basearch-source-rpms]
+name = Red Hat Satellite Maintenance 6 Beta for RHEL 8 $basearch (Source RPMs)
+baseurl = https://cdn.redhat.com/content/beta/layered/rhel8/$basearch/sat-maintenance/6/source/SRPMS
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[openstack-ember-0.9-for-rhel-8-$basearch-rpms]
+name = Red Hat OpenStack Platform Ember-CSI 0.9 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/openstack-ember/0.9/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[cnv-2.7-for-rhel-8-$basearch-rpms]
+name = Red Hat Container Native Virtualization 2.7 for RHEL 8 $basearch (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/cnv/2.7/os
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhocp-4.10-for-rhel-8-$basearch-debug-rpms]
+name = Red Hat OpenShift Container Platform 4.10 for RHEL 8 $basearch (Debug RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.10/debug
+enabled = 0
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/4350402264171663734-key.pem
+sslclientcert = /etc/pki/entitlement/4350402264171663734.pem
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0

--- a/ztp/resource-generator/.konflux/rpms.in.yaml
+++ b/ztp/resource-generator/.konflux/rpms.in.yaml
@@ -1,0 +1,12 @@
+contentOrigin:
+  repofiles:
+     - ./redhat.repo
+
+packages:
+  [tar, util-linux]
+
+arches:
+  - x86_64
+
+context:
+    containerfile: ../Containerfile

--- a/ztp/resource-generator/.konflux/rpms.lock.yaml
+++ b/ztp/resource-generator/.konflux/rpms.lock.yaml
@@ -1,0 +1,99 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/cracklib-2.9.6-15.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 95532
+    checksum: sha256:9cf2e24fdbe89f25b8283291fd3fcaf73ca60554bbf5767932c38882cdd0e3c4
+    name: cracklib
+    evr: 2.9.6-15.el8
+    sourcerpm: cracklib-2.9.6-15.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-15.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 4144880
+    checksum: sha256:3423075b5f924b1512e91fb5c8532ef2768cd2b1b9591e4a2ac3b76d99aa380d
+    name: cracklib-dicts
+    evr: 2.9.6-15.el8
+    sourcerpm: cracklib-2.9.6-15.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/g/gzip-1.9-13.el8_5.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 170828
+    checksum: sha256:7f80be301cda8a6af027f15898058b1f62a0069f347a84aecb2a9c7b4c6d1ef7
+    name: gzip
+    evr: 1.9-13.el8_5
+    sourcerpm: gzip-1.9-13.el8_5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libfdisk-2.32.1-46.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 260128
+    checksum: sha256:e7793c66af8f2cdd7893527bc81971e50f985f27c67dc22bbf118e3e0468f1a9
+    name: libfdisk
+    evr: 2.32.1-46.el8
+    sourcerpm: util-linux-2.32.1-46.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libnsl2-1.2.0-2.20180605git4a062cf.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 59120
+    checksum: sha256:f7e60c8a5eaf056a9c67834671561196b961fba7bc763568f1c01c3ab998bb46
+    name: libnsl2
+    evr: 1.2.0-2.20180605git4a062cf.el8
+    sourcerpm: libnsl2-1.2.0-2.20180605git4a062cf.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-6.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 109704
+    checksum: sha256:ae3dfbc6ca432681b137f76bee081735d61c65db986b1238ed7837e3112d3180
+    name: libpwquality
+    evr: 1.4.4-6.el8
+    sourcerpm: libpwquality-1.4.4-6.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libsemanage-2.9-11.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 172936
+    checksum: sha256:2fbbded84101ff93c19bdaebf7b05c2950654b010c37ba5de13d7a0342bd634b
+    name: libsemanage
+    evr: 2.9-11.el8_10
+    sourcerpm: libsemanage-2.9-11.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libtirpc-1.1.4-12.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 116808
+    checksum: sha256:d35b01a79f17bcaca9a774fa78136acadabf6f627db43b7dca43a83a63afffa4
+    name: libtirpc
+    evr: 1.1.4-12.el8_10
+    sourcerpm: libtirpc-1.1.4-12.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/l/libutempter-1.1.6-14.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 32564
+    checksum: sha256:ebc4d394a251feba7e1025d7f8ba61e619c2a6fc14229482bf28096e49cef520
+    name: libutempter
+    evr: 1.1.6-14.el8
+    sourcerpm: libutempter-1.1.6-14.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/p/pam-1.3.1-36.el8_10.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 765548
+    checksum: sha256:92bb7478c5945f4c83f748197ffb3ead918ba55e2d08448be6bafdbafbc2c821
+    name: pam
+    evr: 1.3.1-36.el8_10
+    sourcerpm: pam-1.3.1-36.el8_10.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/s/shadow-utils-4.6-22.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 1292332
+    checksum: sha256:ea73ee201451bbca0d6d14ca434c93800f01c8fb1b9daef727a5af1a27356d07
+    name: shadow-utils
+    evr: 2:4.6-22.el8
+    sourcerpm: shadow-utils-4.6-22.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/t/tar-1.30-9.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 858812
+    checksum: sha256:6b0dc7341d743c89fa038292a7e04761ebb6cc98208ebc26dee9f01e2c1a9529
+    name: tar
+    evr: 2:1.30-9.el8
+    sourcerpm: tar-1.30-9.el8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/Packages/u/util-linux-2.32.1-46.el8.x86_64.rpm
+    repoid: rhel-8-for-x86_64-baseos-rpms
+    size: 2597616
+    checksum: sha256:1accef88d06655139903a7b4aa6a01cab62b3c899a93d297cb7ac92a476abed6
+    name: util-linux
+    evr: 2.32.1-46.el8
+    sourcerpm: util-linux-2.32.1-46.el8.src.rpm
+  source: []
+  module_metadata: []

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -1,5 +1,6 @@
 # Builder
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.21 as builder
+#
 ARG IMAGE_REF
 USER root
 ENV PKG_ROOT=cnf-features-deploy
@@ -23,6 +24,7 @@ RUN make build-pgt-plugin
 
 # Container image
 FROM ubi8-minimal
+#
 USER root
 ENV BUILDER_ZTP=/go/src/cnf-features-deploy/ztp
 ENV ZTP_HOME=/home/ztp


### PR DESCRIPTION
This PR backports all konflux changes related to ztp-site-generate to release-4.16

- Add tekton pipeline files and konflux RPM lockfile
- Add owners for tekton files