### PR TITLE
OCPBUGS-57792: ran powersave 4.15

### DIFF
--- a/ztp/kube-compare-reference/metadata.yaml
+++ b/ztp/kube-compare-reference/metadata.yaml
@@ -84,6 +84,10 @@ parts:
         allOf:
           - path: required/node-tuning-operator/PerformanceProfile.yaml
           - path: required/node-tuning-operator/TunedPerformancePatch.yaml
+            config:
+              perField:
+                - pathToKey: spec.profile.0.data
+                  inlineDiffFunc: capturegroups
   - name: required-ptp-operator
     description: |-
       https://docs.openshift.com/container-platform/4.15/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-components.html#telco-ran-ptp-operator_ran-ref-design-components

--- a/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
+++ b/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
@@ -11,13 +11,16 @@ metadata:
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
 spec:
   additionalKernelArgs:
-    {{- template "unorderedList" (list .spec.additionalKernelArgs (list
-      "efi=runtime" 
-      "module_blacklist=irdma" 
-      "rcupdate.rcu_normal_after_boot=0" 
-      "vfio_pci.disable_idle_d3=1" 
+    {{- $requiredArgs := list
+      "efi=runtime"
+      "module_blacklist=irdma"
+      "rcupdate.rcu_normal_after_boot=0"
+    }}
+    {{- $optionalArgs := list
+      "vfio_pci.disable_idle_d3=1"
       "vfio_pci.enable_sriov=1"
-    )) }}
+    }}
+    {{- template "kernelArgList" (list .spec.additionalKernelArgs $requiredArgs $optionalArgs) }}
   cpu:
     isolated: {{ .spec.cpu.isolated }}
     reserved: {{ .spec.cpu.reserved }}
@@ -55,4 +58,4 @@ spec:
     # The configuration below is set for a low latency, performance mode.
     realTime: true
     highPowerConsumption: false
-    perPodPowerManagement: {{ .spec.workloadHints.perPodPowerManagement }}
+    perPodPowerManagement: {{ .spec.workloadHints.perPodPowerManagement | default false }}

--- a/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
+++ b/ztp/kube-compare-reference/required/node-tuning-operator/PerformanceProfile.yaml
@@ -20,6 +20,9 @@ spec:
       "vfio_pci.disable_idle_d3=1"
       "vfio_pci.enable_sriov=1"
     }}
+    {{- if .spec.workloadHints.perPodPowerManagement }}
+      {{- $optionalArgs = append $optionalArgs "cpufreq.default_governor=.*" }}
+    {{- end }}
     {{- template "kernelArgList" (list .spec.additionalKernelArgs $requiredArgs $optionalArgs) }}
   cpu:
     isolated: {{ .spec.cpu.isolated }}

--- a/ztp/kube-compare-reference/required/node-tuning-operator/TunedPerformancePatch.yaml
+++ b/ztp/kube-compare-reference/required/node-tuning-operator/TunedPerformancePatch.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     ran.openshift.io/ztp-deploy-wave: "10"
 spec:
+  {{- $powersaveSysfs := "" }}
+  {{- if and (.spec.profile) (contains "max_perf_pct" (index .spec.profile 0).data) }}
+    {{- $powersaveSysfs = "[sysfs]\n/sys/devices/system/cpu/intel_pstate/max_perf_pct=(?<max_perf_pct>[0-9]+)" }}
+  {{- end }}
   profile:
     - name: performance-patch
       # Please note:
@@ -26,6 +30,9 @@ spec:
         [service]
         service.stalld=start,enable
         service.chronyd=stop,disable
+        {{- if $powersaveSysfs }}
+          {{- $powersaveSysfs | nindent 8 }}
+        {{- end }}
   recommend:
   {{- range .spec.recommend }}
     - machineConfigLabels:

--- a/ztp/kube-compare-reference/unordered_list.tmpl
+++ b/ztp/kube-compare-reference/unordered_list.tmpl
@@ -1,8 +1,38 @@
 {{- define "unorderedList" }}
+{{- /* compare two unordered lists: unorderedList <listToEval> <requiredValues> [optionalValues] */}}
 {{- $result := list }}
+{{- $optionalArgs := list }}
+{{- if gt (len .) 2 }}
+{{- $optionalArgs = concat $optionalArgs (index . 2) }}
+{{- end }}
 {{- $expectedArgs := index . 1 }}
 {{- range $value := (index . 0) }}
-  {{- if has $value $expectedArgs }}
+  {{- if or (has $value $expectedArgs) (has $value $optionalArgs) }}
+    {{- $result = append $result $value }}
+    {{- $expectedArgs = without $expectedArgs $value }}
+  {{- end }}
+{{- end }}
+{{- range $value := $expectedArgs }}
+  {{- $result = append $result $value }}
+{{- end }}
+{{- $result | toYaml | nindent 4 }}
+{{- end }}
+
+{{- define "kernelArgList" }}
+{{- /* compare two unordered lists: kernelArgList <listToEval> <requiredValues> [optionalValues] */}}
+{{- /* Additionally, allows wildcard values such as 'foo=.*' in either list, which will match more openly than non-wildcard values */}}
+{{- $result := list }}
+{{- $optionalArgs := list }}
+{{- if gt (len .) 2 }}
+{{- $optionalArgs = concat $optionalArgs (index . 2) }}
+{{- end }}
+{{- $expectedArgs := index . 1 }}
+{{- range $value := (index . 0) }}
+  {{- $wildcardValue := $value }}
+  {{- if contains "=" $value }}
+    {{- $wildcardValue = mustRegexReplaceAllLiteral "=.*$" $value "=.*" }}
+  {{- end }}
+  {{- if or (has $value $expectedArgs) (has $value $optionalArgs) (has $wildcardValue $expectedArgs) (has $wildcardValue $optionalArgs) }}
     {{- $result = append $result $value }}
     {{- $expectedArgs = without $expectedArgs $value }}
   {{- end }}


### PR DESCRIPTION
- **ztp: RAN reference: Cleanup PerformanceProfile template**
- **ztp: RAN reference: Allow setting cpufreq governor when perPodPowermanagement is set**
- **ztp: RAN reference: Optionally allow max_perf_pct sysfs in Tuned**
