### PR TITLE
Add by2waysprojects to konflux OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -58,8 +58,10 @@ aliases:
     - shajmakh
     - fontivan
     - rauhersu
+    - by2waysprojects
   konflux-reviewers:
     - yanirq
     - shajmakh
     - fontivan
     - rauhersu
+    - by2waysprojects


### PR DESCRIPTION
## Summary

Add `by2waysprojects` to `konflux-approvers` and `konflux-reviewers` in `OWNERS_ALIASES`.


Made with [Cursor](https://cursor.com)