### PR TITLE
cnf-tests: dockerfile: use lastest ubi

### DIFF
--- a/cnf-tests/.konflux/Dockerfile
+++ b/cnf-tests/.konflux/Dockerfile
@@ -44,8 +44,8 @@ COPY . .
 RUN make test-bin
 
 # Container runtime image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6@sha256:2f06ae0e6d3d9c4f610d32c480338eef474867f435d8d28625f2985e8acde6e8
-#
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:6fc28bcb6776e387d7a35a2056d9d2b985dc4e26031e98a2bd35a7137cd6fd71
+
 
 RUN mkdir -p /usr/local/etc/cnf
 RUN microdnf install -y lksctp-tools iproute \


### PR DESCRIPTION
To reduce the average number of CVEs reported in Red Hat operator and layered product container images by lowering the package count shipping in the base image. We need to keep up with base image updates and preferably
 consume the ubi9-minimal:latest tag, see OCPSTRAT-2553.