### PR TITLE
OCPBUGS-65595: ztp: siteconfig-converter: Generate extra-manifest without using siteconfig-generator binary

### DIFF
--- a/ztp/tools/siteconfig-converter/Makefile
+++ b/ztp/tools/siteconfig-converter/Makefile
@@ -2,8 +2,8 @@
 
 # Variables
 BINARY_NAME = siteconfig-converter
-GO_FILES = main.go convert.go
-TEST_FILES = convert_test.go
+GO_FILES = main.go convert.go extraManifests.go
+TEST_FILES = convert_test.go extraManifests_test.go
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 EXAMPLE_FILE = samples/example-sno1.yaml

--- a/ztp/tools/siteconfig-converter/README.md
+++ b/ztp/tools/siteconfig-converter/README.md
@@ -15,7 +15,6 @@ The manifests will be generated in the `./output` directory
 
 ```
 podman run -d --rm --name ztp ${IMAGE} tail -f /dev/null
-podman cp ztp:/usr/bin/siteconfig-generator ./
 podman cp ztp:/usr/bin/siteconfig-converter ./
 podman stop ztp
 sudo cp siteconfig-converter siteconfig-generator /usr/local/bin
@@ -25,7 +24,7 @@ tree output-cluster-instance
 output-cluster-instance
 ├── cnfdf26.yaml
 ├── extra-manifests
-│   └── cnfdf26_machineconfig_98-var-lib-containers-partitioned.yaml
+│   └── 98-var-lib-containers-partitioned.yaml
 └── kustomization-configMapGenerator-snippet.yaml
 ```
 
@@ -233,7 +232,7 @@ The `siteconfig-converter` tool automatically generates ConfigMap kustomization 
 
 This process:
 1. Creates the `extra-manifests` directory in the output directory
-2. Extracts all the extra manifests using the `siteconfig-generator` binary into this directory
+2. Extracts all the extra manifests into this directory
 3. Creates a `kustomization-configMapGenerator-snippet.yaml` file which includes a kustomize `configMapGenerator` that will sync the extra manifests ConfigMap on the hub cluster.
 
 The extra manifest ConfigMap is automatically added to the `extraManifestRefs` field of the `ClusterInstance`.
@@ -257,15 +256,12 @@ $ tree output
 output
 ├── cnfdf28.yaml
 ├── extra-manifests
-│   ├── cnfdf28_machineconfig_98-var-lib-containers-partitioned.yaml
-│   └── cnfdf28_machineconfig_99-set-core-user-password.yaml
+│   ├── 98-var-lib-containers-partitioned.yaml
+│   └── set-core-user-password.yaml
 └── kustomization-configMapGenerator-snippet.yaml
 ```
 
 You can merge the generated kustomization file with your original one to generate the ConfigMap and the `ClusterInstance`.
-
-**Requirements:**
-- The `siteconfig-generator` binary must be available in your system PATH (available in the `ztp-site-generator` container)
 
 For the complete directory structure and detailed workflow, refer to the [SiteConfig documentation](https://github.com/stolostron/siteconfig/blob/main/docs/argocd.md#generate-extra-manifests-configmap-using-kustomize).
 

--- a/ztp/tools/siteconfig-converter/convert.go
+++ b/ztp/tools/siteconfig-converter/convert.go
@@ -453,22 +453,14 @@ func convertToClusterInstance(siteConfig *SiteConfig, outputDir string, clusterT
 				"Use a ConfigMap which contains the already merged MachineConfigs and reference it through extraManifestsRefs instead.\n")
 		}
 
-		// Check for extraManifestOnly
 		if cluster.ExtraManifestOnly {
-			warningsCollector.AddWarning("WARNING: extraManifestOnly field is not supported in ClusterInstance and will be ignored. \n")
+			warningsCollector.AddWarning("WARNING: extraManifestOnly field is not part of ClusterInstance spec. " +
+				"Extra manifests will be generated from this SiteConfig and included in the extraManifestsRefs ConfigMap, but the full ClusterInstance CR set will also be generated.\n")
 		}
 
-		// Check for extraManifests
-		if (cluster.ExtraManifests.SearchPaths != nil && len(*cluster.ExtraManifests.SearchPaths) > 0) ||
-			(cluster.ExtraManifests.Filter != nil && len(cluster.ExtraManifests.Filter.Exclude) > 0) {
-			warningsCollector.AddWarning("WARNING: extraManifests field is not supported in ClusterInstance and will be ignored. " +
-				"Create one or more configmaps with the exact desired set of CRs for the cluster and include them in the extraManifestsRefs.\n")
-		}
-
-		// Check for extraManifestPath
 		if cluster.ExtraManifestPath != "" {
 			warningsCollector.AddWarning(fmt.Sprintf("WARNING: extraManifestPath field '%s' is not supported in ClusterInstance and will be ignored. "+
-				"Create one or more configmaps with the exact desired set of CRs for the cluster and include them in the extraManifestsRefs.\n",
+				"Use extraManifests field instead\n",
 				cluster.ExtraManifestPath))
 		}
 

--- a/ztp/tools/siteconfig-converter/extraManifests.go
+++ b/ztp/tools/siteconfig-converter/extraManifests.go
@@ -1,0 +1,527 @@
+package main
+
+import (
+	"bytes"
+	base64 "encoding/base64"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"text/template"
+	"unicode"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Constants for extra-manifests generation
+const (
+	localExtraManifestPath    = "extra-manifest"
+	workloadPath              = "workload"
+	workloadFile              = "03-workload-partitioning.yaml"
+	workloadCrioFile          = "crio.conf"
+	workloadKubeletFile       = "kubelet.conf"
+	cpuset                    = "$cpuset"
+	SNO                       = "sno"
+	ZtpAnnotation             = "ran.openshift.io/ztp-gitops-generated"
+	ZtpAnnotationDefaultValue = "{}"
+)
+
+// DirContainFiles represents a directory and its files
+type DirContainFiles struct {
+	Directory string
+	Files     []fs.FileInfo
+}
+
+// resolveFilePath resolves a file path, checking if it's absolute first
+func resolveFilePath(filePath string, basedir string) string {
+	// If path is already absolute, return it as-is
+	if filepath.IsAbs(filePath) {
+		return filePath
+	}
+	// Check if the path exists as-is (could be relative to current working directory)
+	if _, err := os.Stat(filePath); err == nil {
+		return filePath
+	}
+	// Otherwise, resolve relative to basedir
+	return filepath.Join(basedir, filePath)
+}
+
+// GetFiles returns file info for a path (file or directory)
+func GetFiles(path string) ([]fs.FileInfo, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if fileInfo.IsDir() {
+		var files []fs.FileInfo
+		results, err := os.ReadDir(path)
+		if err != nil {
+			return nil, err
+		}
+
+		// Translate []fs.DirEntry to []fs.FileInfo
+		for _, result := range results {
+			resultsInfo, err := result.Info()
+			if err != nil {
+				return nil, err
+			}
+			files = append(files, resultsInfo)
+		}
+
+		return files, nil
+	}
+
+	return []fs.FileInfo{fileInfo}, nil
+}
+
+// ReadFile reads a file and returns its contents
+func ReadFile(filePath string) ([]byte, error) {
+	return os.ReadFile(filePath)
+}
+
+// ReadExtraManifestResourceFile reads an extra manifest resource file
+func ReadExtraManifestResourceFile(filePath string) ([]byte, error) {
+	var dir = ""
+	var err error = nil
+	var ret []byte
+
+	ex, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	dir = filepath.Dir(ex)
+
+	ret, err = ReadFile(resolveFilePath(filePath, dir))
+
+	// added fail safe for test runs as `os.Executable()` will fail for tests
+	if err != nil {
+		dir, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+
+		ret, err = ReadFile(resolveFilePath(filePath, dir))
+	}
+	return ret, err
+}
+
+// GetExtraManifestResourceDir gets the directory for extra manifest resources
+func GetExtraManifestResourceDir(manifestsPath string) (string, error) {
+	// If path is already absolute, return it as-is
+	if filepath.IsAbs(manifestsPath) {
+		return manifestsPath, nil
+	}
+
+	// Try to resolve relative to executable
+	ex, err := os.Executable()
+	if err != nil {
+		// If we can't get executable path, try current working directory
+		dir, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return resolveFilePath(manifestsPath, dir), nil
+	}
+
+	dir := filepath.Dir(ex)
+	return resolveFilePath(manifestsPath, dir), nil
+}
+
+// addZTPAnnotationToManifest adds ZTP annotation to a manifest string
+func addZTPAnnotationToManifest(manifestStr string) (string, error) {
+	var data map[string]interface{}
+	err := yaml.Unmarshal([]byte(manifestStr), &data)
+	if err != nil {
+		return manifestStr, fmt.Errorf("could not unmarshal string: %w", err)
+	}
+
+	// Add ZTP annotation
+	if data["metadata"] == nil {
+		data["metadata"] = make(map[string]interface{})
+	}
+
+	if data["metadata"].(map[string]interface{})["annotations"] == nil {
+		data["metadata"].(map[string]interface{})["annotations"] = make(map[string]interface{})
+	}
+
+	data["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})[ZtpAnnotation] = ZtpAnnotationDefaultValue
+
+	out, err := yaml.Marshal(data)
+	if err != nil {
+		return manifestStr, fmt.Errorf("could not marshal data: %w", err)
+	}
+	return string(out), nil
+}
+
+// getWorkloadManifest generates workload manifest for SNO clusters
+func getWorkloadManifest(fPath string, cpuSet string, role string) (string, interface{}, error) {
+	filePath := filepath.Join(fPath, workloadPath)
+	crio, err := ReadExtraManifestResourceFile(filepath.Join(filePath, workloadCrioFile))
+	if err != nil {
+		return "", nil, err
+	}
+	crioStr := string(crio)
+	crioStr = strings.ReplaceAll(crioStr, cpuset, cpuSet)
+	crioStr = base64.StdEncoding.EncodeToString([]byte(crioStr))
+
+	kubelet, err := ReadExtraManifestResourceFile(filepath.Join(filePath, workloadKubeletFile))
+	if err != nil {
+		return "", nil, err
+	}
+	kubeletStr := string(kubelet)
+	kubeletStr = strings.ReplaceAll(kubeletStr, cpuset, cpuSet)
+	kubeletStr = base64.StdEncoding.EncodeToString([]byte(kubeletStr))
+
+	workload, err := ReadExtraManifestResourceFile(filepath.Join(filePath, workloadFile))
+	if err != nil {
+		return "", nil, err
+	}
+	workloadStr := string(workload)
+	workloadStr = strings.ReplaceAll(workloadStr, "$crio", crioStr)
+	workloadStr = strings.ReplaceAll(workloadStr, "$k8s", kubeletStr)
+	workloadStr = strings.ReplaceAll(workloadStr, "$mcp", role)
+
+	workloadFileParts := append(strings.Split(workloadFile, "-"), "")
+	copy(workloadFileParts[2:], workloadFileParts[1:])
+	workloadFileParts[1] = role
+	workloadFileForRole := strings.Join(workloadFileParts, "-")
+
+	return workloadFileForRole, reflect.ValueOf(workloadStr).Interface(), nil
+}
+
+// getManifestFromTemplate processes a template file and returns the rendered manifest
+func getManifestFromTemplate(templatePath, role string, data interface{}) (string, string, error) {
+	baseName := filepath.Base(templatePath)
+	renderedName := fmt.Sprintf("%s-%s", role, strings.TrimSuffix(baseName, ".tmpl"))
+	tStr, err := ReadExtraManifestResourceFile(templatePath)
+	if err != nil {
+		return "", "", err
+	}
+	t, err := template.New(baseName).Parse(string(tStr))
+	if err != nil {
+		return "", "", err
+	}
+	var output bytes.Buffer
+	err = t.Execute(&output, struct {
+		Role string
+		Data interface{}
+	}{
+		Role: role,
+		Data: data,
+	})
+	if err != nil {
+		return "", "", err
+	}
+	// Ensure there's non-whitespace content
+	for _, r := range output.String() {
+		if !unicode.IsSpace(r) {
+			return renderedName, output.String(), nil
+		}
+	}
+	// Output is all whitespace; return nil instead
+	return "", "", nil
+}
+
+// getExtraManifestMaps returns 2 maps and error
+// first map consists: key as fileName, value as file content
+// second map contains: key as machineConfigs filename, value as true/false
+func getExtraManifestMaps(roles map[string]bool, clusterSpec Cluster, filePath ...string) (map[string]interface{}, map[string]bool, error) {
+	var (
+		files []fs.FileInfo
+		err   error
+	)
+
+	dirFiles := &DirContainFiles{}
+	dirFilesArray := []DirContainFiles{}
+	dataMap := make(map[string]interface{})
+	// Note: doNotMerge is not used as MergeManifests is not implemented
+	doNotMerge := make(map[string]bool)
+
+	for _, p := range filePath {
+		files, err = GetFiles(p)
+		if err != nil {
+			return nil, nil, err
+		}
+		dirFiles = &DirContainFiles{
+			Directory: p,
+			Files:     files,
+		}
+		dirFilesArray = append(dirFilesArray, *dirFiles)
+	}
+
+	for _, v := range dirFilesArray {
+		for _, file := range v.Files {
+			if file.IsDir() || file.Name()[0] == '.' {
+				continue
+			}
+
+			filePath := filepath.Join(v.Directory, file.Name())
+
+			if strings.HasSuffix(file.Name(), ".tmpl") {
+				// For templates, we can inject the roles directly
+				// Assumes that templates that don't care about roles take precautions that they will be called per role.
+				for role := range roles {
+					filename, value, err := getManifestFromTemplate(filePath, role, clusterSpec)
+					if err != nil {
+						return dataMap, doNotMerge, err
+					}
+					if value != "" {
+						value, err = addZTPAnnotationToManifest(value)
+						if err != nil {
+							return dataMap, doNotMerge, err
+						}
+						dataMap[filename] = value
+						// Note: doNotMerge tracking removed as MergeManifests is not implemented
+					}
+				}
+			} else {
+				// This is a pure passthrough, assuming any static files for both 'master' and 'worker' have their contents set up properly.
+				manifestFile, err := ReadExtraManifestResourceFile(filePath)
+				if err != nil {
+					return dataMap, doNotMerge, err
+				}
+				if len(manifestFile) != 0 {
+					manifestFileStr, err := addZTPAnnotationToManifest(string(manifestFile))
+					if err != nil {
+						return dataMap, doNotMerge, err
+					}
+					dataMap[file.Name()] = manifestFileStr
+				}
+			}
+		}
+	}
+
+	// Adding workload partitions MC only for SNO clusters.
+	if len(clusterSpec.Nodes) == 1 {
+		for node := range clusterSpec.Nodes {
+			cpuSet := clusterSpec.Nodes[node].Cpuset
+			role := clusterSpec.Nodes[node].Role
+			if cpuSet != "" {
+				for _, v := range dirFilesArray {
+					for _, file := range v.Files {
+						if file.Name() == workloadPath {
+							k, v, err := getWorkloadManifest(v.Directory, cpuSet, role)
+							if err != nil {
+								errStr := fmt.Sprintf("Error could not read WorkloadManifest %s %s\n", clusterSpec.ClusterName, err)
+								return dataMap, doNotMerge, errors.New(errStr)
+							} else if v.(string) != "" {
+								data, err := addZTPAnnotationToManifest(v.(string))
+								if err != nil {
+									return dataMap, doNotMerge, err
+								}
+								dataMap[k] = data
+								// Note: doNotMerge tracking removed as MergeManifests is not implemented
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return dataMap, doNotMerge, err
+}
+
+// filterExtraManifests filters manifests based on filter configuration
+func filterExtraManifests(dataMap map[string]interface{}, filter *Filter) (map[string]interface{}, error) {
+	// return if there's no filter initialized
+	if filter == nil {
+		return dataMap, nil
+	}
+
+	inclusionDefaultInclude := "include"
+	inclusionDefaultExclude := "exclude"
+	// use this internally for faster comparison
+	var excludeAllByDefault bool
+
+	// default value is include. treat use of `exclude` as an advanced feature
+	if filter.InclusionDefault == nil || strings.EqualFold(*filter.InclusionDefault, inclusionDefaultInclude) {
+		excludeAllByDefault = false
+	} else if strings.EqualFold(*filter.InclusionDefault, inclusionDefaultExclude) {
+		excludeAllByDefault = true
+	} else {
+		errStr := fmt.Sprintf("acceptable values for inclusionDefault are %s and %s. You have entered %s", inclusionDefaultInclude, inclusionDefaultExclude, *filter.InclusionDefault)
+		return dataMap, errors.New(errStr)
+	}
+
+	// helper to create the debug msg
+	getDataMapFileNameInStrings := func(dataMap map[string]interface{}) string {
+		var files []string
+		for s := range dataMap {
+			files = append(files, s)
+		}
+		stringFiles := strings.Join(files, ",")
+		return stringFiles
+	}
+
+	if excludeAllByDefault {
+		// in `exclude` mode
+
+		// check if include list is empty
+		if len(filter.Exclude) > 0 {
+			return dataMap, errors.New("when InclusionDefault is set to exclude, exclude list can not have entries")
+		}
+
+		temp := make(map[string]interface{})
+		for _, fileToInclude := range filter.Include {
+			value, exists := dataMap[fileToInclude]
+			if exists {
+				temp[fileToInclude] = value
+			} else {
+				errStr := fmt.Sprintf("Filename %s under include array is invalid. Valid files names are: %s",
+					fileToInclude, getDataMapFileNameInStrings(dataMap))
+				return dataMap, errors.New(errStr)
+			}
+		}
+		return temp, nil
+	} else {
+		// in `include` mode
+
+		// check if exclude list is empty
+		if len(filter.Include) > 0 {
+			return dataMap, errors.New("when InclusionDefault is set to include, include list can not have entries")
+		}
+
+		// remove the files using exclude list
+		for _, fileToExclude := range filter.Exclude {
+			_, exists := dataMap[fileToExclude]
+			if exists {
+				delete(dataMap, fileToExclude)
+			} else {
+				errStr := fmt.Sprintf("Filename %s under exclude array is invalid. Valid files names are: %s", fileToExclude, getDataMapFileNameInStrings(dataMap))
+				return dataMap, errors.New(errStr)
+			}
+		}
+	}
+
+	return dataMap, nil
+}
+
+// getExtraManifest generates extra manifests for a cluster
+func getExtraManifest(dataMap map[string]interface{}, clusterSpec Cluster, inputFileDir string) (map[string]interface{}, error) {
+	// Figure out the list of node roles we need to support in this cluster
+	roles := map[string]bool{}
+	var err error
+
+	for _, node := range clusterSpec.Nodes {
+		roles[node.Role] = true
+	}
+
+	if clusterSpec.ExtraManifests.SearchPaths != nil {
+		// Resolve relative paths in searchPaths relative to the input file directory
+		resolvedPaths := make([]string, 0, len(*clusterSpec.ExtraManifests.SearchPaths))
+		for _, path := range *clusterSpec.ExtraManifests.SearchPaths {
+			resolvedPath := path
+			if !filepath.IsAbs(path) {
+				// Resolve relative to input file directory
+				resolvedPath = filepath.Join(inputFileDir, path)
+				// Clean the path to remove any ".." or "." components
+				resolvedPath = filepath.Clean(resolvedPath)
+			}
+			resolvedPaths = append(resolvedPaths, resolvedPath)
+		}
+		dataMap, _, err = getExtraManifestMaps(roles, clusterSpec, resolvedPaths...)
+		if err != nil {
+			return dataMap, err
+		}
+	} else {
+		containerPath, err := GetExtraManifestResourceDir(localExtraManifestPath)
+		if err != nil {
+			return dataMap, err
+		}
+		// Check if the directory exists before trying to use it
+		if _, err := os.Stat(containerPath); err == nil {
+			dataMap, _, err = getExtraManifestMaps(roles, clusterSpec, containerPath)
+			if err != nil {
+				return dataMap, err
+			}
+		}
+		// If directory doesn't exist, continue without error (no default extra-manifests)
+	}
+
+	// Adding End User Extra-manifest
+	if clusterSpec.ExtraManifests.SearchPaths == nil && clusterSpec.ExtraManifestPath != "" {
+		// Resolve extraManifestPath relative to input file directory if it's relative
+		extraManifestPath := clusterSpec.ExtraManifestPath
+		if !filepath.IsAbs(extraManifestPath) {
+			extraManifestPath = filepath.Join(inputFileDir, extraManifestPath)
+			extraManifestPath = filepath.Clean(extraManifestPath)
+		}
+		files, err := GetFiles(extraManifestPath)
+		if err != nil {
+			return dataMap, fmt.Errorf("failed to access extraManifestPath %s (resolved from %s): %w", extraManifestPath, clusterSpec.ExtraManifestPath, err)
+		}
+		for _, file := range files {
+			if file.IsDir() || file.Name()[0] == '.' {
+				continue
+			}
+
+			// return and fail if one of the end user extra-manifest has same name as the pre-defined extra-manifest.
+			if dataMap[file.Name()] != nil {
+				errStr := fmt.Sprintf("Pre-defined extra-manifest cannot be over written %s", file.Name())
+				return dataMap, errors.New(errStr)
+			}
+
+			filePath := filepath.Join(extraManifestPath, file.Name())
+			manifestFile, err := ReadFile(filePath)
+			if err != nil {
+				return dataMap, err
+			}
+
+			if len(manifestFile) != 0 {
+				manifestFileStr, err := addZTPAnnotationToManifest(string(manifestFile))
+				if err != nil {
+					return dataMap, err
+				}
+				dataMap[file.Name()] = manifestFileStr
+			}
+		}
+	}
+
+	//filter CRs
+	dataMap, err = filterExtraManifests(dataMap, clusterSpec.ExtraManifests.Filter)
+	if err != nil {
+		return dataMap, fmt.Errorf("could not filter %s.%s: %w", clusterSpec.ClusterName, clusterSpec.ExtraManifestPath, err)
+	}
+
+	// Note: MergeManifests is not included here as it requires machine-config-operator dependencies
+	// If mergeDefaultMachineConfigs is needed, it should be handled separately
+
+	return dataMap, nil
+}
+
+// generateExtraManifests generates extra manifests for a SiteConfig and writes them to the output directory
+func generateExtraManifests(siteConfig *SiteConfig, outputDir string, inputFileDir string) error {
+	if len(siteConfig.Spec.Clusters) == 0 {
+		return fmt.Errorf("no clusters found in SiteConfig")
+	}
+
+	// Process each cluster
+	for _, cluster := range siteConfig.Spec.Clusters {
+		// Generate extra manifests for this cluster
+		dataMap := make(map[string]interface{})
+		extraManifests, err := getExtraManifest(dataMap, cluster, inputFileDir)
+		if err != nil {
+			return fmt.Errorf("failed to generate extra manifests for cluster %s: %w", cluster.ClusterName, err)
+		}
+
+		// Write each manifest to a file
+		for filename, content := range extraManifests {
+			manifestContent, ok := content.(string)
+			if !ok {
+				return fmt.Errorf("invalid manifest content type for %s", filename)
+			}
+
+			outputFile := filepath.Join(outputDir, filename)
+			if err := os.WriteFile(outputFile, []byte(manifestContent), 0644); err != nil {
+				return fmt.Errorf("failed to write manifest file %s: %w", outputFile, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/ztp/tools/siteconfig-converter/extraManifests_test.go
+++ b/ztp/tools/siteconfig-converter/extraManifests_test.go
@@ -1,0 +1,466 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Test_filterExtraManifests(t *testing.T) {
+	getMapWithFileNames := func() map[string]interface{} {
+		// Create a test data map with some file names
+		dataMap := make(map[string]interface{})
+		files := []string{
+			"01-container-mount-ns-and-kubelet-conf-master.yaml",
+			"01-container-mount-ns-and-kubelet-conf-worker.yaml",
+			"03-sctp-machine-config-master.yaml",
+			"03-sctp-machine-config-worker.yaml",
+			"03-workload-partitioning.yaml",
+			"04-accelerated-container-startup-master.yaml",
+			"04-accelerated-container-startup-worker.yaml",
+			"06-kdump-master.yaml",
+			"06-kdump-worker.yaml",
+		}
+		for _, f := range files {
+			dataMap[f] = "test content"
+		}
+		return dataMap
+	}
+
+	const filter = `
+  inclusionDefault: %s
+  exclude: %s 
+  include: %s
+`
+
+	type args struct {
+		dataMap map[string]interface{}
+		filter  string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		want       map[string]interface{}
+		wantErrMsg string
+		wantErr    bool
+	}{
+		{
+			name:    "remove files from the list",
+			wantErr: false,
+			args: args{
+				dataMap: getMapWithFileNames(),
+				filter:  fmt.Sprintf(filter, ``, `[03-sctp-machine-config-worker.yaml, 03-sctp-machine-config-master.yaml]`, ``),
+			},
+			want: map[string]interface{}{
+				"01-container-mount-ns-and-kubelet-conf-master.yaml": "test content",
+				"01-container-mount-ns-and-kubelet-conf-worker.yaml": "test content",
+				"03-workload-partitioning.yaml":                      "test content",
+				"04-accelerated-container-startup-master.yaml":       "test content",
+				"04-accelerated-container-startup-worker.yaml":       "test content",
+				"06-kdump-master.yaml":                               "test content",
+				"06-kdump-worker.yaml":                               "test content",
+			},
+		},
+		{
+			name:    "exclude all files except 03-workload-partitioning.yaml",
+			wantErr: false,
+			args: args{
+				dataMap: getMapWithFileNames(),
+				filter:  fmt.Sprintf(filter, `exclude`, ``, `[03-workload-partitioning.yaml]`),
+			},
+			want: map[string]interface{}{"03-workload-partitioning.yaml": "test content"},
+		},
+		{
+			name:    "error when both include and exclude contain a list of files and user in exclude mode",
+			wantErr: true,
+			args: args{
+				dataMap: getMapWithFileNames(),
+				filter:  fmt.Sprintf(filter, `exclude`, `[03-workload-partitioning.yaml]`, `[03-workload-partitioning.yaml]`),
+			},
+			wantErrMsg: "when InclusionDefault is set to exclude, exclude list can not have entries",
+		},
+		{
+			name:    "error when a file is listed under include list but user in include mode",
+			wantErr: true,
+			args: args{
+				dataMap: getMapWithFileNames(),
+				filter:  fmt.Sprintf(filter, `include`, ``, `[03-workload-partitioning.yaml]`),
+			},
+			wantErrMsg: "when InclusionDefault is set to include, include list can not have entries",
+		},
+		{
+			name:    "error when incorrect value is used for inclusionDefault",
+			wantErr: true,
+			args: args{
+				dataMap: getMapWithFileNames(),
+				filter:  fmt.Sprintf(filter, `something_random`, `[03-workload-partitioning.yaml]`, ``),
+			},
+			wantErrMsg: "acceptable values for inclusionDefault are include and exclude. You have entered something_random",
+		},
+		{
+			name:    "error when trying to remove a file that is not in the dir",
+			wantErr: true,
+			args: args{
+				dataMap: getMapWithFileNames(),
+				filter:  fmt.Sprintf(filter, `include`, `[03-my-unknown-file.yaml]`, ``),
+			},
+			wantErrMsg: "Filename 03-my-unknown-file.yaml under exclude array is invalid. Valid files names are:",
+		},
+		{
+			name:    "error when trying to keep a file that is not in the dir",
+			wantErr: true,
+			args: args{
+				dataMap: getMapWithFileNames(),
+				filter:  fmt.Sprintf(filter, `exclude`, ``, `[03-my-unknown-file.yaml]`),
+			},
+			wantErrMsg: "Filename 03-my-unknown-file.yaml under include array is invalid. Valid files names are:",
+		},
+		{
+			name:    "nil filter returns dataMap unchanged",
+			wantErr: false,
+			args: args{
+				dataMap: getMapWithFileNames(),
+				filter:  "",
+			},
+			want: getMapWithFileNames(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var f *Filter
+			if tt.args.filter != "" {
+				f = &Filter{}
+				err := yaml.Unmarshal([]byte(tt.args.filter), f)
+				if err != nil {
+					t.Fatalf("Failed to unmarshal filter: %v", err)
+				}
+			}
+			got, err := filterExtraManifests(tt.args.dataMap, f)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("filterExtraManifests() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if !strings.Contains(err.Error(), tt.wantErrMsg) {
+					t.Errorf("filterExtraManifests() error message = %v, want contains %v", err.Error(), tt.wantErrMsg)
+				}
+			} else {
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("filterExtraManifests() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func Test_addZTPAnnotationToManifest(t *testing.T) {
+	tests := []struct {
+		name           string
+		manifestStr    string
+		wantAnnotation string
+		wantErr        bool
+	}{
+		{
+			name: "add annotation to manifest without metadata",
+			manifestStr: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  key: value
+`,
+			wantAnnotation: ZtpAnnotationDefaultValue,
+			wantErr:        false,
+		},
+		{
+			name: "add annotation to manifest with existing annotations",
+			manifestStr: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+data:
+  key: value
+`,
+			wantAnnotation: ZtpAnnotationDefaultValue,
+			wantErr:        false,
+		},
+		{
+			name: "add annotation to manifest without annotations",
+			manifestStr: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  key: value
+`,
+			wantAnnotation: ZtpAnnotationDefaultValue,
+			wantErr:        false,
+		},
+		{
+			name: "invalid YAML should return error",
+			manifestStr: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  invalid: [unclosed
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := addZTPAnnotationToManifest(tt.manifestStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("addZTPAnnotationToManifest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				var result map[string]interface{}
+				err = yaml.Unmarshal([]byte(got), &result)
+				if err != nil {
+					t.Fatalf("Failed to unmarshal result: %v", err)
+				}
+
+				metadata, ok := result["metadata"].(map[string]interface{})
+				if !ok {
+					t.Fatalf("metadata is not a map")
+				}
+
+				annotations, ok := metadata["annotations"].(map[string]interface{})
+				if !ok {
+					t.Fatalf("annotations is not a map")
+				}
+
+				annotationValue, ok := annotations[ZtpAnnotation].(string)
+				if !ok {
+					t.Errorf("ZTP annotation not found or not a string")
+					return
+				}
+
+				if annotationValue != tt.wantAnnotation {
+					t.Errorf("addZTPAnnotationToManifest() annotation = %v, want %v", annotationValue, tt.wantAnnotation)
+				}
+			}
+		})
+	}
+}
+
+func Test_GetFiles(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir, err := os.MkdirTemp("", "test-getfiles-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a test file
+	testFile := filepath.Join(tmpDir, "test.yaml")
+	err = os.WriteFile(testFile, []byte("test content"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create a subdirectory
+	subDir := filepath.Join(tmpDir, "subdir")
+	err = os.Mkdir(subDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create subdir: %v", err)
+	}
+
+	// Test with a file
+	files, err := GetFiles(testFile)
+	if err != nil {
+		t.Errorf("GetFiles() error = %v", err)
+		return
+	}
+	if len(files) != 1 {
+		t.Errorf("GetFiles() returned %d files, want 1", len(files))
+		return
+	}
+	if files[0].Name() != "test.yaml" {
+		t.Errorf("GetFiles() file name = %v, want test.yaml", files[0].Name())
+	}
+
+	// Test with a directory
+	files, err = GetFiles(tmpDir)
+	if err != nil {
+		t.Errorf("GetFiles() error = %v", err)
+		return
+	}
+	if len(files) < 1 {
+		t.Errorf("GetFiles() returned %d files, want at least 1", len(files))
+	}
+
+	// Test with non-existent path
+	_, err = GetFiles(filepath.Join(tmpDir, "nonexistent"))
+	if err == nil {
+		t.Error("GetFiles() expected error for non-existent path, got nil")
+	}
+}
+
+func Test_ReadFile(t *testing.T) {
+	// Create a temporary file
+	tmpFile, err := os.CreateTemp("", "test-readfile-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	testContent := []byte("test content")
+	err = os.WriteFile(tmpFile.Name(), testContent, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Test reading the file
+	content, err := ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Errorf("ReadFile() error = %v", err)
+		return
+	}
+	if !reflect.DeepEqual(content, testContent) {
+		t.Errorf("ReadFile() content = %v, want %v", content, testContent)
+	}
+
+	// Test with non-existent file
+	_, err = ReadFile("/nonexistent/file")
+	if err == nil {
+		t.Error("ReadFile() expected error for non-existent file, got nil")
+	}
+}
+
+func Test_resolveFilePath(t *testing.T) {
+	// Create a temporary directory
+	tmpDir, err := os.MkdirTemp("", "test-resolve-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a test file
+	testFile := filepath.Join(tmpDir, "test.yaml")
+	err = os.WriteFile(testFile, []byte("test"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Test with absolute path (should return as-is)
+	resolved := resolveFilePath(testFile, "/some/base/dir")
+	if resolved != testFile {
+		t.Errorf("resolveFilePath() = %v, want %v", resolved, testFile)
+	}
+
+	// Test with relative path (should resolve to baseDir + path)
+	resolved = resolveFilePath("test.yaml", tmpDir)
+	expected := filepath.Join(tmpDir, "test.yaml")
+	if resolved != expected {
+		t.Errorf("resolveFilePath() = %v, want %v", resolved, expected)
+	}
+}
+
+func Test_getExtraManifest_basic(t *testing.T) {
+	// Create a minimal cluster spec for testing
+	cluster := Cluster{
+		ClusterName: "test-cluster",
+		Nodes: []Node{
+			{
+				HostName: "node1",
+				Role:     "master",
+			},
+		},
+		ExtraManifests: ExtraManifests{},
+	}
+
+	// Test with empty dataMap
+	dataMap := make(map[string]interface{})
+	// Use current directory as input file directory for testing
+	inputFileDir, _ := os.Getwd()
+	result, err := getExtraManifest(dataMap, cluster, inputFileDir)
+
+	// This should not error even if no manifests are found
+	// (it depends on whether extra-manifest directory exists)
+	// We just check that the function doesn't panic
+	if err != nil {
+		// If there's an error, it should be about missing directory, which is expected
+		if !strings.Contains(err.Error(), "no such file") && !strings.Contains(err.Error(), "not a directory") {
+			t.Logf("getExtraManifest() error = %v (expected for missing directory)", err)
+		}
+	} else {
+		// If no error, result should be a map (even if empty)
+		if result == nil {
+			t.Error("getExtraManifest() result is nil")
+		}
+	}
+}
+
+func Test_filterExtraManifests_edgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		dataMap map[string]interface{}
+		filter  *Filter
+		wantErr bool
+	}{
+		{
+			name:    "nil filter with empty dataMap",
+			dataMap: make(map[string]interface{}),
+			filter:  nil,
+			wantErr: false,
+		},
+		{
+			name: "filter with nil InclusionDefault (defaults to include)",
+			dataMap: map[string]interface{}{
+				"file1.yaml": "content1",
+				"file2.yaml": "content2",
+			},
+			filter: &Filter{
+				InclusionDefault: nil,
+				Exclude:          []string{"file1.yaml"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "filter with empty exclude list",
+			dataMap: map[string]interface{}{
+				"file1.yaml": "content1",
+				"file2.yaml": "content2",
+			},
+			filter: &Filter{
+				InclusionDefault: stringPtr("include"),
+				Exclude:          []string{},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := filterExtraManifests(tt.dataMap, tt.filter)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("filterExtraManifests() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got == nil {
+					t.Error("filterExtraManifests() result is nil")
+				}
+			}
+		})
+	}
+}
+
+// Helper function to create string pointer
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
siteconfig-converter no longer rely on siteconfig-generator to generate extra-manifests.
The logic of generating extra-manifests is directly brought in from siteconfig-generator.