### PR TITLE
CNF-22873: infra: Replace deprecated kustomize bases: with resources:

### DIFF
--- a/feature-configs/ci/container-mount-namespace/kustomization.yaml
+++ b/feature-configs/ci/container-mount-namespace/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../deploy/container-mount-namespace/
+resources:
+- ../../deploy/container-mount-namespace/

--- a/feature-configs/ci/fec/kustomization.yaml
+++ b/feature-configs/ci/fec/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/fec
+resources:
+- ../../deploy/fec

--- a/feature-configs/ci/gatekeeper/kustomization.yaml
+++ b/feature-configs/ci/gatekeeper/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/gatekeeper
-
-patchesStrategicMerge:
-  - subscription.yaml
+resources:
+- ../../deploy/gatekeeper
+patches:
+- path: subscription.yaml

--- a/feature-configs/ci/knmstate/kustomization.yaml
+++ b/feature-configs/ci/knmstate/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/knmstate
-
-patchesStrategicMerge:
-  - operator_subscription.yaml
+resources:
+- ../../deploy/knmstate
+patches:
+- path: operator_subscription.yaml

--- a/feature-configs/ci/localhost-workaround/kustomization.yaml
+++ b/feature-configs/ci/localhost-workaround/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/localhost-workaround
+resources:
+- ../../deploy/localhost-workaround

--- a/feature-configs/ci/multinetworkpolicy/kustomization.yaml
+++ b/feature-configs/ci/multinetworkpolicy/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/multinetworkpolicy
+resources:
+- ../../deploy/multinetworkpolicy

--- a/feature-configs/ci/n3000/kustomization.yaml
+++ b/feature-configs/ci/n3000/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/n3000
+resources:
+- ../../deploy/n3000

--- a/feature-configs/ci/ptp/kustomization.yaml
+++ b/feature-configs/ci/ptp/kustomization.yaml
@@ -1,9 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/ptp
-
-patchesStrategicMerge:
-  - subscription.yaml
-
+resources:
+- ../../deploy/ptp
+patches:
+- path: subscription.yaml

--- a/feature-configs/ci/s2i/kustomization.yaml
+++ b/feature-configs/ci/s2i/kustomization.yaml
@@ -5,5 +5,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/s2i
+resources:
+- ../../deploy/s2i

--- a/feature-configs/ci/sctp/kustomization.yaml
+++ b/feature-configs/ci/sctp/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/sctp
+resources:
+- ../../deploy/sctp

--- a/feature-configs/ci/sriov/kustomization.yaml
+++ b/feature-configs/ci/sriov/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/sriov
-
-patchesStrategicMerge:
-  - sriov-subscription.yaml
+resources:
+- ../../deploy/sriov
+patches:
+- path: sriov-subscription.yaml

--- a/feature-configs/ci/sro/kustomization.yaml
+++ b/feature-configs/ci/sro/kustomization.yaml
@@ -1,9 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/sro
-
-patchesStrategicMerge:
-  - nfd-subscription.yaml
-  - sro-subscription.yaml
+resources:
+- ../../deploy/sro
+patches:
+- path: nfd-subscription.yaml
+- path: sro-subscription.yaml

--- a/feature-configs/cn-ran-overlays/ran-profile-gcp/kustomization.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile-gcp/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../ran-profile
-patchesStrategicMerge:
-  - ./cluster-config/du-common/performance/performance_profile_patch.yaml
 # This is duplicate from feature-configs/ci/ptp and sriov because it is not possble to patch from an external folder
 # security; file 'feature-configs/ci/sriov/sriov-subscription.yaml' is not in or below 'cnf-features-deploy/feature-configs/cn-ran-overlays/ran-profile-gcp'
-  - ./cluster-config/ci/sriov/sriov-subscription.yaml
-  - ./cluster-config/ci/ptp/subscription.yaml
-  - ./cluster-config/ci/sro/sro-subscription.yaml
-  - ./cluster-config/ci/sro/nfd-subscription.yaml
+resources:
+- ../ran-profile
+patches:
+- path: ./cluster-config/du-common/performance/performance_profile_patch.yaml
+- path: ./cluster-config/ci/sriov/sriov-subscription.yaml
+- path: ./cluster-config/ci/ptp/subscription.yaml
+- path: ./cluster-config/ci/sro/sro-subscription.yaml
+- path: ./cluster-config/ci/sro/nfd-subscription.yaml

--- a/feature-configs/cn-ran-overlays/ran-profile/cluster-config/kustomization.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/cluster-config/kustomization.yaml
@@ -1,25 +1,20 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  # Note - should be deleted in CU-only cluster
-  # PTP operator deployment
-  - ../../../deploy/ptp
-  # PTP profiles
-  - du-common/ptp
-
-  # SR-IOV deployment (Networks are deployed as a part of site configuration)
-  # SR-IOV network node policies are defined per site
-  - ../../../deploy/sriov
-  
-  # SCTP deployment (There is no profile)
-  - ../../../deploy/sctp
-
-  # PAO profile is given as an example. Must be adapted for a specific hardware
-  - du-common/performance
-
-  # SRIOV-FEC Deployment
-  - ../../../deploy/fec
-
-  # SRO Deployment
-  - ../../../deploy/sro
+resources:
+# Note - should be deleted in CU-only cluster
+# PTP operator deployment
+- ../../../deploy/ptp
+# PTP profiles
+- du-common/ptp
+# SR-IOV deployment (Networks are deployed as a part of site configuration)
+# SR-IOV network node policies are defined per site
+- ../../../deploy/sriov
+# SCTP deployment (There is no profile)
+- ../../../deploy/sctp
+# PAO profile is given as an example. Must be adapted for a specific hardware
+- du-common/performance
+# SRIOV-FEC Deployment
+- ../../../deploy/fec
+# SRO Deployment
+- ../../../deploy/sro

--- a/feature-configs/cn-ran-overlays/ran-profile/kustomization.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - cluster-config
-
-
+resources:
+- cluster-config

--- a/feature-configs/cn-ran-overlays/ran-profile/site.1.fqdn/kustomization.yaml
+++ b/feature-configs/cn-ran-overlays/ran-profile/site.1.fqdn/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - networks
-
-
+resources:
+- networks

--- a/feature-configs/demo/ptp/kustomization.yaml
+++ b/feature-configs/demo/ptp/kustomization.yaml
@@ -1,11 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/ptp
 resources:
-  - ptpconfig-grandmaster.yaml
-  - ptpconfig-slave.yaml
-  - disable-chronyd.yaml
-patchesStrategicMerge:
-  - subscription.yaml
+- ptpconfig-grandmaster.yaml
+- ptpconfig-slave.yaml
+- disable-chronyd.yaml
+- ../../deploy/ptp
+patches:
+- path: subscription.yaml

--- a/feature-configs/demo/s2i/kustomization.yaml
+++ b/feature-configs/demo/s2i/kustomization.yaml
@@ -5,11 +5,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/s2i
-
 resources:
-  - sriov-networknodepolicy-dpdk.yaml
-  - dpdk-network.yaml
-  - scc.yaml
-  - deployment-config.yaml
+- sriov-networknodepolicy-dpdk.yaml
+- dpdk-network.yaml
+- scc.yaml
+- deployment-config.yaml
+- ../../deploy/s2i

--- a/feature-configs/demo/sctp/kustomization.yaml
+++ b/feature-configs/demo/sctp/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/sctp
-patchesStrategicMerge:
-  - sctp_module_mc_patch.yaml
+resources:
+- ../../deploy/sctp
+patches:
+- path: sctp_module_mc_patch.yaml

--- a/feature-configs/demo/sriov/kustomization.yaml
+++ b/feature-configs/demo/sriov/kustomization.yaml
@@ -1,10 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/sriov
 resources:
-  - ipv6-network_attachment_defintion.yaml
-  - sriov-networknodepolicy.yaml
-patchesStrategicMerge:
-  - sriov-subscription.yaml
+- ipv6-network_attachment_defintion.yaml
+- sriov-networknodepolicy.yaml
+- ../../deploy/sriov
+patches:
+- path: sriov-subscription.yaml

--- a/feature-configs/deploy/container-mount-namespace/kustomization.yaml
+++ b/feature-configs/deploy/container-mount-namespace/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - worker/
-  - master/
+resources:
+- worker/
+- master/

--- a/feature-configs/deploy/container-mount-namespace/master/kustomization.yaml
+++ b/feature-configs/deploy/container-mount-namespace/master/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: 02-master-
-commonLabels:
-  machineconfiguration.openshift.io/role: master
-bases:
-  - ../container-private-mounts
+resources:
+- ../container-private-mounts
+labels:
+- includeSelectors: true
+  pairs:
+    machineconfiguration.openshift.io/role: master

--- a/feature-configs/deploy/container-mount-namespace/worker/kustomization.yaml
+++ b/feature-configs/deploy/container-mount-namespace/worker/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: 02-worker-
-commonLabels:
-  machineconfiguration.openshift.io/role: worker
-bases:
-  - ../container-private-mounts
+resources:
+- ../container-private-mounts
+labels:
+- includeSelectors: true
+  pairs:
+    machineconfiguration.openshift.io/role: worker

--- a/feature-configs/hypershift-ci/multinetworkpolicy/kustomization.yaml
+++ b/feature-configs/hypershift-ci/multinetworkpolicy/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/multinetworkpolicy
+resources:
+- ../../deploy/multinetworkpolicy

--- a/feature-configs/hypershift-ci/ptp/kustomization.yaml
+++ b/feature-configs/hypershift-ci/ptp/kustomization.yaml
@@ -1,9 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/ptp
-
-patchesStrategicMerge:
-  - subscription.yaml
-
+resources:
+- ../../deploy/ptp
+patches:
+- path: subscription.yaml

--- a/feature-configs/hypershift-ci/s2i/kustomization.yaml
+++ b/feature-configs/hypershift-ci/s2i/kustomization.yaml
@@ -5,5 +5,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/s2i
+resources:
+- ../../deploy/s2i

--- a/feature-configs/hypershift-ci/sriov/kustomization.yaml
+++ b/feature-configs/hypershift-ci/sriov/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/sriov
-
-patchesStrategicMerge:
-  - sriov-subscription.yaml
+resources:
+- ../../deploy/sriov
+patches:
+- path: sriov-subscription.yaml

--- a/feature-configs/integration-base/ptp/kustomization.yaml
+++ b/feature-configs/integration-base/ptp/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/ptp
-
 resources:
-  - 04-ptpconfig.yaml
+- 04-ptpconfig.yaml
+- ../../deploy/ptp

--- a/feature-configs/integration-base/sctp/kustomization.yaml
+++ b/feature-configs/integration-base/sctp/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/sctp
-patchesStrategicMerge:
-  - sctp_module_mc_patch.yaml
+resources:
+- ../../deploy/sctp
+patches:
+- path: sctp_module_mc_patch.yaml

--- a/feature-configs/integration-base/sriov/kustomization.yaml
+++ b/feature-configs/integration-base/sriov/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../deploy/sriov
 resources:
-  - 04-sriov-networknodepolicy.yaml
-  - 05-sriov-network.yaml
+- 04-sriov-networknodepolicy.yaml
+- 05-sriov-network.yaml
+- ../../deploy/sriov

--- a/feature-configs/integration-kni1/performance/kustomization.yaml
+++ b/feature-configs/integration-kni1/performance/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../demo/performance
-
-patchesStrategicMerge:
-  - performance_profile_patch.yaml
+resources:
+- ../../demo/performance
+patches:
+- path: performance_profile_patch.yaml

--- a/feature-configs/integration-kni1/ptp/kustomization.yaml
+++ b/feature-configs/integration-kni1/ptp/kustomization.yaml
@@ -1,9 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../demo/ptp
-
-patchesStrategicMerge:
-  - ptpconfig-slave.yaml
-  - ptpconfig-grandmaster.yaml
+resources:
+- ../../demo/ptp
+patches:
+- path: ptpconfig-slave.yaml
+- path: ptpconfig-grandmaster.yaml

--- a/feature-configs/integration-kni1/s2i/kustomization.yaml
+++ b/feature-configs/integration-kni1/s2i/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../demo/s2i
-
-patchesStrategicMerge:
-  - sriov-networknodepolicy-dpdk.yaml
+resources:
+- ../../demo/s2i
+patches:
+- path: sriov-networknodepolicy-dpdk.yaml

--- a/feature-configs/integration-kni1/sctp/kustomization.yaml
+++ b/feature-configs/integration-kni1/sctp/kustomization.yaml
@@ -1,9 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../demo/sctp
-
 resources:
-  - sctp-demo-ns.yaml
-  - sctp-demo-svc.yaml
+- sctp-demo-ns.yaml
+- sctp-demo-svc.yaml
+- ../../demo/sctp

--- a/feature-configs/integration-kni1/sriov/kustomization.yaml
+++ b/feature-configs/integration-kni1/sriov/kustomization.yaml
@@ -1,13 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../integration-base/sriov
-
-patchesStrategicMerge:
-  - sriov-subscription.yaml
-  - sriov-networknodepolicy.yaml
-
 resources:
-  - sriov-unsupported-nics-ds.yaml
-  - sriov-unsupported-nics-entrypoint-cm.yaml
+- sriov-unsupported-nics-ds.yaml
+- sriov-unsupported-nics-entrypoint-cm.yaml
+- ../../integration-base/sriov
+patches:
+- path: sriov-subscription.yaml
+- path: sriov-networknodepolicy.yaml

--- a/feature-configs/integration-u08/performance/kustomization.yaml
+++ b/feature-configs/integration-u08/performance/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../integration-base/performance
-
-patchesStrategicMerge:
-  - performance_profile_patch.yaml
+resources:
+- ../../integration-base/performance
+patches:
+- path: performance_profile_patch.yaml

--- a/feature-configs/integration-u08/ptp/kustomization.yaml
+++ b/feature-configs/integration-u08/ptp/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../integration-base/ptp
-
-patchesStrategicMerge: []
+resources:
+- ../../integration-base/ptp

--- a/feature-configs/integration-u08/s2i/kustomization.yaml
+++ b/feature-configs/integration-u08/s2i/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../demo/s2i
-
-patchesStrategicMerge: []
+resources:
+- ../../demo/s2i

--- a/feature-configs/integration-u08/sctp/kustomization.yaml
+++ b/feature-configs/integration-u08/sctp/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../integration-base/sctp
-
-patchesStrategicMerge: []
+resources:
+- ../../integration-base/sctp

--- a/feature-configs/integration-u08/sriov/kustomization.yaml
+++ b/feature-configs/integration-u08/sriov/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../integration-base/sriov
-
-patchesStrategicMerge: []
+resources:
+- ../../integration-base/sriov

--- a/feature-configs/integration-vms/performance/kustomization.yaml
+++ b/feature-configs/integration-vms/performance/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../integration-base/performance
-
-patchesStrategicMerge:
-  - performance_profile_patch.yaml
+resources:
+- ../../integration-base/performance
+patches:
+- path: performance_profile_patch.yaml

--- a/feature-configs/integration-vms/sctp/kustomization.yaml
+++ b/feature-configs/integration-vms/sctp/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../integration-base/sctp
-
-patchesStrategicMerge: []
+resources:
+- ../../integration-base/sctp

--- a/feature-configs/integration-wl4-d17u01b05/performance/kustomization.yaml
+++ b/feature-configs/integration-wl4-d17u01b05/performance/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../../integration-base/performance
-
-patchesStrategicMerge:
-  - performance_profile_patch.yaml
+resources:
+- ../../integration-base/performance
+patches:
+- path: performance_profile_patch.yaml

--- a/feature-configs/typical-baremetal/container-mount-namespace/kustomization.yaml
+++ b/feature-configs/typical-baremetal/container-mount-namespace/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-bases:
-- ../../deploy/container-mount-namespace
 kind: Kustomization
+resources:
+- ../../deploy/container-mount-namespace

--- a/feature-configs/typical-baremetal/performance/kustomization.yaml
+++ b/feature-configs/typical-baremetal/performance/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-bases:
-- ../../integration-base/performance
 kind: Kustomization
 
-patchesStrategicMerge:
-- performance_profile.patch.yaml
+resources:
+- ../../integration-base/performance
+patches:
+- path: performance_profile.patch.yaml

--- a/feature-configs/typical-baremetal/ptp/kustomization.yaml
+++ b/feature-configs/typical-baremetal/ptp/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-bases:
-- ../../deploy/ptp
 kind: Kustomization
+resources:
+- ../../deploy/ptp

--- a/feature-configs/typical-baremetal/s2i/kustomization.yaml
+++ b/feature-configs/typical-baremetal/s2i/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-bases:
-- ../../deploy/s2i
 kind: Kustomization
+resources:
+- ../../deploy/s2i

--- a/feature-configs/typical-baremetal/sctp/kustomization.yaml
+++ b/feature-configs/typical-baremetal/sctp/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
 - ../../deploy/sctp

--- a/feature-configs/typical-baremetal/sriov/kustomization.yaml
+++ b/feature-configs/typical-baremetal/sriov/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-bases:
-- ../../deploy/sriov
 kind: Kustomization
+resources:
+- ../../deploy/sriov


### PR DESCRIPTION
## Summary

- Migrate all 51 kustomization.yaml files in feature-configs/ from deprecated bases: field to resources:
- Also migrates patchesStrategicMerge: to patches: syntax where applicable
- Migration performed by running `kustomize edit fix` (v5.8.1) in each affected directory per official guidance ([bases](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/bases/), [patchesStrategicMerge](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesstrategicmerge/))

The bases: field was deprecated in kustomize v2.1.0 and will not be included in the kustomize.config.k8s.io/v1 API.

## How this was done

```bash
for dir in $(grep -rl '^bases:' feature-configs/ --include='kustomization.yaml' | xargs -n1 dirname); do
  (cd "$dir" && kustomize edit fix)
done
```

## Jira

https://issues.redhat.com/browse/CNF-22873

## Test plan

- [ ] Verify kustomize build succeeds on all updated files
- [ ] Verify make test-kustomize passes (once PR #3097 merges)