### PR TITLE
[release-4.17] tekton: build-source-image tekton task migration

### DIFF
--- a/.tekton/cnf-tests-4-17-pull-request.yaml
+++ b/.tekton/cnf-tests-4-17-pull-request.yaml
@@ -299,7 +299,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/cnf-tests-4-17-push.yaml
+++ b/.tekton/cnf-tests-4-17-push.yaml
@@ -296,7 +296,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/ztp-site-generate-4-17-pull-request.yaml
+++ b/.tekton/ztp-site-generate-4-17-pull-request.yaml
@@ -356,7 +356,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT

--- a/.tekton/ztp-site-generate-4-17-push.yaml
+++ b/.tekton/ztp-site-generate-4-17-push.yaml
@@ -353,7 +353,9 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: "$(tasks.build-image-index.results.IMAGE_URL)"
+      - name: BINARY_IMAGE_DIGEST
+        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT


### PR DESCRIPTION
This PR address a build issue that creeped in from a konflux reference update that was merged without performing migration tasks