### PR TITLE
cnf-tests: k5x: RPMs bump  

### DIFF
--- a/cnf-tests/.konflux/rpms.in.yaml
+++ b/cnf-tests/.konflux/rpms.in.yaml
@@ -8,8 +8,8 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: 1
       sslcacert: /etc/rhsm/ca/redhat-uep.pem
-      sslclientkey: /etc/pki/entitlement/2565193581949800986-key.pem
-      sslclientcert: /etc/pki/entitlement/2565193581949800986.pem
+      sslclientkey: /etc/pki/entitlement/8882101036362786898-key.pem
+      sslclientcert: /etc/pki/entitlement/8882101036362786898.pem
       sslverifystatus: 1
       varsFromContainerfile: Dockerfile
     - repoid: rhel-9-for-$basearch-baseos-rpms
@@ -19,8 +19,8 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: 1
       sslcacert: /etc/rhsm/ca/redhat-uep.pem
-      sslclientkey: /etc/pki/entitlement/2565193581949800986-key.pem
-      sslclientcert: /etc/pki/entitlement/2565193581949800986.pem
+      sslclientkey: /etc/pki/entitlement/8882101036362786898-key.pem
+      sslclientcert: /etc/pki/entitlement/8882101036362786898.pem
       sslverifystatus: 1
       varsFromContainerfile: Dockerfile
     - repoid: rhel-9-for-$basearch-baseos-eus-rpms
@@ -30,8 +30,8 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: 1
       sslcacert: /etc/rhsm/ca/redhat-uep.pem
-      sslclientkey: /etc/pki/entitlement/2565193581949800986-key.pem
-      sslclientcert: /etc/pki/entitlement/2565193581949800986.pem
+      sslclientkey: /etc/pki/entitlement/8882101036362786898-key.pem
+      sslclientcert: /etc/pki/entitlement/8882101036362786898.pem
       sslverifystatus: 1
       varsFromContainerfile: Dockerfile
     - repoid: rhel-9-for-$basearch-appstream-rpms
@@ -41,8 +41,8 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: 1
       sslcacert: /etc/rhsm/ca/redhat-uep.pem
-      sslclientkey: /etc/pki/entitlement/2565193581949800986-key.pem
-      sslclientcert: /etc/pki/entitlement/2565193581949800986.pem
+      sslclientkey: /etc/pki/entitlement/8882101036362786898-key.pem
+      sslclientcert: /etc/pki/entitlement/8882101036362786898.pem
       sslverifystatus: 1
       varsFromContainerfile: Dockerfile
 

--- a/cnf-tests/.konflux/rpms.lock.yaml
+++ b/cnf-tests/.konflux/rpms.lock.yaml
@@ -116,13 +116,13 @@ arches:
     name: iputils
     evr: 20210202-11.el9_6.1
     sourcerpm: iputils-20210202-11.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kernel-tools-libs-5.14.0-570.23.1.el9_6.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kernel-tools-libs-5.14.0-570.30.1.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1872545
-    checksum: sha256:c99a1e204fdd58d6c73804854acae127992a4fbbd525be4fa8da2e2f410cc071
+    size: 1880645
+    checksum: sha256:e7e1a960faf4455c9b75109ef69ef8eb8a7d99c939ce431b3c722f8dcdf81695
     name: kernel-tools-libs
-    evr: 5.14.0-570.23.1.el9_6
-    sourcerpm: kernel-5.14.0-570.23.1.el9_6.src.rpm
+    evr: 5.14.0-570.30.1.el9_6
+    sourcerpm: kernel-5.14.0-570.30.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 132888
@@ -277,20 +277,20 @@ arches:
     name: psmisc
     evr: 23.4-3.el9
     sourcerpm: psmisc-23.4-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-3.9.21-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-3.9.21-2.el9_6.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 30481
-    checksum: sha256:65c73ac98cfbd459b1b9672da58f4e7cf89b6ad979717aa9912ebbed7242a944
+    size: 27318
+    checksum: sha256:2fd8fcab383890dd6012d91ed59687282b55c65e979fa22c40e767b7106a6361
     name: python3
-    evr: 3.9.21-2.el9
-    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9.x86_64.rpm
+    evr: 3.9.21-2.el9_6.1
+    sourcerpm: python3.9-3.9.21-2.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 8477687
-    checksum: sha256:7d1a15f4540d24ce9e3c17fbfa9850e1ce87c41993b94931a85f1fcfda7eefdd
+    size: 8475685
+    checksum: sha256:00658a5409c64ad8158706fdec864c17e9e8f23a00b2f964bc19d6eaf2a2b388
     name: python3-libs
-    evr: 3.9.21-2.el9
-    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+    evr: 3.9.21-2.el9_6.1
+    sourcerpm: python3.9-3.9.21-2.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1193706
@@ -298,13 +298,13 @@ arches:
     name: python3-pip-wheel
     evr: 21.3.1-1.el9
     sourcerpm: python-pip-21.3.1-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9_6.1.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 480100
-    checksum: sha256:daf18aa58dd3571cf4258a5a4f67410a1d30ab8c62cd64b2ea99eda5a7f618cf
+    size: 479114
+    checksum: sha256:99807cec6f3941b1ec963813a5eaf7cf7922690cda6b35cd0f1fe0a3bdc1459f
     name: python3-setuptools-wheel
-    evr: 53.0.0-13.el9
-    sourcerpm: python-setuptools-53.0.0-13.el9.src.rpm
+    evr: 53.0.0-13.el9_6.1
+    sourcerpm: python-setuptools-53.0.0-13.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-252-51.el9_6.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 4406105
@@ -368,13 +368,13 @@ arches:
     name: nmap-ncat
     evr: 3:7.92-3.el9
     sourcerpm: nmap-7.92-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.1.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 10730
-    checksum: sha256:d835fd578f8ebf17c5914a4d8695ca78e68676880b690dd2a322b541a2897a71
+    size: 10243
+    checksum: sha256:93af9db6c07e09b77f7dfd32d1210cc39e49e02d456b79c4bff185604422c55f
     name: python-unversioned-command
-    evr: 3.9.21-2.el9
-    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+    evr: 3.9.21-2.el9_6.1
+    sourcerpm: python3.9-3.9.21-2.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/realtime-tests-2.8-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 203068


### PR DESCRIPTION
Regenerate lockfile to consume latest packages to fix CHI score.