### PR TITLE
cnf-tests: bump rpms

### DIFF
--- a/cnf-tests/.konflux/lock-runtime/rpms.lock.yaml
+++ b/cnf-tests/.konflux/lock-runtime/rpms.lock.yaml
@@ -2,385 +2,385 @@
 lockfileVersion: 1
 lockfileVendor: redhat
 arches:
-- arch: x86_64
-  packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/a/acl-2.3.1-4.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 77226
-    checksum: sha256:150d7232faa90f84a09268f8998ee32670eef59cba98612aeb996ab75c4dfcc4
-    name: acl
-    evr: 2.3.1-4.el9
-    sourcerpm: acl-2.3.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/b/bc-1.07.1-14.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 127511
-    checksum: sha256:9b6d28a6563d4c9f721f031ab0cf146fed097d8c4d186b57eaa8dd9ceb4d0685
-    name: bc
-    evr: 1.07.1-14.el9
-    sourcerpm: bc-1.07.1-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/c/cracklib-2.9.6-27.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 100903
-    checksum: sha256:8551b711718596fbfef6622bbf32f785864959af9d06a76da2545ec9f3a126e7
-    name: cracklib
-    evr: 2.9.6-27.el9
-    sourcerpm: cracklib-2.9.6-27.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 3821230
-    checksum: sha256:ab4356c86bdc996dc9e55703a7ae936e3e46aec6ebf6d6f008e126ff06e83df2
-    name: cracklib-dicts
-    evr: 2.9.6-27.el9
-    sourcerpm: cracklib-2.9.6-27.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 8073
-    checksum: sha256:96b1daa4de0a635ab760a8431fb005022bb7cb48d2d1d3ec9a8adb1798c0e10e
-    name: dbus
-    evr: 1:1.12.20-8.el9
-    sourcerpm: dbus-1.12.20-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dbus-broker-28-7.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 179634
-    checksum: sha256:de9869c08df7f6952787d0335b9bf1a09b328bea920556a59af07c8e085dd3cb
-    name: dbus-broker
-    evr: 28-7.el9
-    sourcerpm: dbus-broker-28-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 18551
-    checksum: sha256:298f1cada3cbcef6713098b9925694a0e30e8566f7a5bdbd72384520cf6c8360
-    name: dbus-common
-    evr: 1:1.12.20-8.el9
-    sourcerpm: dbus-1.12.20-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/elfutils-libelf-0.192-6.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 212613
-    checksum: sha256:9c9e2bc6ea19cda24a73f95ef9f439d61fd4480ae1889ac7e0730ee67432fd64
-    name: elfutils-libelf
-    evr: 0.192-6.el9_6
-    sourcerpm: elfutils-0.192-6.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/ethtool-6.11-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 258861
-    checksum: sha256:aa81447faad16c8120a7392e03b8fe96d5ac159015fb34403639ca35189a2e46
-    name: ethtool
-    evr: 2:6.11-1.el9
-    sourcerpm: ethtool-6.11-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/expat-2.5.0-5.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 121835
-    checksum: sha256:63522da84934e944305c9e206894031988ab9e561bba2e6c131d76093d1a0211
-    name: expat
-    evr: 2.5.0-5.el9_6
-    sourcerpm: expat-2.5.0-5.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/f/findutils-4.8.0-7.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 563531
-    checksum: sha256:a6328afea0a11647b7fb5c48436f0af6c795407bac0650676d3196dd47070de6
-    name: findutils
-    evr: 1:4.8.0-7.el9
-    sourcerpm: findutils-4.8.0-7.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 171206
-    checksum: sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac
-    name: gzip
-    evr: 1.12-1.el9
-    sourcerpm: gzip-1.12-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/i/iproute-6.11.0-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 855648
-    checksum: sha256:8fdbd5d311c7002f6553c31406f642ed136e94008b49376d581286646648d11d
-    name: iproute
-    evr: 6.11.0-1.el9
-    sourcerpm: iproute-6.11.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 476678
-    checksum: sha256:3e79ca4cc3d35c1f1e0ac6c9f05c5be56b7ab6dd1f8ae719a21ec1b9e3bfa018
-    name: iptables-libs
-    evr: 1.8.10-11.el9_5
-    sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/i/iptables-nft-1.8.10-11.el9_5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 214056
-    checksum: sha256:54e031813637738af285ff4b1c2e4a20b913f2ea643a29940a07ccaf8bd197f5
-    name: iptables-nft
-    evr: 1.8.10-11.el9_5
-    sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/i/iputils-20210202-11.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 178195
-    checksum: sha256:2760d3b457614fd29d24f6ceff4cd5354fb099193237ba9914dbeee5e69e67d3
-    name: iputils
-    evr: 20210202-11.el9_6.1
-    sourcerpm: iputils-20210202-11.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kernel-tools-libs-5.14.0-570.46.1.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1909709
-    checksum: sha256:3bfa02b67c5392276ba5820c5feaef0f5aa2fc701c02e8a6df336a93b3bfee76
-    name: kernel-tools-libs
-    evr: 5.14.0-570.46.1.el9_6
-    sourcerpm: kernel-5.14.0-570.46.1.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 132888
-    checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
-    name: kmod
-    evr: 28-10.el9
-    sourcerpm: kmod-28-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kmod-libs-28-10.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 66607
-    checksum: sha256:9ae0b89812908ee50ec654ba35f74dc478057e8981afd4a5cc8d2befd987b342
-    name: kmod-libs
-    evr: 28-10.el9
-    sourcerpm: kmod-28-10.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libbpf-1.5.0-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 191098
-    checksum: sha256:488a913a5f10debb4fb27756f59da75c61c6fefac403ea62d50b8071625d5cf3
-    name: libbpf
-    evr: 2:1.5.0-1.el9
-    sourcerpm: libbpf-1.5.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 755192
-    checksum: sha256:3246e76f197e2b60eb470b9b55d3e0dda2301b029f295fed9c38ff70b87c5b6b
-    name: libdb
-    evr: 5.3.28-57.el9_6
-    sourcerpm: libdb-5.3.28-57.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libeconf-0.4.1-4.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 30371
-    checksum: sha256:f7998382ca1be7836f6af05d42dc03f88799abcb10aa7a761e16f74058598012
-    name: libeconf
-    evr: 0.4.1-4.el9
-    sourcerpm: libeconf-0.4.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-21.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 159417
-    checksum: sha256:81c7676b72b85d8b5822888c510952ec0996b3d89bf8cddaf76dba31bc72a4a1
-    name: libfdisk
-    evr: 2.37.4-21.el9
-    sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libibverbs-54.0-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 466434
-    checksum: sha256:fc593dc18f73c296df4fa808341cb2dbee7e5082fb872b79e7984c3b24279d3b
-    name: libibverbs
-    evr: 54.0-1.el9
-    sourcerpm: rdma-core-54.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 30949
-    checksum: sha256:badfd4eb5b7cd3622da84168674002ec718ef810ce615a1113d3e19e265b777e
-    name: libmnl
-    evr: 1.0.4-16.el9_4
-    sourcerpm: libmnl-1.0.4-16.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 62066
-    checksum: sha256:beeb73e78390077c6afd9ed6177bad8bad278dbfaae9d90edf7243cdf6a44a3f
-    name: libnetfilter_conntrack
-    evr: 1.0.9-1.el9
-    sourcerpm: libnetfilter_conntrack-1.0.9-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnfnetlink-1.0.1-23.el9_5.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 32236
-    checksum: sha256:177882bfe48c9c9effc7b1bce6b58b2466988c53e400c07fb1ba2d3a4ebe6f40
-    name: libnfnetlink
-    evr: 1.0.1-23.el9_5
-    sourcerpm: libnfnetlink-1.0.1-23.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 91380
-    checksum: sha256:e64d7b270be4be36af80ed220852cb760a1069e34667b1ba9eec7a02762a14bf
-    name: libnftnl
-    evr: 1.2.6-4.el9_4
-    sourcerpm: libnftnl-1.2.6-4.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 376137
-    checksum: sha256:89728a253a5bf1c8e01c40573f1283d40188e003bdbd4ac565f8b0f05bced55c
-    name: libnl3
-    evr: 3.11.0-1.el9
-    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libpcap-1.10.0-4.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 180846
-    checksum: sha256:3c0c51cc6b947970812238914713f1f96aa5e9bdaaceb6ee50249540ad89f05b
-    name: libpcap
-    evr: 14:1.10.0-4.el9
-    sourcerpm: libpcap-1.10.0-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 126104
-    checksum: sha256:14b7ff2f7fdaf8ebec90261f4619ea7f7c3564c4de8483666de7ed4b1f49b66f
-    name: libpwquality
-    evr: 1.4.4-8.el9
-    sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 76200
-    checksum: sha256:e2015f60dbe784330d5df43f3f05c68c307694600a636a1706bf86527cc82e82
-    name: libseccomp
-    evr: 2.5.2-2.el9
-    sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 30354
-    checksum: sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597
-    name: libutempter
-    evr: 1.2.1-6.el9
-    sourcerpm: libutempter-1.2.1-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/lksctp-tools-1.0.19-3.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 106024
-    checksum: sha256:ac2fc5dcba641ec68b03db44c0b644ef10661bc89a060be2aa1eaa9c6a4215db
-    name: lksctp-tools
-    evr: 1.0.19-3.el9_4
-    sourcerpm: lksctp-tools-1.0.19-3.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/n/numactl-libs-2.0.19-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 33709
-    checksum: sha256:ce2f00b2527e29f6b389e5899750e2b6eb1e5ce484ddfdcd6f01fa311efe7860
-    name: numactl-libs
-    evr: 2.0.19-1.el9
-    sourcerpm: numactl-2.0.19-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1420999
-    checksum: sha256:f379686df99db814e30568a896b417278775fc96864ac6d2660bf48ef94309e3
-    name: openssl
-    evr: 1:3.2.2-6.el9_5.1
-    sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/pam-1.5.1-26.el9_6.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 636788
-    checksum: sha256:247027fa7a2236c1fb46756ed372637f85cf85886603a2ad5ba918e4231324bc
-    name: pam
-    evr: 1.5.1-26.el9_6
-    sourcerpm: pam-1.5.1-26.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 361526
-    checksum: sha256:506ad778f63821e8d9647ca8e0a3ff21b8af9c1666060d5200f9b26ee718333c
-    name: procps-ng
-    evr: 3.3.17-14.el9
-    sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/psmisc-23.4-3.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 253357
-    checksum: sha256:30ad5408417c7f06fb945dc321bef3ce31f813f25389707dd1efa7c1d337b806
-    name: psmisc
-    evr: 23.4-3.el9
-    sourcerpm: psmisc-23.4-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-3.9.21-2.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 26190
-    checksum: sha256:2572fc0f6c65dc5201c65a48f7d962a04a09669feae2fcdc4e5f9e910b9195c6
-    name: python3
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 8474800
-    checksum: sha256:a8a433346daa16f25d8f672bdc6cbee9277631c60378006fb1056b4443ce505d
-    name: python3-libs
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1193706
-    checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
-    name: python3-pip-wheel
-    evr: 21.3.1-1.el9
-    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 479114
-    checksum: sha256:99807cec6f3941b1ec963813a5eaf7cf7922690cda6b35cd0f1fe0a3bdc1459f
-    name: python3-setuptools-wheel
-    evr: 53.0.0-13.el9_6.1
-    sourcerpm: python-setuptools-53.0.0-13.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-252-51.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4406105
-    checksum: sha256:f1513095807cd040f2192efbf1d152053dbd8ba266f348f0b87305c0aa3cb2f2
-    name: systemd
-    evr: 252-51.el9_6.1
-    sourcerpm: systemd-252-51.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-pam-252-51.el9_6.1.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 289579
-    checksum: sha256:b03c085f98981e6e9754adf2765789728f871809a38657000a90915eeb6a8265
-    name: systemd-pam
-    evr: 252-51.el9_6.1
-    sourcerpm: systemd-252-51.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9_6.1.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 72567
-    checksum: sha256:0d93329b435c0a3e8352abad07516b7715b8687e504f457e5220e24b52a88e5e
-    name: systemd-rpm-macros
-    evr: 252-51.el9_6.1
-    sourcerpm: systemd-252-51.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/u/util-linux-2.37.4-21.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2395065
-    checksum: sha256:61c795084ae4b7745b904347d4643110cd62558fce2978bd4f025ff83524e55f
-    name: util-linux
-    evr: 2.37.4-21.el9
-    sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-21.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 480619
-    checksum: sha256:36389814fcec56d9b9d4bd1a4a63efb1cefa00bc8bacab73f89ef8f8be04b1cd
-    name: util-linux-core
-    evr: 2.37.4-21.el9
-    sourcerpm: util-linux-2.37.4-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/i/iperf3-3.9-14.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 113494
-    checksum: sha256:aa178fcd0927549c9cb5f3df052831405ae31387e05a83c4fb10ca3db2c772d0
-    name: iperf3
-    evr: 3.9-14.el9
-    sourcerpm: iperf3-3.9-14.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 93189
-    checksum: sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a
-    name: libxcrypt-compat
-    evr: 4.4.18-3.el9
-    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/linuxptp-4.4-1.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 308275
-    checksum: sha256:728f1578824407991103868c8f143c949580ca79cbad791685f448afaf2c5238
-    name: linuxptp
-    evr: 4.4-1.el9_6.2
-    sourcerpm: linuxptp-4.4-1.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 234565
-    checksum: sha256:4107c9b2ac6fe1a6be44088f79fcafd012e22c7867dad98741c88590cadeb5a2
-    name: nmap-ncat
-    evr: 3:7.92-3.el9
-    sourcerpm: nmap-7.92-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.2.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 9102
-    checksum: sha256:7aec11632e430e2d0ee4a4a4e60336ce36ebdd023e6a5645175654e3e339e688
-    name: python-unversioned-command
-    evr: 3.9.21-2.el9_6.2
-    sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/realtime-tests-2.8-4.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
-    size: 203068
-    checksum: sha256:9966b0a59543c39994a281c52380dea15804c7388ea930054f827a71ce57cbcc
-    name: realtime-tests
-    evr: 2.8-4.el9
-    sourcerpm: realtime-tests-2.8-4.el9.src.rpm
-  source: []
-  module_metadata: []
+  - arch: x86_64
+    packages:
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/a/acl-2.3.1-4.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 77226
+        checksum: sha256:150d7232faa90f84a09268f8998ee32670eef59cba98612aeb996ab75c4dfcc4
+        name: acl
+        evr: 2.3.1-4.el9
+        sourcerpm: acl-2.3.1-4.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/b/bc-1.07.1-14.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 127511
+        checksum: sha256:9b6d28a6563d4c9f721f031ab0cf146fed097d8c4d186b57eaa8dd9ceb4d0685
+        name: bc
+        evr: 1.07.1-14.el9
+        sourcerpm: bc-1.07.1-14.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/c/cracklib-2.9.6-27.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 100903
+        checksum: sha256:8551b711718596fbfef6622bbf32f785864959af9d06a76da2545ec9f3a126e7
+        name: cracklib
+        evr: 2.9.6-27.el9
+        sourcerpm: cracklib-2.9.6-27.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 3821230
+        checksum: sha256:ab4356c86bdc996dc9e55703a7ae936e3e46aec6ebf6d6f008e126ff06e83df2
+        name: cracklib-dicts
+        evr: 2.9.6-27.el9
+        sourcerpm: cracklib-2.9.6-27.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 8073
+        checksum: sha256:96b1daa4de0a635ab760a8431fb005022bb7cb48d2d1d3ec9a8adb1798c0e10e
+        name: dbus
+        evr: 1:1.12.20-8.el9
+        sourcerpm: dbus-1.12.20-8.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dbus-broker-28-7.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 179634
+        checksum: sha256:de9869c08df7f6952787d0335b9bf1a09b328bea920556a59af07c8e085dd3cb
+        name: dbus-broker
+        evr: 28-7.el9
+        sourcerpm: dbus-broker-28-7.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/d/dbus-common-1.12.20-8.el9.noarch.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 18551
+        checksum: sha256:298f1cada3cbcef6713098b9925694a0e30e8566f7a5bdbd72384520cf6c8360
+        name: dbus-common
+        evr: 1:1.12.20-8.el9
+        sourcerpm: dbus-1.12.20-8.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/elfutils-libelf-0.192-6.el9_6.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 212613
+        checksum: sha256:9c9e2bc6ea19cda24a73f95ef9f439d61fd4480ae1889ac7e0730ee67432fd64
+        name: elfutils-libelf
+        evr: 0.192-6.el9_6
+        sourcerpm: elfutils-0.192-6.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/ethtool-6.11-1.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 258861
+        checksum: sha256:aa81447faad16c8120a7392e03b8fe96d5ac159015fb34403639ca35189a2e46
+        name: ethtool
+        evr: 2:6.11-1.el9
+        sourcerpm: ethtool-6.11-1.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/e/expat-2.5.0-5.el9_6.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 121835
+        checksum: sha256:63522da84934e944305c9e206894031988ab9e561bba2e6c131d76093d1a0211
+        name: expat
+        evr: 2.5.0-5.el9_6
+        sourcerpm: expat-2.5.0-5.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/f/findutils-4.8.0-7.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 563531
+        checksum: sha256:a6328afea0a11647b7fb5c48436f0af6c795407bac0650676d3196dd47070de6
+        name: findutils
+        evr: 1:4.8.0-7.el9
+        sourcerpm: findutils-4.8.0-7.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 171206
+        checksum: sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac
+        name: gzip
+        evr: 1.12-1.el9
+        sourcerpm: gzip-1.12-1.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/i/iproute-6.11.0-1.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 855648
+        checksum: sha256:8fdbd5d311c7002f6553c31406f642ed136e94008b49376d581286646648d11d
+        name: iproute
+        evr: 6.11.0-1.el9
+        sourcerpm: iproute-6.11.0-1.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 476678
+        checksum: sha256:3e79ca4cc3d35c1f1e0ac6c9f05c5be56b7ab6dd1f8ae719a21ec1b9e3bfa018
+        name: iptables-libs
+        evr: 1.8.10-11.el9_5
+        sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/i/iptables-nft-1.8.10-11.el9_5.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 214056
+        checksum: sha256:54e031813637738af285ff4b1c2e4a20b913f2ea643a29940a07ccaf8bd197f5
+        name: iptables-nft
+        evr: 1.8.10-11.el9_5
+        sourcerpm: iptables-1.8.10-11.el9_5.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/i/iputils-20210202-11.el9_6.3.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 177724
+        checksum: sha256:7fe14d3955bb4964bd23e720e6008f01c371b9442cb65d28049b31b34e3885de
+        name: iputils
+        evr: 20210202-11.el9_6.3
+        sourcerpm: iputils-20210202-11.el9_6.3.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kernel-tools-libs-5.14.0-570.51.1.el9_6.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 1913113
+        checksum: sha256:2e92dc54f075d268ef35711782046603557ca1f95b33303326e13ac9e312e4ea
+        name: kernel-tools-libs
+        evr: 5.14.0-570.51.1.el9_6
+        sourcerpm: kernel-5.14.0-570.51.1.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 132888
+        checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
+        name: kmod
+        evr: 28-10.el9
+        sourcerpm: kmod-28-10.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/k/kmod-libs-28-10.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 66607
+        checksum: sha256:9ae0b89812908ee50ec654ba35f74dc478057e8981afd4a5cc8d2befd987b342
+        name: kmod-libs
+        evr: 28-10.el9
+        sourcerpm: kmod-28-10.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libbpf-1.5.0-1.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 191098
+        checksum: sha256:488a913a5f10debb4fb27756f59da75c61c6fefac403ea62d50b8071625d5cf3
+        name: libbpf
+        evr: 2:1.5.0-1.el9
+        sourcerpm: libbpf-1.5.0-1.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libdb-5.3.28-57.el9_6.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 755192
+        checksum: sha256:3246e76f197e2b60eb470b9b55d3e0dda2301b029f295fed9c38ff70b87c5b6b
+        name: libdb
+        evr: 5.3.28-57.el9_6
+        sourcerpm: libdb-5.3.28-57.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libeconf-0.4.1-4.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 30371
+        checksum: sha256:f7998382ca1be7836f6af05d42dc03f88799abcb10aa7a761e16f74058598012
+        name: libeconf
+        evr: 0.4.1-4.el9
+        sourcerpm: libeconf-0.4.1-4.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libfdisk-2.37.4-21.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 159417
+        checksum: sha256:81c7676b72b85d8b5822888c510952ec0996b3d89bf8cddaf76dba31bc72a4a1
+        name: libfdisk
+        evr: 2.37.4-21.el9
+        sourcerpm: util-linux-2.37.4-21.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libibverbs-54.0-1.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 466434
+        checksum: sha256:fc593dc18f73c296df4fa808341cb2dbee7e5082fb872b79e7984c3b24279d3b
+        name: libibverbs
+        evr: 54.0-1.el9
+        sourcerpm: rdma-core-54.0-1.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libmnl-1.0.4-16.el9_4.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 30949
+        checksum: sha256:badfd4eb5b7cd3622da84168674002ec718ef810ce615a1113d3e19e265b777e
+        name: libmnl
+        evr: 1.0.4-16.el9_4
+        sourcerpm: libmnl-1.0.4-16.el9_4.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnetfilter_conntrack-1.0.9-1.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 62066
+        checksum: sha256:beeb73e78390077c6afd9ed6177bad8bad278dbfaae9d90edf7243cdf6a44a3f
+        name: libnetfilter_conntrack
+        evr: 1.0.9-1.el9
+        sourcerpm: libnetfilter_conntrack-1.0.9-1.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnfnetlink-1.0.1-23.el9_5.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 32236
+        checksum: sha256:177882bfe48c9c9effc7b1bce6b58b2466988c53e400c07fb1ba2d3a4ebe6f40
+        name: libnfnetlink
+        evr: 1.0.1-23.el9_5
+        sourcerpm: libnfnetlink-1.0.1-23.el9_5.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 91380
+        checksum: sha256:e64d7b270be4be36af80ed220852cb760a1069e34667b1ba9eec7a02762a14bf
+        name: libnftnl
+        evr: 1.2.6-4.el9_4
+        sourcerpm: libnftnl-1.2.6-4.el9_4.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 376137
+        checksum: sha256:89728a253a5bf1c8e01c40573f1283d40188e003bdbd4ac565f8b0f05bced55c
+        name: libnl3
+        evr: 3.11.0-1.el9
+        sourcerpm: libnl3-3.11.0-1.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libpcap-1.10.0-4.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 180846
+        checksum: sha256:3c0c51cc6b947970812238914713f1f96aa5e9bdaaceb6ee50249540ad89f05b
+        name: libpcap
+        evr: 14:1.10.0-4.el9
+        sourcerpm: libpcap-1.10.0-4.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libpwquality-1.4.4-8.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 126104
+        checksum: sha256:14b7ff2f7fdaf8ebec90261f4619ea7f7c3564c4de8483666de7ed4b1f49b66f
+        name: libpwquality
+        evr: 1.4.4-8.el9
+        sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libseccomp-2.5.2-2.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 76200
+        checksum: sha256:e2015f60dbe784330d5df43f3f05c68c307694600a636a1706bf86527cc82e82
+        name: libseccomp
+        evr: 2.5.2-2.el9
+        sourcerpm: libseccomp-2.5.2-2.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/libutempter-1.2.1-6.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 30354
+        checksum: sha256:0f1df5e0d48c2ac9914bfffa7ed569cd58e42b17ba96bb3f7cf74d1e80de2597
+        name: libutempter
+        evr: 1.2.1-6.el9
+        sourcerpm: libutempter-1.2.1-6.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/l/lksctp-tools-1.0.19-3.el9_4.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 106024
+        checksum: sha256:ac2fc5dcba641ec68b03db44c0b644ef10661bc89a060be2aa1eaa9c6a4215db
+        name: lksctp-tools
+        evr: 1.0.19-3.el9_4
+        sourcerpm: lksctp-tools-1.0.19-3.el9_4.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/n/numactl-libs-2.0.19-1.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 33709
+        checksum: sha256:ce2f00b2527e29f6b389e5899750e2b6eb1e5ce484ddfdcd6f01fa311efe7860
+        name: numactl-libs
+        evr: 2.0.19-1.el9
+        sourcerpm: numactl-2.0.19-1.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-3.2.2-6.el9_5.1.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 1420999
+        checksum: sha256:f379686df99db814e30568a896b417278775fc96864ac6d2660bf48ef94309e3
+        name: openssl
+        evr: 1:3.2.2-6.el9_5.1
+        sourcerpm: openssl-3.2.2-6.el9_5.1.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/pam-1.5.1-26.el9_6.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 636788
+        checksum: sha256:247027fa7a2236c1fb46756ed372637f85cf85886603a2ad5ba918e4231324bc
+        name: pam
+        evr: 1.5.1-26.el9_6
+        sourcerpm: pam-1.5.1-26.el9_6.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/procps-ng-3.3.17-14.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 361526
+        checksum: sha256:506ad778f63821e8d9647ca8e0a3ff21b8af9c1666060d5200f9b26ee718333c
+        name: procps-ng
+        evr: 3.3.17-14.el9
+        sourcerpm: procps-ng-3.3.17-14.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/psmisc-23.4-3.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 253357
+        checksum: sha256:30ad5408417c7f06fb945dc321bef3ce31f813f25389707dd1efa7c1d337b806
+        name: psmisc
+        evr: 23.4-3.el9
+        sourcerpm: psmisc-23.4-3.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-3.9.21-2.el9_6.2.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 26190
+        checksum: sha256:2572fc0f6c65dc5201c65a48f7d962a04a09669feae2fcdc4e5f9e910b9195c6
+        name: python3
+        evr: 3.9.21-2.el9_6.2
+        sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9_6.2.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 8474800
+        checksum: sha256:a8a433346daa16f25d8f672bdc6cbee9277631c60378006fb1056b4443ce505d
+        name: python3-libs
+        evr: 3.9.21-2.el9_6.2
+        sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 1193706
+        checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
+        name: python3-pip-wheel
+        evr: 21.3.1-1.el9
+        sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/p/python3-setuptools-wheel-53.0.0-13.el9_6.1.noarch.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 479114
+        checksum: sha256:99807cec6f3941b1ec963813a5eaf7cf7922690cda6b35cd0f1fe0a3bdc1459f
+        name: python3-setuptools-wheel
+        evr: 53.0.0-13.el9_6.1
+        sourcerpm: python-setuptools-53.0.0-13.el9_6.1.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-252-51.el9_6.2.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 4397767
+        checksum: sha256:b7acb6861d52c368eeb23afe3413f4de4ba60281598e55f931b2a4882b5ae239
+        name: systemd
+        evr: 252-51.el9_6.2
+        sourcerpm: systemd-252-51.el9_6.2.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-pam-252-51.el9_6.2.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 285233
+        checksum: sha256:bb438d85cdf5dc7a53cf1309fa48d7be8814e9cfaec846efe8bb559720325fb7
+        name: systemd-pam
+        evr: 252-51.el9_6.2
+        sourcerpm: systemd-252-51.el9_6.2.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-51.el9_6.2.noarch.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 68125
+        checksum: sha256:a9d98e4240645fa96c953218bc89dbda221e33247f2890790dead31b53adff49
+        name: systemd-rpm-macros
+        evr: 252-51.el9_6.2
+        sourcerpm: systemd-252-51.el9_6.2.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/u/util-linux-2.37.4-21.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 2395065
+        checksum: sha256:61c795084ae4b7745b904347d4643110cd62558fce2978bd4f025ff83524e55f
+        name: util-linux
+        evr: 2.37.4-21.el9
+        sourcerpm: util-linux-2.37.4-21.el9.src.rpm
+      - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/u/util-linux-core-2.37.4-21.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-baseos-rpms
+        size: 480619
+        checksum: sha256:36389814fcec56d9b9d4bd1a4a63efb1cefa00bc8bacab73f89ef8f8be04b1cd
+        name: util-linux-core
+        evr: 2.37.4-21.el9
+        sourcerpm: util-linux-2.37.4-21.el9.src.rpm
+      - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/i/iperf3-3.9-14.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-appstream-eus-rpms
+        size: 113494
+        checksum: sha256:aa178fcd0927549c9cb5f3df052831405ae31387e05a83c4fb10ca3db2c772d0
+        name: iperf3
+        evr: 3.9-14.el9
+        sourcerpm: iperf3-3.9-14.el9.src.rpm
+      - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-appstream-eus-rpms
+        size: 93189
+        checksum: sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a
+        name: libxcrypt-compat
+        evr: 4.4.18-3.el9
+        sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+      - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/linuxptp-4.4-1.el9_6.4.x86_64.rpm
+        repoid: rhel-9-for-x86_64-appstream-eus-rpms
+        size: 307876
+        checksum: sha256:23963292249df6d131cc249ff40edfca9c462b20fedd6aeb951a50aab03d8ddf
+        name: linuxptp
+        evr: 4.4-1.el9_6.4
+        sourcerpm: linuxptp-4.4-1.el9_6.4.src.rpm
+      - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-appstream-eus-rpms
+        size: 234565
+        checksum: sha256:4107c9b2ac6fe1a6be44088f79fcafd012e22c7867dad98741c88590cadeb5a2
+        name: nmap-ncat
+        evr: 3:7.92-3.el9
+        sourcerpm: nmap-7.92-3.el9.src.rpm
+      - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.21-2.el9_6.2.noarch.rpm
+        repoid: rhel-9-for-x86_64-appstream-eus-rpms
+        size: 9102
+        checksum: sha256:7aec11632e430e2d0ee4a4a4e60336ce36ebdd023e6a5645175654e3e339e688
+        name: python-unversioned-command
+        evr: 3.9.21-2.el9_6.2
+        sourcerpm: python3.9-3.9.21-2.el9_6.2.src.rpm
+      - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/realtime-tests-2.8-4.el9.x86_64.rpm
+        repoid: rhel-9-for-x86_64-appstream-eus-rpms
+        size: 203068
+        checksum: sha256:9966b0a59543c39994a281c52380dea15804c7388ea930054f827a71ce57cbcc
+        name: realtime-tests
+        evr: 2.8-4.el9
+        sourcerpm: realtime-tests-2.8-4.el9.src.rpm
+    source: []
+    module_metadata: []


### PR DESCRIPTION
consume latest content to update CHI scores.


(cherry picked from commit d8f59cd4de0d014212132fb590e91ce4c2c1ada5)