### PR TITLE
cnf-tests: replace unfound variable `pull_request_number`[revert]

### DIFF
--- a/.tekton/cnf-tests-4-19-push.yaml
+++ b/.tekton/cnf-tests-4-19-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-19:{{pull_request_number}}
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/cnf-tests-4-19:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
It was not visible to detect that the `pull_request_number` variable is not available on on-push pipeline. revert the change partially done previously.