### PR TITLE
infra: Fix git submodule syncing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,18 @@ init-git-submodules:
 	git submodule update --init --force
 	cnf-tests/hack/init-git-submodules.sh
 
+.PHONY: sync-telco5g-konflux-submodule
+sync-telco5g-konflux-submodule:
+	@echo "Checking sync for telco5g-konflux submodule"
+	@if [ "$(SKIP_SUBMODULE_SYNC)" != "yes" ]; then \
+		echo "Syncing specific git submodule: telco5g-konflux"; \
+		git submodule sync --recursive telco5g-konflux; \
+		git submodule update --init --recursive telco5g-konflux; \
+		echo "Submodule telco5g-konflux sync complete."; \
+	else \
+		echo "Skipping submodule sync for telco5g-konflux"; \
+	fi
+
 .PHONY: print-git-components
 print-git-components:
 	hack/print-git-components.sh

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ wait-and-validate:
 	@echo "Validating"
 	SKIP_TESTS="$(SKIP_TESTS)" DONT_FOCUS=true TEST_SUITES="validationsuite" hack/run-functests.sh
 
-functests-on-ci: sync-git-submodules feature-deploy-on-ci functests
+functests-on-ci: init-git-submodules feature-deploy-on-ci functests
 
-functests-on-ci-no-index-build: sync-git-submodules setup-test-cluster feature-deploy feature-wait functests
+functests-on-ci-no-index-build: init-git-submodules setup-test-cluster feature-deploy feature-wait functests
 
 feature-deploy-on-ci: setup-test-cluster setup-build-index-image feature-deploy feature-wait
 
@@ -121,8 +121,9 @@ custom-rpms:
 	@echo "Installing rpms"
 	RPMS_SRC="$(RPMS_SRC)" hack/custom_rpms.sh
 
-test-bin: sync-git-submodules
+test-bin:
 	@echo "Making test binary"
+	git submodule update --init --force
 	cnf-tests/hack/build-test-bin.sh
 
 cnf-tests-local:
@@ -136,16 +137,10 @@ install-commit-hooks:
 update-helm-chart:
 	cd tools/oot-driver && make helm-repo-index
 
-.PHONY: sync-git-submodules
-sync-git-submodules:
-	@echo "Checking git submodules"
-	@if [ "$(SKIP_SUBMODULE_SYNC)" != "yes" ]; then \
-		echo "Syncing git submodules"; \
-		git submodule sync --recursive; \
-		git submodule update --init --recursive; \
-	else \
-		echo "Skipping submodule sync"; \
-	fi
+init-git-submodules:
+	@echo "Initializing git submodules"
+	git submodule update --init --force
+	cnf-tests/hack/init-git-submodules.sh
 
 .PHONY: print-git-components
 print-git-components:

--- a/cnf-tests/Makefile
+++ b/cnf-tests/Makefile
@@ -28,12 +28,12 @@ help: ## Display this help.
 
 ## Konflux Targets
 
-.PHONY: sync-git-submodules
-sync-git-submodules: ## Sync git submodules via the root Makefile
-	$(MAKE) -C $(ROOT_PROJECT_DIR) sync-git-submodules
+.PHONY: sync-telco5g-konflux-submodule
+sync-telco5g-konflux-submodule: ## Sync git submodule via the root Makefile
+	$(MAKE) -C $(ROOT_PROJECT_DIR) sync-telco5g-konflux-submodule
 
 .PHONY: konflux-update-rpm-lock-runtime
-konflux-update-rpm-lock-runtime: sync-git-submodules ## Update the rpm lock file for the runtime
+konflux-update-rpm-lock-runtime: sync-telco5g-konflux-submodule ## Update the rpm lock file for the runtime
 	@echo "Updating rpm lock file for the runtime..."
 	@echo "Copying Dockerfile to lock-runtime directory for rpm-lockfile-prototype..."
 	cp $(PROJECT_DIR)/.konflux/Dockerfile $(PROJECT_DIR)/.konflux/lock-runtime/Dockerfile

--- a/ztp/resource-generator/Makefile
+++ b/ztp/resource-generator/Makefile
@@ -67,12 +67,12 @@ all: build export
 
 ## Konflux Targets
 
-.PHONY: sync-git-submodules
-sync-git-submodules: ## Sync git submodules via the root Makefile
-	$(MAKE) -C $(ROOT_PROJECT_DIR) sync-git-submodules
+.PHONY: sync-telco5g-konflux-submodule
+sync-telco5g-konflux-submodule: ## Sync git submodule via the root Makefile
+	$(MAKE) -C $(ROOT_PROJECT_DIR) sync-telco5g-konflux-submodule
 
 .PHONY: konflux-update-rpm-lock-runtime
-konflux-update-rpm-lock-runtime: sync-git-submodules ## Update the rpm lock file for the runtime
+konflux-update-rpm-lock-runtime: sync-telco5g-konflux-submodule ## Update the rpm lock file for the runtime
 	@echo "Copying Containerfile to lock-runtime directory for rpm-lockfile-prototype..."
 	cp $(PROJECT_DIR)/Containerfile $(PROJECT_DIR)/.konflux/lock-runtime/Containerfile
 	@echo "Updating rpm lock file for the runtime..."


### PR DESCRIPTION
- Revert bad commit that broke the functest ci
- Add a new target that just syncs the telco5g-konflux submodule and use that for the konflux targets
