### PR TITLE
[release-4.19] AA: cnf-tests: tekton: use PR number as quay builds tag

### DIFF
--- a/.tekton/cnf-tests-4-19-pull-request.yaml
+++ b/.tekton/cnf-tests-4-19-pull-request.yaml
@@ -32,7 +32,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-19:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-19:on-pr-{{pull_request_number}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/cnf-tests-4-19-push.yaml
+++ b/.tekton/cnf-tests-4-19-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-19:{{revision}}
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-19:{{pull_request_number}}
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
Instead of using the commit revision as the quay build tag, use the PR number to easily track and identify the build in quay.

Assisted-by: Cursor v1.2.2
Assited-by-model: claude-4-sonnet