### PR TITLE
ztp: remove the disableDrain for SNO

### DIFF
--- a/ztp/kube-compare-reference/required/sriov-operator/SriovOperatorConfigForSNO.yaml
+++ b/ztp/kube-compare-reference/required/sriov-operator/SriovOperatorConfigForSNO.yaml
@@ -23,8 +23,6 @@ spec:
   #          openshift.io/<resource_name>:  "1"
   #        requests:
   #          openshift.io/<resource_name>:  "1"
-  # Disable drain is needed for Single Node Openshift
-  disableDrain: true
   {{- if hasKey .spec "enableInjector" }}
   enableInjector: false
   {{- end }}


### PR DESCRIPTION
On newer versions of the sriov-network-operator there is no need to request the disableDrain: true for SNO.

PR: https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/850