### PR TITLE
infra: renovate: trigger dockerfile and rpm updates at any time

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,21 +4,24 @@
     "automergeType": "pr",
     "prConcurrentLimit": 0,
     "dockerfile": {
-        "autoApprove": true,
-        "automerge": true,
         "enabled": true,
-        "fileMatch": [
-            "\\.conf$"
-        ],
         "ignoreTests": false,
-        "platformAutomerge": true,
         "schedule": [
             "at any time"
         ],
         "postUpgradeTasks": {
            "commands": ["rpm-lockfile-prototype rpms.in.yaml"],
            "fileFilters": ["rpms.lock.yaml"]
-        }
+        },
+        "packageRules": [
+            {
+                "addLabels": [
+                    "approved",
+                    "lgtm"
+                ],
+                "automerge": true
+            }
+        ]
     },
     "gomod": {
         "enabled": false
@@ -27,9 +30,9 @@
     "rpmVulnerabilityAutomerge": "ALL",
     "tekton": {
         "enabled": true,
-        "fileMatch": [
-            "\\.yaml$",
-            "\\.yml$"
+        "managerFilePatterns": [
+            "/\\.yaml$/",
+            "/\\.yml$/"
         ],
         "ignoreTests": false,
         "includePaths": [
@@ -76,7 +79,7 @@
         {
             "matchManagers": ["rpm", "dockerfile"],
             "groupName": "RPM and container image updates",
-            "schedule": ["before 3am on Monday"]
+            "schedule": ["at any time"]
         }
     ]
 }


### PR DESCRIPTION
* we need to keep the dockerfiles always and asap updated, and that follows with the RPM bump.
* remove deprecated `fileMatch`, and where relevant replace it with `managerFilePatterns`
* dockerfile patterns is by default matching Containerfile and Dockerfile, see [1].
* label dockerfile related PRs with lgtm and approved so when CI passes the PR is merged automatically. This ,of course,applies to mintmaker PRs only.

[1] https://docs.renovatebot.com/renovate-schema.json#:~:text=%22dockerfile%22%3A%20%7B%0A%20%20%20%20%20%20%22description%22%3A%20%22Configuration%20object%20for%20the%20dockerfile%20manager%22%2C%0A%20%20%20%20%20%20%22type%22%3A%20%22object%22%2C%0A%20%20%20%20%20%20%22default%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22managerFilePatterns%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%22/(%5E%7C/%7C%5C%5C.)(%5BDd%5Docker%7C%5BCc%5Dontainer)file%24/%22%2C%0A%20%20%20%20%20%20%20%20%20%20%22/(%5E%7C/)(%5BDd%5Docker%7C%5BCc%5Dontainer)file%5B%5E/%5D*%24/%22