### PR TITLE
[release-4.12] cnf-tests: k5x: add missing SUITE_PATH

### DIFF
--- a/cnf-tests/.konflux/Dockerfile
+++ b/cnf-tests/.konflux/Dockerfile
@@ -62,6 +62,7 @@ ENV OCP_VERSION=4.12
 ENV IMAGE_REGISTRY=registry.redhat.io/openshift4/
 ENV CNF_TESTS_IMAGE=cnf-tests-rhel8:v${OCP_VERSION}
 ENV DPDK_TESTS_IMAGE=dpdk-base-rhel8:v${OCP_VERSION}
+ENV SUITES_PATH=/usr/bin/
 
 CMD ["/usr/bin/test-run.sh"]
 


### PR DESCRIPTION
Not specifying the suite path lead to block running the tests. The env var was missed during teh migration to konflux. re-add it to fix the problem.
The variable is used in: `cnf-tests/entrypoint/test-run.sh`