### PR TITLE
infra: lock gitmodule branches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,15 @@
 [submodule "cnf-tests/submodules/metallb-operator"]
 	path = cnf-tests/submodules/metallb-operator
 	url = https://github.com/openshift/metallb-operator.git
+	branch = release-4.19
 [submodule "cnf-tests/submodules/sriov-network-operator"]
 	path = cnf-tests/submodules/sriov-network-operator
 	url = https://github.com/openshift/sriov-network-operator.git
+	branch = release-4.19
 [submodule "cnf-tests/submodules/cluster-node-tuning-operator"]
 	path = cnf-tests/submodules/cluster-node-tuning-operator
 	url = https://github.com/openshift/cluster-node-tuning-operator.git
+	branch = release-4.19
 [submodule "ztp/resource-generator/telco-reference"]
 	path = ztp/resource-generator/telco-reference
 	url = https://github.com/openshift-kni/telco-reference.git


### PR DESCRIPTION
This PR locks release branch in gitmodules for release-4.19 