### PR TITLE
cnf-tests: remove color output in ip command

### DIFF
--- a/cnf-tests/testsuites/e2esuite/bond/bond_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/bond/bond_sriov.go
@@ -91,7 +91,7 @@ var _ = Describe("[sriov] Bond CNI integration", func() {
 			err = pods.WaitForCondition(client.Client, pod, corev1.ContainersReady, corev1.ConditionTrue, 1*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 
-			stdout, err := pods.ExecCommand(client.Client, *pod, []string{"ip", "addr", "show", "bond0"})
+			stdout, err := pods.ExecCommand(client.Client, *pod, []string{"ip", "-c=never", "addr", "show", "bond0"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stdout.String()).To(ContainSubstring("inet 1.1.1."))
 


### PR DESCRIPTION
In newer versions of "ip" command, color output is enabled by default. Overriding it to let our string validation check pass.