### PR TITLE
infra: fix fatal log

### DIFF
--- a/cnf-tests/testsuites/pkg/junit-merger/junit-merger_test.go
+++ b/cnf-tests/testsuites/pkg/junit-merger/junit-merger_test.go
@@ -11,7 +11,7 @@ import (
 func TestJUnitMerger(t *testing.T) {
 	suites, err := loadJUnitFiles([]string{"testdata/junit1.xml", "testdata/junit2.xml"})
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Could not load JUnit files. %s", err))
+		t.Fatalf("Could not load JUnit files. %s", err)
 	}
 
 	result := mergeJUnitFiles(suites)


### PR DESCRIPTION
Log the fatal error without sprintf wrapper. This is failing `make govet` and likely because stricter validation following the bump to go 1.24.