### PR TITLE
cnf-tests: tekton: misplaced additional_tags

### DIFF
--- a/.tekton/cnf-tests-4-19-push.yaml
+++ b/.tekton/cnf-tests-4-19-push.yaml
@@ -49,8 +49,6 @@ spec:
         params:
           - name: IMAGE_URL
             value: $(tasks.build-image-index.results.IMAGE_URL)
-          - name: ADDITIONAL_TAGS
-            value: ["latest"]
         taskRef:
           params:
             - name: name
@@ -557,6 +555,8 @@ spec:
         params:
           - name: IMAGE
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: ADDITIONAL_TAGS
+            value: ["latest"]
         runAfter:
           - build-image-index
         taskRef:


### PR DESCRIPTION
Fix misplaced ADDITIONAL_TAGS, should be under the `apply-tags` task.