### PR TITLE
tekton: migrate source-build-oci-ta task with required params

### DIFF
--- a/.tekton/cnf-tests-4-16-pull-request.yaml
+++ b/.tekton/cnf-tests-4-16-pull-request.yaml
@@ -381,7 +381,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:51d698844b207f7bedff69cc8718858cbc7407b0cadbea3033e5965e71ae5e96
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:4bafcaab0f0c998a89a1cc33bdbbf74f39eea52e6c0e43013c356a322f94940f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cnf-tests-4-16-pull-request.yaml
+++ b/.tekton/cnf-tests-4-16-pull-request.yaml
@@ -299,7 +299,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/cnf-tests-4-16-push.yaml
+++ b/.tekton/cnf-tests-4-16-push.yaml
@@ -378,7 +378,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:51d698844b207f7bedff69cc8718858cbc7407b0cadbea3033e5965e71ae5e96
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:4bafcaab0f0c998a89a1cc33bdbbf74f39eea52e6c0e43013c356a322f94940f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cnf-tests-4-16-push.yaml
+++ b/.tekton/cnf-tests-4-16-push.yaml
@@ -296,7 +296,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/ztp-site-generate-4-16-pull-request.yaml
+++ b/.tekton/ztp-site-generate-4-16-pull-request.yaml
@@ -356,7 +356,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/ztp-site-generate-4-16-pull-request.yaml
+++ b/.tekton/ztp-site-generate-4-16-pull-request.yaml
@@ -438,7 +438,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:51d698844b207f7bedff69cc8718858cbc7407b0cadbea3033e5965e71ae5e96
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:4bafcaab0f0c998a89a1cc33bdbbf74f39eea52e6c0e43013c356a322f94940f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ztp-site-generate-4-16-push.yaml
+++ b/.tekton/ztp-site-generate-4-16-push.yaml
@@ -435,7 +435,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:51d698844b207f7bedff69cc8718858cbc7407b0cadbea3033e5965e71ae5e96
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:4bafcaab0f0c998a89a1cc33bdbbf74f39eea52e6c0e43013c356a322f94940f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/ztp-site-generate-4-16-push.yaml
+++ b/.tekton/ztp-site-generate-4-16-push.yaml
@@ -353,7 +353,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT


### PR DESCRIPTION
This PR address a build issue that creeped in from a konflux reference update [PR](https://github.com/openshift-kni/cnf-features-deploy/pull/2719) that was merged without performing migration tasks