### PR TITLE
fix acc100 skip condition

### DIFF
--- a/cnf-tests/testsuites/e2esuite/fec/fec.go
+++ b/cnf-tests/testsuites/e2esuite/fec/fec.go
@@ -74,13 +74,14 @@ func getAcc100Device() (string, string, bool, error) {
 	if err != nil {
 		return "", "", false, err
 	}
+
+	if len(nodesWithAcc100) == 0 {
+		Skip("0 nodes with ACC100 accelerator found")
+	}
+
 	nn, err := nodes.MatchingOptionalSelectorByName(nodesWithAcc100)
 	if err != nil {
 		return "", "", false, err
-	}
-
-	if len(nn) == 0 {
-		Skip("0 nodes with ACC100 accelerator found")
 	}
 
 	pci, err := getAcc100PciFromNode(nn[0])


### PR DESCRIPTION
Moving `Skip` condition a step backward because when NODES_SELECTOR env var is set, test fails [here](https://github.com/openshift-kni/cnf-features-deploy/blob/19bb42505f0441f4509b216d93a3be4218ad9fb1/cnf-tests/testsuites/pkg/nodes/nodes.go#L240) 