### PR TITLE
ztp: Add cgroup and runtime checks

### DIFF
--- a/ztp/kube-compare-reference/compare_ignore
+++ b/ztp/kube-compare-reference/compare_ignore
@@ -73,3 +73,7 @@ extra-manifest/image-registry-partition-mc.yaml.tmpl
 
 # Exists in the reference only, to enforce version compatibility
 ClusterVersionOperator.yaml
+
+# Reference only to ensure default has not been changed
+required/machine-config/cgroup-check.yaml
+required/machine-config/container-runtime.yaml

--- a/ztp/kube-compare-reference/metadata.yaml
+++ b/ztp/kube-compare-reference/metadata.yaml
@@ -12,6 +12,18 @@ parts:
               ignore-unspecified-fields: true
               fieldsToOmitRefs:
                 - allowStatusCheck
+  - name: defaults-check
+    description: |-
+      A mismatch here means you are overriding expected default
+      values in Openshift configuration
+    components:
+      - name: defaults-required
+        allOf:
+          - path: required/machine-config/cgroup-check.yaml
+      - name: defaults-optional
+        # If the matching CR exists it needs to match expected content
+        anyOf:
+          - path: required/machine-config/container-runtime.yaml
   - name: required-cluster-logging
     description: |-
       https://docs.openshift.com/container-platform/4.18/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-components.html#telco-ran-logging_ran-ref-design-components

--- a/ztp/kube-compare-reference/required/machine-config/cgroup-check.yaml
+++ b/ztp/kube-compare-reference/required/machine-config/cgroup-check.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+spec:
+  {{ if .spec.cgroupMode -}}
+  cgroupMode: "v2"
+  {{- else -}}
+  {}
+  {{- end -}}

--- a/ztp/kube-compare-reference/required/machine-config/container-runtime.yaml
+++ b/ztp/kube-compare-reference/required/machine-config/container-runtime.yaml
@@ -1,0 +1,19 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: {{ .metadata.name }}
+spec:
+  # mcp selector is expected or runtime binds to no pools
+  machineConfigPoolSelector:
+  {{- nindent 4 (.spec.machineConfigPoolSelector | default "value required" | toYaml) }}
+
+  {{- if .spec.containerRuntimeConfig }}
+  containerRuntimeConfig:
+    {{- range $key, $value := .spec.containerRuntimeConfig }}
+    {{- if eq (toString $key) "defaultRuntime" }}
+    defaultRuntime: "crun"
+    {{- else }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+    {{- end }}
+  {{- end }}


### PR DESCRIPTION
All workloads should be moving to cgroup v2. Add a required check for cgroup. If users remain on cgroup v1 the check serves as a reminder that workloads must be moved to v2.

Manual backport of https://github.com/openshift-kni/telco-reference/pull/269