### PR TITLE
Fix rpm lockfile task & Re-run lockfile task

### DIFF
--- a/cnf-tests/.konflux/lock-runtime/rpms.lock.yaml
+++ b/cnf-tests/.konflux/lock-runtime/rpms.lock.yaml
@@ -116,13 +116,13 @@ arches:
     name: iputils
     evr: 20210202-11.el9_6.1
     sourcerpm: iputils-20210202-11.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kernel-tools-libs-5.14.0-570.41.1.el9_6.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kernel-tools-libs-5.14.0-570.46.1.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1897717
-    checksum: sha256:bdbdaac4bc084737562b12d9bd37dadd86a917e0e38933bd1b9d9646ceff3732
+    size: 1909709
+    checksum: sha256:3bfa02b67c5392276ba5820c5feaef0f5aa2fc701c02e8a6df336a93b3bfee76
     name: kernel-tools-libs
-    evr: 5.14.0-570.41.1.el9_6
-    sourcerpm: kernel-5.14.0-570.41.1.el9_6.src.rpm
+    evr: 5.14.0-570.46.1.el9_6
+    sourcerpm: kernel-5.14.0-570.46.1.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 132888

--- a/cnf-tests/Makefile
+++ b/cnf-tests/Makefile
@@ -39,7 +39,7 @@ konflux-update-rpm-lock-runtime: sync-git-submodules ## Update the rpm lock file
 	cp $(PROJECT_DIR)/.konflux/Dockerfile $(PROJECT_DIR)/.konflux/lock-runtime/Dockerfile
 	$(MAKE) -C $(ROOT_PROJECT_DIR)/telco5g-konflux/scripts/rpm-lock generate-rhel9-locks \
 		LOCK_SCRIPT_TARGET_DIR=$(PROJECT_DIR)/.konflux/lock-runtime \
-		RHEL9_IMAGE_TO_LOCK=$$(awk '/^FROM registry.access.redhat.com\/ubi9\/ubi-minimal:/ {split($$2, parts, /[:|@]/); print parts[1] ":" parts[2]}' $(PROJECT_DIR)/.konflux/Dockerfile) \
+		RHEL9_IMAGE_TO_LOCK=$$(awk '/^FROM registry.access.redhat.com\/ubi9\/ubi-minimal:/ {print $$2}' $(PROJECT_DIR)/.konflux/Dockerfile) \
 		REGISTRY_AUTH_FILE=$(REGISTRY_AUTH_FILE) \
 		\
 		RHEL9_RELEASE=$(RHEL9_RELEASE) \

--- a/cnf-tests/Makefile
+++ b/cnf-tests/Makefile
@@ -39,7 +39,7 @@ konflux-update-rpm-lock-runtime: sync-git-submodules ## Update the rpm lock file
 	cp $(PROJECT_DIR)/.konflux/Dockerfile $(PROJECT_DIR)/.konflux/lock-runtime/Dockerfile
 	$(MAKE) -C $(ROOT_PROJECT_DIR)/telco5g-konflux/scripts/rpm-lock generate-rhel9-locks \
 		LOCK_SCRIPT_TARGET_DIR=$(PROJECT_DIR)/.konflux/lock-runtime \
-		RHEL9_IMAGE_TO_LOCK=$$(awk '/^FROM registry.access.redhat.com\/ubi9\/ubi-minimal:/ {split($$2, parts, /[:|@]/); print parts[1] ":" parts[2]}' $(PROJECT_DIR)/.konflux/Dockerfile)
+		RHEL9_IMAGE_TO_LOCK=$$(awk '/^FROM registry.access.redhat.com\/ubi9\/ubi-minimal:/ {split($$2, parts, /[:|@]/); print parts[1] ":" parts[2]}' $(PROJECT_DIR)/.konflux/Dockerfile) \
 		REGISTRY_AUTH_FILE=$(REGISTRY_AUTH_FILE) \
 		\
 		RHEL9_RELEASE=$(RHEL9_RELEASE) \


### PR DESCRIPTION
- A missing backslash was causing parameters to not be passed correctly to the task
- The container image should be passed without stripping the digest
- After fixing the issues, re-run the task to ensure everything is good
