### PR TITLE
Upversion golang to 1.23 in release-4.19

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,15 +2,19 @@
 	path = cnf-tests/submodules/metallb-operator
 	url = https://github.com/openshift/metallb-operator.git
 	branch = release-4.19
+#
 [submodule "cnf-tests/submodules/sriov-network-operator"]
 	path = cnf-tests/submodules/sriov-network-operator
 	url = https://github.com/openshift/sriov-network-operator.git
 	branch = release-4.19
+#
 [submodule "cnf-tests/submodules/cluster-node-tuning-operator"]
 	path = cnf-tests/submodules/cluster-node-tuning-operator
 	url = https://github.com/openshift/cluster-node-tuning-operator.git
 	branch = release-4.19
+#
 [submodule "ztp/resource-generator/telco-reference"]
 	path = ztp/resource-generator/telco-reference
 	url = https://github.com/openshift-kni/telco-reference.git
 	branch = release-4.19
+#

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,7 @@ module github.com/openshift-kni/cnf-features-deploy
 //   - openshift-ci/Dockerfile*
 //   - ztp/resource-generator/Containerfile
 //   - ztp/tools/pgt2acmpg/go.mod
-go 1.22
-toolchain go1.22.5
+go 1.23
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.22 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.23 as builder
 #
 ARG IMAGE_REF
 USER root


### PR DESCRIPTION
This PR:

- Upversions go mod file to 1.23
- Upversion container builder image to 1.23
- Adds a comment # in .gitmodules to fix Renovate parsing