### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for ztp-site-generate-4-12

### DIFF
--- a/.tekton/ztp-site-generate-4-12-pull-request.yaml
+++ b/.tekton/ztp-site-generate-4-12-pull-request.yaml
@@ -299,8 +299,9 @@ spec:
         - description=Container Image for Argo CD integration with ACM
         - distribution-scope=public
         - io.k8s.description=ztp-site-generate
-        - name=openshift4/ztp-site-generate
+        - name=openshift4/ztp-site-generate-rhel8
         - release=4.12
+        - cpe=cpe:/a:redhat:openshift:4.12::el8
         - url=https://github.com/openshift-kni/cnf-features-deploy
         - vendor=Red Hat, Inc.
         - io.k8s.display-name=ztp-site-generate

--- a/.tekton/ztp-site-generate-4-12-push.yaml
+++ b/.tekton/ztp-site-generate-4-12-push.yaml
@@ -296,8 +296,9 @@ spec:
         - description=Container Image for Argo CD integration with ACM
         - distribution-scope=public
         - io.k8s.description=ztp-site-generate
-        - name=openshift4/ztp-site-generate
+        - name=openshift4/ztp-site-generate-rhel8
         - release=4.12
+        - cpe=cpe:/a:redhat:openshift:4.12::el8
         - url=https://github.com/openshift-kni/cnf-features-deploy
         - vendor=Red Hat, Inc.
         - io.k8s.display-name=ztp-site-generate


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
