### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cnf-tests-4-12

### DIFF
--- a/cnf-tests/.konflux/Dockerfile
+++ b/cnf-tests/.konflux/Dockerfile
@@ -67,7 +67,8 @@ ENV SUITES_PATH=/usr/bin/
 CMD ["/usr/bin/test-run.sh"]
 
 LABEL com.redhat.component="cnf-tests-container" \
-      name="openshift4/cnf-tests" \
+      name="openshift4/cnf-tests-rhel8" \
+      cpe="cpe:/a:redhat:openshift:4.12::el8" \
       summary="Cluster verification tests image" \
       io.openshift.expose-services="" \
       io.openshift.tags="data,images" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
