### PR TITLE
CNF-22869: Fix typos across the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains example kustomize configs used to installed openshift feature
 
 ## Contributing kustomize configs
 
-All kustomize configs should be entirely declarative in nature. This means no bash plugin modules performing imperative tasks. Features should be installed simply by posting manifests to the cluster. After posting manifests, determining when the cluster has converged on those manifests successully should be observable.
+All kustomize configs should be entirely declarative in nature. This means no bash plugin modules performing imperative tasks. Features should be installed simply by posting manifests to the cluster. After posting manifests, determining when the cluster has converged on those manifests successfully should be observable.
 
 ## Usage
 
@@ -32,13 +32,13 @@ e.g. `FEATURES="sriov" FOCUS_TESTS="operator.Generic.SriovNetworkNodePolicy.Reso
 
 ##### FEATURES_ENVIRONMENT
 
-i.e. `FEATURES_ENVIRONMENT=demo` determines the kustomization layer that will be used to deploy the choosen features.
+i.e. `FEATURES_ENVIRONMENT=demo` determines the kustomization layer that will be used to deploy the chosen features.
 
 The current default value is `e2e-gcp`
 
 ### Deployment
 
-For each feature choosen via `FEATURES` we expect to have a layer either in [feature-configs/deploy](feature-configs/deploy) or in [feature-configs/$FEATURES_ENVIRONMENT](feature-configs/demo).
+For each feature chosen via `FEATURES` we expect to have a layer either in [feature-configs/deploy](feature-configs/deploy) or in [feature-configs/$FEATURES_ENVIRONMENT](feature-configs/demo).
 
 - run `FEATURES_ENVIRONMENT=demo make feature-deploy`.  
   This will try to apply all manifests in a loop until all deployments succeeded, or until it runs into a timeout.

--- a/cnf-tests/README.md
+++ b/cnf-tests/README.md
@@ -25,7 +25,7 @@ export SRIOV_NETWORK_OPERATOR_TARGET_COMMIT?=main
 export CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT?=main
 ```
 
-And to set all three of them to a specfic release, use `TARGET_RELEASE`.
+And to set all three of them to a specific release, use `TARGET_RELEASE`.
 
 ## Running the Tests
 
@@ -59,7 +59,7 @@ We invoke the tests using the Ginkgo CLI tool.
 - CLEAN_PERFORMANCE_PROFILE - disable performance profile cleanup for faster tests
 - PERFORMANCE_PROFILE_MANIFEST_OVERRIDE - performance profile manifest override
 - IPERF3_BITRATE_OVERRIDE - set a maximum bitrate for iperf3 to use in ovs_qos tests
-- SKIP_LOCAL_RESOURCES - use default test resource of dependant test suites, using hardcoded defaults instead
+- SKIP_LOCAL_RESOURCES - use default test resource of dependent test suites, using hardcoded defaults instead
 
 ## Test Reports
 

--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -555,12 +555,8 @@ sleep INF
 				numaNode, err = numa.FindForCPUs(dpdkWorkloadPod, cpuList)
 				Expect(err).ToNot(HaveOccurred())
 
-				hugepages := performanceprofile.X86HugepageSize
-				if performanceprofile.HugePageSize == performanceprofile.Arm64KPerformanceProfileHugepageSize {
-					hugepages = performanceprofile.Arm64KHugepageSize
-				}
 				buff, err = pods.ExecCommand(client.Client, *dpdkWorkloadPod, []string{"cat",
-					fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%s/free_hugepages", numaNode, hugepages)})
+					fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%s/free_hugepages", numaNode, performanceprofile.SysfsHugepageSize())})
 				Expect(err).ToNot(HaveOccurred())
 				activeNumberOfFreeHugePages, err = strconv.Atoi(strings.Replace(buff.String(), utils.GetSeparator(buff.String()), "", 1))
 				Expect(err).ToNot(HaveOccurred())
@@ -581,14 +577,9 @@ sleep INF
 				pod, err := client.Client.Pods(namespaces.DpdkTest).Create(context.Background(), pod, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				hugepages := performanceprofile.X86HugepageSize
-				if performanceprofile.HugePageSize == performanceprofile.Arm64KPerformanceProfileHugepageSize {
-					hugepages = performanceprofile.Arm64KHugepageSize
-				}
-
 				Eventually(func() int {
 					buff, err := pods.ExecCommand(client.Client, *dpdkWorkloadPod, []string{"cat",
-						fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%s/free_hugepages", numaNode, hugepages)})
+						fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%s/free_hugepages", numaNode, performanceprofile.SysfsHugepageSize())})
 					Expect(err).ToNot(HaveOccurred())
 					numberOfFreeHugePages, err := strconv.Atoi(strings.Replace(buff.String(), utils.GetSeparator(buff.String()), "", 1))
 					Expect(err).ToNot(HaveOccurred())
@@ -1198,11 +1189,12 @@ func getPodPci(pod *corev1.Pod) string {
 }
 
 func getHugePages(pod *corev1.Pod) string {
+	hugepagesResourceName := fmt.Sprintf("hugepages-%si", performanceprofile.HugePageSize)
 	var mb int64
 	podHp := pod.Spec.Containers
 	s := fmt.Sprintln(podHp)
 	for _, line := range strings.Split(s, " ") {
-		if strings.Contains(line, "hugepages-1Gi:") {
+		if strings.Contains(line, hugepagesResourceName+":") {
 			r := regexp.MustCompile(`\d{2,}|[7-9]`)
 			b := r.FindAllString(line, -1)
 			num := path.Join(b...)

--- a/cnf-tests/testsuites/e2esuite/dpdk/numa_node_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/numa_node_sriov.go
@@ -31,7 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"

--- a/cnf-tests/testsuites/e2esuite/multinetworkpolicy/reachmatcher.go
+++ b/cnf-tests/testsuites/e2esuite/multinetworkpolicy/reachmatcher.go
@@ -148,7 +148,7 @@ func (m *ReachMatcher) FailureMessage(actual interface{}) string {
 
 	return fmt.Sprintf(`pod [%s/%s %s] is not reachable by pod [%s/%s] on port[%s:%s], but it should be.
 %s
-Server s:
+Server nftables:
 %s
 -----
 Client nftables:

--- a/cnf-tests/testsuites/pkg/discovery/discovery.go
+++ b/cnf-tests/testsuites/pkg/discovery/discovery.go
@@ -104,7 +104,7 @@ func DiscoverPerformanceProfileAndPolicyWithAvailableNodes(client *testclient.Cl
 					continue
 				}
 
-				// Return profile and policy with the prefered resource name if available
+				// Return profile and policy with the preferred resource name if available
 				if sriovPolicy.Spec.ResourceName == resourceName {
 					return &DpdkResources{profile, sriovPolicy.Spec.ResourceName, device}, nil
 				}

--- a/cnf-tests/testsuites/pkg/performanceprofile/performanceprofile.go
+++ b/cnf-tests/testsuites/pkg/performanceprofile/performanceprofile.go
@@ -30,6 +30,16 @@ var (
 	HugePageSize               string
 )
 
+// SysfsHugepageSize returns the sysfs-style hugepage size string (e.g. "1048576kB")
+// corresponding to the current HugePageSize. This is the format used in paths like
+// /sys/devices/system/node/nodeN/hugepages/hugepages-<size>/free_hugepages.
+func SysfsHugepageSize() string {
+	if HugePageSize == Arm64KPerformanceProfileHugepageSize {
+		return Arm64KHugepageSize
+	}
+	return X86HugepageSize
+}
+
 func FindDefaultPerformanceProfile(performanceProfileName string) (*performancev2.PerformanceProfile, error) {
 	performanceProfile := &performancev2.PerformanceProfile{}
 	err := client.Client.Get(context.TODO(), goclient.ObjectKey{Name: performanceProfileName}, performanceProfile)
@@ -239,7 +249,7 @@ func CreatePerformanceProfile(performanceProfileName string, machineConfigPool *
 		performanceProfile.Annotations = map[string]string{"kubeletconfig.experimental": `{"topologyManagerPolicyOptions": {"max-allowable-numa-nodes":"16"}}`}
 
 	} else {
-		return fmt.Errorf("unsupported system")
+		return fmt.Errorf("unsupported architecture: %s", nodes.Items[0].Status.NodeInfo.Architecture)
 	}
 
 	// If the machineConfigPool is master, the automatic selector from PAO won't work

--- a/feature-configs/deploy/container-mount-namespace/README.md
+++ b/feature-configs/deploy/container-mount-namespace/README.md
@@ -6,4 +6,4 @@ Creates a pair of MC objects, one for masters and one for workers, which do the 
 - Create a new 'container-mount-namespace.service' which manages a unique mount namespace for CRI-O and Kubelet
 - Creates systemd drop-ins for CRI-O and Kubelet so they execute within this mount namespace
 
-The goal is to segregate all contianer-specific mountpoints from systemd to reduce systemd CPU usage.
+The goal is to segregate all container-specific mountpoints from systemd to reduce systemd CPU usage.

--- a/tools/oot-driver/charts/dpdk-kni-driver-0.0.1/Dockerfile-driver.SRO
+++ b/tools/oot-driver/charts/dpdk-kni-driver-0.0.1/Dockerfile-driver.SRO
@@ -25,7 +25,7 @@ rpm -Uvh --nodeps ./files/kernel/kernel-${RT}devel-${KVER}.rpm --force; \
 rpm -Uvh --nodeps ./files/kernel/kernel-${RT}core-${KVER}.rpm --force; \
 fi
 
-ENV DPDK_DIR /usr/src/dpdk-stable-${DPDK_VERION}
+ENV DPDK_DIR /usr/src/dpdk-stable-${DPDK_VERSION}
 ENV RTE_TARGET=x86_64-native-linuxapp-gcc
 ENV RTE_SDK=${DPDK_DIR}
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig/

--- a/ztp/policygenerator/policyGen/policyBuilder.go
+++ b/ztp/policygenerator/policyGen/policyBuilder.go
@@ -403,7 +403,7 @@ func (pbuilder *PolicyBuilder) splitYamls(yamls []byte) ([][]byte, error) {
 		}
 
 		// Check that resIntf is not nil in order to mitigate appending an empty
-		// object as a result of redundant trailing seperator(s) "---""
+		// object as a result of redundant trailing separator(s) "---""
 		if resIntf != nil {
 			resBytes, err := yaml.Marshal(resIntf)
 

--- a/ztp/policygenerator/policyGen/policyBuilder_test.go
+++ b/ztp/policygenerator/policyGen/policyBuilder_test.go
@@ -1113,7 +1113,7 @@ spec:
 }
 
 // Test cases for when source-cr contains trailing separators
-func TestTrailingSeperators(t *testing.T) {
+func TestTrailingSeparators(t *testing.T) {
 	input := `
 apiVersion: ran.openshift.io/v1
 kind: PolicyGenTemplate

--- a/ztp/tools/siteconfig-converter/samples/test-3node-siteconfig.yaml
+++ b/ztp/tools/siteconfig-converter/samples/test-3node-siteconfig.yaml
@@ -41,7 +41,7 @@ spec:
     # Optionally; This can be used to override the KlusterletAddonConfig that is created for this cluster:
     #crTemplates:
     #  KlusterletAddonConfig: "KlusterletAddonConfigOverride.yaml"
-    # Optionally; This can be used to to configure desired BIOS setting on all nodes in this cluster:
+    # Optionally; This can be used to configure desired BIOS setting on all nodes in this cluster:
     #biosConfigRef:
     #  filePath: "example-hw.profile"
     nodes:


### PR DESCRIPTION
## Summary
- Fix `DPDK_VERION` → `DPDK_VERSION` typo in `Dockerfile-driver.SRO` that caused ENV to reference incorrect path
- Fix spelling errors across documentation (`successully`, `choosen`, `specfic`, `dependant`, `contianer`, etc.)
- Fix `seperator` → `separator` in Go comment and test function name (`TestTrailingSeperators` → `TestTrailingSeparators`)
- Refactor duplicate hugepage-size arch logic into new `SysfsHugepageSize()` helper; upgrade `klog` to `klog/v2`; improve error message in `CreatePerformanceProfile`

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [openshift-kni/cnf-features-deploy#3961](https://github.com/openshift-kni/cnf-features-deploy/pull/3961) | [CNF-22895](https://redhat.atlassian.net/browse/CNF-22895): Add retry logic to git submodule initialization | Open |
| [openshift/release#82628](https://github.com/openshift/release/pull/82628) | ci: improve image-based e2e step reliability with retries and validation | Open |

## Jira
- [CNF-22869](https://issues.redhat.com/browse/CNF-22869) — Fix typos across the codebase (Code Review)
- Epic: [CNF-23511](https://issues.redhat.com/browse/CNF-23511) — cnf-features-deploy Tuning (In Progress)

## Test Plan
- [ ] CI passes
- [ ] Verify DPDK driver build uses correct `DPDK_VERSION` variable
- [ ] Verify `TestTrailingSeparators` test still passes after rename
- [ ] No behavioral changes expected beyond the DPDK ENV fix and hugepage refactor
