### PR TITLE
tools: Fix namespace for pod to build index image

### DIFF
--- a/hack/setup-build-index-image.sh
+++ b/hack/setup-build-index-image.sh
@@ -33,11 +33,30 @@ else
 fi
 
 # TODO: improve the script
-jobdefinition='apiVersion: v1
+jobdefinition='apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-podman
+  namespace: openshift-marketplace
+spec:
+  podSelector:
+    matchLabels:
+      app: podman
+  policyTypes:
+  - Egress
+  - Ingress
+  ingress:
+  - {}   # allow all ingress
+  egress:
+  - {}   # allow al
+---
+apiVersion: v1
 kind: Pod
 metadata:
   name: podman
   namespace: openshift-marketplace
+  labels:
+    app: podman
 spec:
   restartPolicy: Never
   serviceAccountName: builder


### PR DESCRIPTION
openshift-marketplace requires specific selectors for pods to query DNS and go to internet.

CNF-19268