### PR TITLE
CNF-22868: cnf-tests: fix missing $ in clone_repo.sh variable reference

### DIFF
--- a/cnf-tests/testsuites/external-tests/clone_repo.sh
+++ b/cnf-tests/testsuites/external-tests/clone_repo.sh
@@ -24,11 +24,11 @@ echo "$TESTS_REPO commit hash: $TESTS_TARGET_HASH"
 if ! [ -d "$TESTS_LOCATION" ]; then
     DOWNLOAD_SRC=true
 elif ! [ "$(cat "$TESTS_LOCATION"/git-hash)" = "$TESTS_TARGET_HASH" ]; then
-    rm -rf TESTS_LOCATION
+    rm -rf "$TESTS_LOCATION"
     DOWNLOAD_SRC=true
 fi
 
-if [ $DOWNLOAD_SRC ]; then
+if [ "$DOWNLOAD_SRC" ]; then
     echo "Cloning code from $TESTS_REPO using hash $TESTS_TARGET_HASH"
     # shellcheck disable=SC2086
     repo_name=$(basename $TESTS_REPO)


### PR DESCRIPTION
## Summary

- Fix bug where `rm -rf TESTS_LOCATION` deletes a literal file named "TESTS_LOCATION" instead of the directory path stored in the `$TESTS_LOCATION` variable
- Adds proper quoting around the variable expansion

## Jira

https://issues.redhat.com/browse/CNF-22868

## Test plan

- [ ] Verify `clone_repo.sh` correctly removes the cached test location when the git hash changes