### PR TITLE
ztp: download newer golang version in ACM PG tests if required by upstream

### DIFF
--- a/ztp/tools/pgt2acmpg/scripts/build-acmpg-plugin.sh
+++ b/ztp/tools/pgt2acmpg/scripts/build-acmpg-plugin.sh
@@ -28,6 +28,12 @@ git clone --depth 1 --branch "${POLICY_GENERATOR_TAG}" --single-branch "https://
 
 # build binary and copy it out
 pushd "policy-generator-plugin"
+
+# Allow Go to download a newer toolchain if required by the upstream module
+# and enable checksum database for toolchain verification
+export GOTOOLCHAIN=auto
+export GOSUMDB=sum.golang.org
+
 go mod vendor
 make build-binary
 cp PolicyGenerator "$1"


### PR DESCRIPTION
This PR updates the ACM pg script to download latest golang if required by upstream