### PR TITLE
[release-4.12] CNF-22668: Replace centos references with ubi

### DIFF
--- a/cnf-tests/Dockerfile
+++ b/cnf-tests/Dockerfile
@@ -47,7 +47,7 @@ RUN go build -mod=vendor -o /oslat-runner oslat-runner/main.go && \
     go build -mod=vendor -o /hwlatdetect-runner hwlatdetect-runner/main.go
 
 # Build latency-test binaries
-FROM centos:7 as builder-latency-test-tools
+FROM registry.access.redhat.com/ubi8/ubi:latest as builder-latency-test-tools
 
 ENV RT_TESTS_URL=https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git/snapshot
 ENV RT_TESTS_PKG=rt-tests-2.0
@@ -61,7 +61,7 @@ RUN yum install -y numactl-devel make gcc && \
     cp hwlatdetect /hwlatdetect && \
     cp cyclictest /cyclictest
 
-FROM centos:7
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
 # python3 is needed for hwlatdetect
 RUN yum install -y lksctp-tools iproute libhugetlbfs-utils libhugetlbfs tmux ethtool ping numactl-libs linuxptp iperf3 python3 nc iptables

--- a/cnf-tests/GATEKEEPER.md
+++ b/cnf-tests/GATEKEEPER.md
@@ -80,7 +80,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: centos
+    image: ubi8
     command: ["/bin/bash", "-c", "sleep INF"]
 EOF    
 ```
@@ -107,7 +107,7 @@ spec:
     operator: Exists
   containers:
   - name: main
-    image: centos
+    image: ubi8
     command: ["/bin/bash", "-c", "sleep INF"]
 EOF
 ```
@@ -134,7 +134,7 @@ spec:
   - operator: "Exists"
   containers:
   - name: podexample
-    image: centos
+    image: ubi8
     command: ["/bin/bash", "-c", "sleep INF"]
 EOF
 ```

--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
 LABEL maintainer="Sebastian Scheinkman <sebassch@gmail.com>"
 LABEL io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"


### PR DESCRIPTION
We should not be using centos at this point, so instead use ubi