### PR TITLE
infra: Add kustomize validation check

### DIFF
--- a/.github/workflows/test-kustomize.yaml
+++ b/.github/workflows/test-kustomize.yaml
@@ -1,0 +1,36 @@
+name: Kustomize Validation
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  kustomize-validation:
+    name: Validate Kustomization Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Kustomize
+        run: |
+          set -euo pipefail
+
+          KUSTOMIZE_VERSION="5.8.1"
+          ASSET="kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/${ASSET}"
+          EXPECTED_SHA256="029a7f0f4e1932c52a0476cf02a0fd855c0bb85694b82c338fc648dcb53a819d"
+
+          curl -fsSLO --retry 3 --retry-delay 2 "$URL"
+          echo "${EXPECTED_SHA256}  ${ASSET}" | sha256sum -c -
+
+          tar -xzf "${ASSET}"
+          sudo install -m 0755 kustomize /usr/local/bin/kustomize
+          kustomize version
+
+      - name: Validate Kustomization Files
+        run: make test-kustomize

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ export FEATURES_ENVIRONMENT?=deploy
 	ci-job \
 	feature-deploy \
 	cnf-tests-local \
-	test-bin
+	test-bin \
+	test-kustomize
 
 TARGET_GOOS=linux
 TARGET_GOARCH=amd64
@@ -168,3 +169,7 @@ list:
 cnftests-unit:
 	@echo "Running cnf-tests utility function unit tests"
 	go test ./cnf-tests/testsuites/pkg/...
+
+test-kustomize:
+	@echo "Validating kustomization files"
+	hack/test-kustomize.sh

--- a/hack/test-kustomize.sh
+++ b/hack/test-kustomize.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Directories that require OpenShift ZTP external kustomize plugins
+# These plugins (PolicyGenerator, ClusterInstance, SiteConfig, PolicyGenTemplate) are distributed
+# via Red Hat container images and are designed to run in OpenShift ArgoCD with ACM/MCE installed.
+#
+# These plugins come from:
+# - registry.redhat.io/openshift4/ztp-site-generate-rhel8 (ClusterInstance, SiteConfig)
+# - registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9 (PolicyGenerator)
+#
+# They require:
+# - KUSTOMIZE_PLUGIN_HOME environment variable
+# - kustomize --enable-alpha-plugins flag
+# - The plugin binaries extracted from the container images
+#
+# These can only be validated in an OpenShift cluster environment with ZTP tooling installed.
+# Standard kustomize cannot process them without these prerequisites.
+EXCLUDED_DIRS=(
+    "./ztp/policygenerator-kustomize-plugin"
+    "./ztp/siteconfig-generator-kustomize-plugin"
+    "./ztp/gitops-subscriptions/argocd/example/acmpolicygenerator"
+    "./ztp/gitops-subscriptions/argocd/example/policygentemplates"
+    "./ztp/gitops-subscriptions/argocd/example/siteconfig"
+    "./ztp/gitops-subscriptions/argocd/example/image-based-upgrades"
+    "./ztp/resource-generator/telco-reference/telco-ran/configuration/argocd/example/acmpolicygenerator"
+    "./ztp/resource-generator/telco-reference/telco-ran/configuration/argocd/example/policygentemplates"
+    "./ztp/resource-generator/telco-reference/telco-ran/configuration/argocd/example/siteconfig"
+    "./ztp/resource-generator/telco-reference/telco-ran/configuration/argocd/example/image-based-upgrades"
+    "./ztp/resource-generator/telco-reference/telco-ran/configuration/argocd/example/clusterinstance"
+    "./ztp/resource-generator/telco-reference/telco-ran/install/siteconfig"
+    "./ztp/resource-generator/telco-reference/telco-ran/install/clusterinstance"
+    "./ztp/resource-generator/telco-reference/telco-core/configuration"
+    "./feature-configs/demo/local_bfd"
+    "./cnf-tests/submodules/cluster-node-tuning-operator/examples/performanceprofile/default"
+    "./cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/cluster-setup/manual-cluster/cpuFrequency"
+    "./cnf-tests/submodules/metallb-operator/hack/ocp-kustomize-overlay"
+    "./cnf-tests/submodules/metallb-operator/manifests/ocpcsv"
+)
+
+# Check if kustomize is installed
+if ! command -v kustomize &> /dev/null; then
+    echo -e "${RED}ERROR: kustomize is not installed${NC}"
+    echo ""
+    echo "Please install kustomize to run this check:"
+    echo "  - macOS: brew install kustomize"
+    echo "  - Linux: curl -s \"https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh\" | bash"
+    echo "  - Manual: https://kubectl.docs.kubernetes.io/installation/kustomize/"
+    echo ""
+    exit 1
+fi
+
+echo "Checking all kustomization.yaml files can build successfully..."
+echo ""
+
+ERRORS=0
+CHECKED=0
+SKIPPED=0
+
+# Helper function to check if directory should be excluded
+is_excluded() {
+    local dir="$1"
+    for excluded in "${EXCLUDED_DIRS[@]}"; do
+        if [ "$dir" = "$excluded" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Find all kustomization.yaml files
+kustomize_files=()
+while IFS= read -r file; do
+    kustomize_files+=("$file")
+done < <(find . \( -name 'kustomization.yaml' -o -name 'kustomization.yml' \) -not -path '*/vendor/*' -not -path '*/submodules/*' -not -path '*/.git/*' | sort)
+
+if [ ${#kustomize_files[@]} -eq 0 ]; then
+    echo -e "${YELLOW}WARNING: No kustomization.yaml files found${NC}"
+    exit 0
+fi
+
+for kustomize_file in "${kustomize_files[@]}"; do
+    dir=$(dirname "$kustomize_file")
+    echo -n "  $dir: "
+
+    # Check if this directory requires external plugins
+    if is_excluded "$dir"; then
+        echo -e "${BLUE}SKIPPED${NC} (requires external plugins)"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    # Try to build the kustomization
+    if kustomize build "$dir" > /dev/null 2>&1; then
+        echo -e "${GREEN}OK${NC}"
+        CHECKED=$((CHECKED + 1))
+    else
+        echo -e "${RED}FAILED${NC}"
+        echo -e "${YELLOW}    Error details:${NC}"
+        kustomize build "$dir" 2>&1 | sed 's/^/    /'
+        echo ""
+        ERRORS=$((ERRORS + 1))
+        CHECKED=$((CHECKED + 1))
+    fi
+done
+
+echo ""
+echo "Summary: Checked $CHECKED kustomization.yaml files, skipped $SKIPPED (require external plugins)"
+
+if [[ $ERRORS -eq 0 ]]; then
+    echo -e "${GREEN}All kustomization files validated successfully!${NC}"
+    exit 0
+else
+    echo -e "${RED}$ERRORS kustomization file(s) failed validation${NC}"
+    exit 1
+fi


### PR DESCRIPTION
**Note**: It looks like Actions aren't enabled for this repo.  So it will need to be enabled prior to this being merged.

Similar to: https://github.com/openshift-kni/telco-reference/pull/433

Changes:
- Adds a quick PR check that attempts to `kustomize build` appropriate files.  Only runs against `main`.
- Adds a make path for `make test-kustomize` which runs the script.  Users can run this locally as well as there are safeguards to ensure `kustomize` exists first.
- Skips YAMLs that might require external plugins.  See `EXCLUDED_DIRS`.

Example run:

```
$ make test-kustomize 
Validating kustomization files
hack/test-kustomize.sh
Checking all kustomization.yaml files can build successfully...

  ./cnf-tests/submodules/cluster-node-tuning-operator/examples/performanceprofile/crd: OK
  ./cnf-tests/submodules/cluster-node-tuning-operator/examples/performanceprofile/default: SKIPPED (requires external plugins)
  ./cnf-tests/submodules/cluster-node-tuning-operator/examples/performanceprofile/rbac: OK
  ./cnf-tests/submodules/cluster-node-tuning-operator/examples/performanceprofile/samples: OK
  ./cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/cluster-setup/base/performance: OK
  ./cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/cluster-setup/ci-cluster/performance: OK
  ./cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/cluster-setup/ci-upgrade-test-cluster/performance: OK
  ./cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/cluster-setup/manual-cluster/arm: OK
  ./cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/cluster-setup/manual-cluster/cpuFrequency: SKIPPED (requires external plugins)
  ./cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance-norps: OK
  ./cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance: OK
  ./cnf-tests/submodules/cluster-node-tuning-operator/test/e2e/performanceprofile/cluster-setup/mcp-only-cluster/performance: OK
  ./cnf-tests/submodules/metallb-operator/config/crd: OK
  ./cnf-tests/submodules/metallb-operator/config/default: OK
  ./cnf-tests/submodules/metallb-operator/config/frr-webhook-prometheus: OK
  ./cnf-tests/submodules/metallb-operator/config/manager: OK
  ./cnf-tests/submodules/metallb-operator/config/manifests: OK
  ./cnf-tests/submodules/metallb-operator/config/metallb_rbac: OK
  ./cnf-tests/submodules/metallb-operator/config/olm-install: OK
  ./cnf-tests/submodules/metallb-operator/config/openshift: OK
  ./cnf-tests/submodules/metallb-operator/config/rbac: OK
  ./cnf-tests/submodules/metallb-operator/config/samples: OK
  ./cnf-tests/submodules/metallb-operator/config/scorecard: OK
  ./cnf-tests/submodules/metallb-operator/config/webhook/backend: OK
  ./cnf-tests/submodules/metallb-operator/config/webhook: OK
  ./cnf-tests/submodules/metallb-operator/config/webhook/webhook: OK
  ./cnf-tests/submodules/metallb-operator/hack/ocp-kustomize-overlay: SKIPPED (requires external plugins)
  ./cnf-tests/submodules/metallb-operator/manifests/ocpcsv: SKIPPED (requires external plugins)
  ./cnf-tests/submodules/sriov-network-operator/config/crd: OK
  ./cnf-tests/submodules/sriov-network-operator/config/default: OK
  ./cnf-tests/submodules/sriov-network-operator/config/manager: OK
  ./cnf-tests/submodules/sriov-network-operator/config/manifests: OK
  ./cnf-tests/submodules/sriov-network-operator/config/prometheus: OK
  ./cnf-tests/submodules/sriov-network-operator/config/rbac: OK
  ./cnf-tests/submodules/sriov-network-operator/config/samples: OK
  ./cnf-tests/submodules/sriov-network-operator/config/scorecard: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/cu-up-m1: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/cu-up-m1/nw-config: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/cu-up-m1/nw-config/sriov: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/cu-up-m1/role-hardware: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/cu-up-m1/role-hardware/performance: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/cu-up-m1/role-hardware/ran-general: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/du-dc-m1: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/du-dc-m1/nw-config: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/du-dc-m1/nw-config/sriov: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/du-dc-m1/role-hardware: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/du-dc-m1/role-hardware/performance: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/du-dc-m1/role-hardware/ptp: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/du-dc-m1/role-hardware/ran-general: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/remote-sites/otwaon23456rw: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/remote-sites/otwaon23456rw/nw-config: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/remote-sites/otwaon23456rw/nw-config/sriov: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/remote-sites/otwaon23456rw/role-hardware: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/remote-sites/otwaon23456rw/role-hardware/performance: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/remote-sites/otwaon23456rw/role-hardware/ptp: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon1234rd/remote-sites/otwaon23456rw/role-hardware/ran-general: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon34567sno: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon34567sno/nw-config: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon34567sno/nw-config/logging: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon34567sno/nw-config/sriov: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon34567sno/role-hardware: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon34567sno/role-hardware/performance: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon34567sno/role-hardware/ptp: OK
  ./feature-configs/5g-ref-nw/clusters/otwaon34567sno/role-hardware/ran-general: OK
  ./feature-configs/5g-ref-nw/operators/cluster-logging: OK
  ./feature-configs/5g-ref-nw/operators/ptp: OK
  ./feature-configs/5g-ref-nw/operators/sriov: OK
  ./feature-configs/5g-ref-nw/profile-base/cu-up/performance: OK
  ./feature-configs/5g-ref-nw/profile-base/cu-up/sriov: OK
  ./feature-configs/5g-ref-nw/profile-base/du-dual/performance: OK
  ./feature-configs/5g-ref-nw/profile-base/du-dual/sriov: OK
  ./feature-configs/5g-ref-nw/profile-base/du-general: OK
  ./feature-configs/5g-ref-nw/profile-base/du-general/performance: OK
  ./feature-configs/5g-ref-nw/profile-base/du-general/ptp/disable-chronyd: OK
  ./feature-configs/5g-ref-nw/profile-base/du-general/ptp: OK
  ./feature-configs/5g-ref-nw/profile-base/du-single/performance: OK
  ./feature-configs/5g-ref-nw/profile-base/du-single/sriov: OK
  ./feature-configs/5g-ref-nw/profile-base/ran-general/container-mount-namespace: OK
  ./feature-configs/5g-ref-nw/profile-base/ran-general: OK
  ./feature-configs/5g-ref-nw/profile-base/ran-general/sctp: OK
  ./feature-configs/5g-ref-nw/profile-base/sno-general: OK
  ./feature-configs/ci/container-mount-namespace: OK
  ./feature-configs/ci/fec: OK
  ./feature-configs/ci/gatekeeper: OK
  ./feature-configs/ci/knmstate: OK
  ./feature-configs/ci/localhost-workaround: OK
  ./feature-configs/ci/metallb: OK
  ./feature-configs/ci/multinetworkpolicy: OK
  ./feature-configs/ci/n3000: OK
  ./feature-configs/ci/ptp: OK
  ./feature-configs/ci/s2i: OK
  ./feature-configs/ci/sctp: OK
  ./feature-configs/ci/sriov: OK
  ./feature-configs/ci/sro: OK
  ./feature-configs/cn-ran-overlays/ran-profile-gcp: OK
  ./feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/performance: OK
  ./feature-configs/cn-ran-overlays/ran-profile/cluster-config/du-common/ptp: OK
  ./feature-configs/cn-ran-overlays/ran-profile/cluster-config: OK
  ./feature-configs/cn-ran-overlays/ran-profile: OK
  ./feature-configs/cn-ran-overlays/ran-profile/site.1.fqdn: OK
  ./feature-configs/cn-ran-overlays/ran-profile/site.1.fqdn/networks: OK
  ./feature-configs/demo/local_bfd: SKIPPED (requires external plugins)
  ./feature-configs/demo/performance: OK
  ./feature-configs/demo/ptp: OK
  ./feature-configs/demo/s2i: OK
  ./feature-configs/demo/sctp: OK
  ./feature-configs/demo/sriov: OK
  ./feature-configs/deploy/container-mount-namespace/container-private-mounts: OK
  ./feature-configs/deploy/container-mount-namespace: OK
  ./feature-configs/deploy/container-mount-namespace/master: OK
  ./feature-configs/deploy/container-mount-namespace/worker: OK
  ./feature-configs/deploy/fec: OK
  ./feature-configs/deploy/gatekeeper: OK
  ./feature-configs/deploy/knmstate: OK
  ./feature-configs/deploy/localhost-workaround: OK
  ./feature-configs/deploy/metallb: OK
  ./feature-configs/deploy/multinetworkpolicy: OK
  ./feature-configs/deploy/n3000: OK
  ./feature-configs/deploy/ptp: OK
  ./feature-configs/deploy/s2i: OK
  ./feature-configs/deploy/sctp: OK
  ./feature-configs/deploy/sriov: OK
  ./feature-configs/deploy/sro: OK
  ./feature-configs/hypershift-ci/metallb: OK
  ./feature-configs/hypershift-ci/multinetworkpolicy: OK
  ./feature-configs/hypershift-ci/ptp: OK
  ./feature-configs/hypershift-ci/s2i: OK
  ./feature-configs/hypershift-ci/sriov: OK
  ./feature-configs/integration-base/performance: OK
  ./feature-configs/integration-base/ptp: OK
  ./feature-configs/integration-base/sctp: OK
  ./feature-configs/integration-base/sriov: OK
  ./feature-configs/integration-kni1/performance: OK
  ./feature-configs/integration-kni1/ptp: OK
  ./feature-configs/integration-kni1/s2i: OK
  ./feature-configs/integration-kni1/sctp: OK
  ./feature-configs/integration-kni1/sriov: OK
  ./feature-configs/integration-u08/performance: OK
  ./feature-configs/integration-u08/ptp: OK
  ./feature-configs/integration-u08/s2i: OK
  ./feature-configs/integration-u08/sctp: OK
  ./feature-configs/integration-u08/sriov: OK
  ./feature-configs/integration-vms/performance: OK
  ./feature-configs/integration-vms/sctp: OK
  ./feature-configs/integration-wl4-d17u01b05/performance: OK
  ./feature-configs/typical-baremetal/container-mount-namespace: OK
  ./feature-configs/typical-baremetal/performance: OK
  ./feature-configs/typical-baremetal/ptp: OK
  ./feature-configs/typical-baremetal/s2i: OK
  ./feature-configs/typical-baremetal/sctp: OK
  ./feature-configs/typical-baremetal/sriov: OK
  ./ztp/gitops-subscriptions/acm: OK
  ./ztp/gitops-subscriptions/argocd/deployment: OK
  ./ztp/gitops-subscriptions/argocd/example/acmpolicygenerator: SKIPPED (requires external plugins)
  ./ztp/gitops-subscriptions/argocd/example/image-based-upgrades: SKIPPED (requires external plugins)
  ./ztp/gitops-subscriptions/argocd/example/policygentemplates: SKIPPED (requires external plugins)
  ./ztp/gitops-subscriptions/argocd/example/siteconfig: SKIPPED (requires external plugins)
  ./ztp/policygenerator-kustomize-plugin: SKIPPED (requires external plugins)
  ./ztp/ran-crd: OK
  ./ztp/resource-generator/telco-reference/telco-core/configuration: SKIPPED (requires external plugins)
  ./ztp/resource-generator/telco-reference/telco-hub/configuration/reference-crs: OK
  ./ztp/resource-generator/telco-reference/telco-hub/configuration/reference-crs/optional/lso: OK
  ./ztp/resource-generator/telco-reference/telco-hub/configuration/reference-crs/optional/odf-internal: OK
  ./ztp/resource-generator/telco-reference/telco-hub/configuration/reference-crs/required/acm: OK
  ./ztp/resource-generator/telco-reference/telco-hub/configuration/reference-crs/required/gitops: OK
  ./ztp/resource-generator/telco-reference/telco-hub/configuration/reference-crs/required/gitops/ztp-installation: OK
  ./ztp/resource-generator/telco-reference/telco-hub/configuration/reference-crs/required/talm: OK
  ./ztp/resource-generator/telco-reference/telco-ran/configuration/argocd/deployment: OK
  ./ztp/resource-generator/telco-reference/telco-ran/configuration/argocd/example/acmpolicygenerator: SKIPPED (requires external plugins)
  ./ztp/resource-generator/telco-reference/telco-ran/configuration/argocd/example/image-based-upgrades: SKIPPED (requires external plugins)
  ./ztp/resource-generator/telco-reference/telco-ran/configuration/argocd/example/policygentemplates: SKIPPED (requires external plugins)
  ./ztp/resource-generator/telco-reference/telco-ran/configuration/argocd/example/siteconfig: SKIPPED (requires external plugins)
  ./ztp/resource-generator/telco-reference/telco-ran/install/clusterinstance: SKIPPED (requires external plugins)
  ./ztp/resource-generator/telco-reference/telco-ran/install/siteconfig: SKIPPED (requires external plugins)
  ./ztp/siteconfig-generator-kustomize-plugin: SKIPPED (requires external plugins)

Summary: Checked 157 kustomization.yaml files, skipped 18 (require external plugins)
All kustomization files validated successfully!
```