### PR TITLE
cnf-tests: `ExecCommandInContainer` return combined output

### DIFF
--- a/cnf-tests/testsuites/pkg/numa/numa.go
+++ b/cnf-tests/testsuites/pkg/numa/numa.go
@@ -25,12 +25,9 @@ func FindForCPUs(pod *corev1.Pod, cpuList []string) (int, error) {
 
 func findForCPUsParseOutput(lscpuOutput string, cpuList []string) (int, error) {
 	foundNUMAnode := -1
-	separator := "\r\n"
-	if !strings.Contains(lscpuOutput, separator) {
-		separator = "\n"
-	}
 
-	for _, line := range strings.Split(lscpuOutput, separator) {
+	lscpuOutput = strings.ReplaceAll(lscpuOutput, "\r\n", "\n")
+	for _, line := range strings.Split(lscpuOutput, "\n") {
 		if strings.HasPrefix(line, "#") {
 			continue
 		}
@@ -60,6 +57,10 @@ func findForCPUsParseOutput(lscpuOutput string, cpuList []string) (int, error) {
 
 			foundNUMAnode = numa
 		}
+	}
+
+	if foundNUMAnode == -1 {
+		return -1, fmt.Errorf("no NUMA node found for the given CPUs: %v. lscpu output: %s", cpuList, lscpuOutput)
 	}
 
 	return foundNUMAnode, nil


### PR DESCRIPTION
Starting from
- https://github.com/openshift-kni/cnf-features-deploy/pull/2109

stderr is not returned by the function `ExecCommandInContainer`. This PR means to restore that behavior.