### PR TITLE
infra: update components for konflux bots

### DIFF
--- a/.githooks/components.sh
+++ b/.githooks/components.sh
@@ -11,6 +11,8 @@ components=( \
 	["cnf-tests"]="cnf-tests" \
 	["oot-driver"]="tools/oot-driver" \
 	["owners"]="OWNERS","OWNERS_ALIASES" \
-	["docs"]="README.md"
+	["docs"]="README.md" \
+	["depbot"]="vendor","go.mod","go.sum" \
+	["chore(deps)"]="vendor","go.mod","go.sum"
 )
 


### PR DESCRIPTION
Adds missing components for depbot and konfluxbot so commits from those dont fail ci job.
Present in all release branches, seems to have missed 4.12