### PR TITLE
infra:renovate:configure submodules bumps differently for different dirs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,23 @@
         ]
     },
     "git-submodules": {
-        "enabled": true
+        "enabled": true,
+        "packageRules": [
+            {
+                "includePaths": [
+                    "ztp/resource-generator/**"
+                ],
+                "schedule": [
+                    "at any time"
+                ],
+                "additionalBranchPrefix": "ztp/resource-generator-"
+            },
+            {
+                "includePaths": [
+                    "cnf-tests/submodules/**"
+                ],
+                "additionalBranchPrefix": "cnf-tests/submodules-"
+            }
+        ]
     }
 }


### PR DESCRIPTION
It was stated in
https://github.com/openshift-kni/cnf-features-deploy/pull/2597 that updates to the submodule telco-reference in ztp is required more often that once a week. In this commit, configure different rules for different packages such that ztp submodule will have seperate PRs than the rest of the submodules updates.
 ref: https://docs.renovatebot.com/configuration-options/#additionalbranchprefix