### PR TITLE
infra: configure mintmaker to automerge RPM security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,11 @@
         "platformAutomerge": true,
         "schedule": [
             "at any time"
-        ]
+        ],
+        "postUpgradeTasks": {
+           "commands": ["rpm-lockfile-prototype rpms.in.yaml"],
+           "fileFilters": ["rpms.lock.yaml"]
+        }
     },
     "gomod": {
         "enabled": false
@@ -67,5 +71,12 @@
                 "additionalBranchPrefix": "cnf-tests/submodules-"
             }
         ]
-    }
+    },
+    "packageRules": [
+        {
+            "matchManagers": ["rpm", "dockerfile"],
+            "groupName": "RPM and container image updates",
+            "schedule": ["before 3am on Monday"]
+        }
+    ]
 }


### PR DESCRIPTION
MintMaker's separate Pull Requests for regular and security RPM lockfile updates create merge conflicts when the security PR is merged first. Configure `rpmVulnerabilityAutomerge` to merge security PRs automatically, preventing future race conditions. MintMaker will pick up the new configuration on its next run.