### PR TITLE
ztp: OCPBUGS-60364: Fix for CVE-2025-7195 - Harden /etc/passwd permissions

### DIFF
--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -65,6 +65,10 @@ COPY --from=builder $BUILDER_ZTP/tools/siteconfig-converter/siteconfig-converter
 COPY --from=builder $BUILDER_ZTP/siteconfig-generator/siteconfig-generator /usr/bin
 RUN mkdir -p /kustomize-pgt2acmpg/policy.open-cluster-management.io
 COPY --from=builder $BUILDER_ZTP/tools/pgt2acmpg/kustomize /kustomize-pgt2acmpg
+
+# Harden permissions for /etc/passwd to mitigate CVE-2025-7195
+RUN chmod 644 /etc/passwd
+
 USER 1001
 CMD entrypoints
 


### PR DESCRIPTION
This PR fixes a privilege escalation issue CVE-2025-7195 due to incorrect permissions of /etc/passwd
The permissions of /etc/passwd 664 due to which /etc/passwd is group writable and can be used to escalate privileges to root. This PR updates it to group read-only.