### PR TITLE
cnf-tests: rpms: use custom authentication certificate

### DIFF
--- a/cnf-tests/.konflux/Makefile
+++ b/cnf-tests/.konflux/Makefile
@@ -41,6 +41,9 @@ konflux-update-rpm-lock-runtime: sync-telco5g-konflux-submodule ## Update the rp
 	cp $(PROJECT_DIR)/Dockerfile $(PROJECT_DIR)/lock-runtime/Dockerfile
 	@echo "Copying rpms.in.yaml to lock-runtime directory..."
 	cp $(PROJECT_DIR)/rpms.in.yaml $(PROJECT_DIR)/lock-runtime/rpms.in.yaml
+	sed -i 's|sslclientkey: $$SSL_CLIENT_KEY|sslclientkey: /etc/pki/entitlement/placeholder-key.pem|g' $(PROJECT_DIR)/lock-runtime/rpms.in.yaml
+	sed -i 's|sslclientcert: $$SSL_CLIENT_CERT|sslclientcert: /etc/pki/entitlement/placeholder.pem|g' $(PROJECT_DIR)/lock-runtime/rpms.in.yaml
+	@cat $(PROJECT_DIR)/lock-runtime/rpms.in.yaml
 	$(MAKE) -C $(ROOT_PROJECT_DIR)/telco5g-konflux/scripts/rpm-lock generate-rhel9-locks \
 		LOCK_SCRIPT_TARGET_DIR=$(PROJECT_DIR)/lock-runtime \
 		RHEL9_IMAGE_TO_LOCK=$$(awk '/^FROM registry.access.redhat.com\/ubi9\/ubi-minimal:/ {print $$2}' $(PROJECT_DIR)/Dockerfile) \

--- a/cnf-tests/.konflux/rpms.in.yaml
+++ b/cnf-tests/.konflux/rpms.in.yaml
@@ -9,8 +9,8 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: 1
       sslcacert: /etc/rhsm/ca/redhat-uep.pem
-      sslclientkey: /etc/pki/entitlement/6393523032355816278-key.pem
-      sslclientcert: /etc/pki/entitlement/6393523032355816278.pem
+      sslclientkey: $SSL_CLIENT_KEY
+      sslclientcert: $SSL_CLIENT_CERT
       sslverifystatus: 1
       varsFromContainerfile: Dockerfile
     - repoid: rhel-9-for-$basearch-baseos-rpms
@@ -20,8 +20,8 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: 1
       sslcacert: /etc/rhsm/ca/redhat-uep.pem
-      sslclientkey: /etc/pki/entitlement/6393523032355816278-key.pem
-      sslclientcert: /etc/pki/entitlement/6393523032355816278.pem
+      sslclientkey: $SSL_CLIENT_KEY
+      sslclientcert: $SSL_CLIENT_CERT
       sslverifystatus: 1
       varsFromContainerfile: Dockerfile
     - repoid: rhel-9-for-$basearch-baseos-eus-rpms
@@ -31,8 +31,8 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: 1
       sslcacert: /etc/rhsm/ca/redhat-uep.pem
-      sslclientkey: /etc/pki/entitlement/6393523032355816278-key.pem
-      sslclientcert: /etc/pki/entitlement/6393523032355816278.pem
+      sslclientkey: $SSL_CLIENT_KEY
+      sslclientcert: $SSL_CLIENT_CERT
       sslverifystatus: 1
       varsFromContainerfile: Dockerfile
     - repoid: rhel-9-for-$basearch-appstream-rpms
@@ -42,8 +42,8 @@ contentOrigin:
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
       sslverify: 1
       sslcacert: /etc/rhsm/ca/redhat-uep.pem
-      sslclientkey: /etc/pki/entitlement/6393523032355816278-key.pem
-      sslclientcert: /etc/pki/entitlement/6393523032355816278.pem
+      sslclientkey: $SSL_CLIENT_KEY
+      sslclientcert: $SSL_CLIENT_CERT
       sslverifystatus: 1
       varsFromContainerfile: Dockerfile
 


### PR DESCRIPTION
Following
https://konflux.pages.redhat.com/docs/users/mintmaker/rpm-lockfile.html#rpm-lockfile-with-rpms-that-require-subscription, use env variables to pass on the auth certificate of the telco tenant activation key.