### PR TITLE
Sort on-cel-expression file paths && add telco5g-konflux to it

### DIFF
--- a/.tekton/cnf-tests-4-20-pull-request.yaml
+++ b/.tekton/cnf-tests-4-20-pull-request.yaml
@@ -14,9 +14,11 @@ metadata:
       (
         '.tekton/cnf-tests-4-20-pull-request.yaml'.pathChanged() ||
         'cnf-tests/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
         'go.mod'.pathChanged() ||
-        'go.sum'.pathChanged()
+        'go.sum'.pathChanged() ||
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged()
       )
   creationTimestamp:
   labels:

--- a/.tekton/cnf-tests-4-20-push.yaml
+++ b/.tekton/cnf-tests-4-20-push.yaml
@@ -13,9 +13,11 @@ metadata:
       (
         '.tekton/cnf-tests-4-20-push.yaml'.pathChanged() ||
         'cnf-tests/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
         'go.mod'.pathChanged() ||
-        'go.sum'.pathChanged()
+        'go.sum'.pathChanged() ||
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged()
         )
   creationTimestamp:
   labels:

--- a/.tekton/ztp-site-generate-4-20-pull-request.yaml
+++ b/.tekton/ztp-site-generate-4-20-pull-request.yaml
@@ -13,10 +13,12 @@ metadata:
       target_branch == "master" &&
       (
         '.tekton/ztp-site-generate-4-20-pull-request.yaml'.pathChanged() ||
-        'ztp/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
         'go.mod'.pathChanged() ||
-        'go.sum'.pathChanged()
+        'go.sum'.pathChanged() ||
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged() ||
+        'ztp/***'.pathChanged()
       )
   creationTimestamp:
   labels:

--- a/.tekton/ztp-site-generate-4-20-push.yaml
+++ b/.tekton/ztp-site-generate-4-20-push.yaml
@@ -12,10 +12,12 @@ metadata:
       target_branch == "master" &&
       (
         '.tekton/ztp-site-generate-4-20-push.yaml'.pathChanged() ||
-        'ztp/***'.pathChanged() ||
-        'vendor/***'.pathChanged() ||
         'go.mod'.pathChanged() ||
-        'go.sum'.pathChanged()
+        'go.sum'.pathChanged() ||
+        'telco5g-konflux'.pathChanged() ||
+        'telco5g-konflux/***'.pathChanged() ||
+        'vendor/***'.pathChanged() ||
+        'ztp/***'.pathChanged()
       )
   creationTimestamp:
   labels:


### PR DESCRIPTION
- Sorting them will make it easier to keep the paths sane going forward
- Since the library scripts are used by the tekton builds, changes there should trigger the builds

AI-attribution: AIA,Entirely human-created,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/