### PR TITLE
tekton: migrate source-build-oci-ta with required params for v0.3

### DIFF
--- a/.tekton/cnf-tests-4-15-pull-request.yaml
+++ b/.tekton/cnf-tests-4-15-pull-request.yaml
@@ -299,7 +299,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/cnf-tests-4-15-push.yaml
+++ b/.tekton/cnf-tests-4-15-push.yaml
@@ -296,7 +296,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/ztp-site-generate-4-15-pull-request.yaml
+++ b/.tekton/ztp-site-generate-4-15-pull-request.yaml
@@ -356,7 +356,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/ztp-site-generate-4-15-push.yaml
+++ b/.tekton/ztp-site-generate-4-15-push.yaml
@@ -353,7 +353,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT


### PR DESCRIPTION
The tasks digests were updated to the new release but the migration updates were missing. Add missing params needed by this update as per https://github.com/konflux-ci/build-definitions/blob/main/task/source-build-oci-ta/0.3/MIGRATION.md