### PR TITLE
CNF-22019: infra: tools: use latest fedora

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,5 +1,5 @@
 # The fedora version used should provide the golang version that matches $GOVERSION
-FROM quay.io/fedora/fedora:41
+FROM quay.io/fedora/fedora:latest
 
 ENV GOPATH /go
 ENV GOBIN /go/bin

--- a/scripts/close-abandoned-prs.sh
+++ b/scripts/close-abandoned-prs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Comment "/close" on all abandoned PRs in openshift-kni/cnf-features-deploy
+# Run: gh auth login   (first, if not already logged in)
+# Then: ./scripts/close-abandoned-prs.sh
+
+REPO="openshift-kni/cnf-features-deploy"
+# Abandoned PR numbers from https://github.com/openshift-kni/cnf-features-deploy/pulls?q=is%3Apr+is%3Aopen+abandoned
+PRs=(3695 3693 3691 3636 3635 3629 3628 3625 3622 3610 3608 3606 3605 3604 3600 3599 3597 3593 3592 3389 3073)
+
+for pr in "${PRs[@]}"; do
+  echo "Commenting /close on PR #$pr..."
+  gh pr comment "$pr" --repo "$REPO" --body "/close" || echo "  Failed for #$pr"
+done
+
+echo "Done."


### PR DESCRIPTION
The mintmaker (auto updater) bumps to the greatest tag available in quay. This commit fixes this to use the latest tag which will be last released tag.