### PR TITLE
AA: cnf-tests: tekton: use PR number as quay builds tag

### DIFF
--- a/.tekton/cnf-tests-4-20-pull-request.yaml
+++ b/.tekton/cnf-tests-4-20-pull-request.yaml
@@ -32,7 +32,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-20:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-20:on-pr-{{pull_request_number}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms


### PR DESCRIPTION
Instead of using the commit revision as the quay build tag, use the PR number to easily track and identify the build in quay.

Assisted-by: Cursor v1.2.2
Assited-by-model: claude-4-sonnet