### PR TITLE
CNF-22895: cnf-tests: Add retry logic to git submodule initialization

### DIFF
--- a/cnf-tests/hack/init-git-submodules.sh
+++ b/cnf-tests/hack/init-git-submodules.sh
@@ -5,6 +5,26 @@ cd "$(dirname "$0")"/..
 set -x
 set -e
 
+# Retry wrapper to handle transient DNS/network failures in CI
+retry() {
+    local max_attempts=3
+    local attempt=1
+    local delay=5
+    while [ $attempt -le $max_attempts ]; do
+        if "$@"; then
+            return 0
+        fi
+        if [ $attempt -lt $max_attempts ]; then
+            echo "'$*' failed (attempt $attempt/$max_attempts), retrying in ${delay}s..."
+            sleep $delay
+            delay=$((delay * 2))
+        fi
+        attempt=$((attempt + 1))
+    done
+    echo "'$*' failed after $max_attempts attempts"
+    return 1
+}
+
 if [ -n "$TARGET_RELEASE" ]; then
     SRIOV_NETWORK_OPERATOR_TARGET_COMMIT="$TARGET_RELEASE"
     CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT="$TARGET_RELEASE"
@@ -14,11 +34,11 @@ echo "sriov-operator target commit: ${SRIOV_NETWORK_OPERATOR_TARGET_COMMIT}"
 echo "cluster-node-tuning-operator target commit: ${CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT}"
 
 cd submodules/sriov-network-operator/
-git fetch --all
+retry git fetch origin
 git checkout origin/"${SRIOV_NETWORK_OPERATOR_TARGET_COMMIT}"
 
 cd ../cluster-node-tuning-operator/
-git fetch --all
+retry git fetch origin
 git checkout origin/"${CLUSTER_NODE_TUNING_OPERATOR_TARGET_COMMIT}"
 
 # cluster-node-tuning-operator's test suite need binary files to be compiled before running test


### PR DESCRIPTION
## Summary
- Add `retry()` wrapper with exponential backoff (3 attempts, 5s/10s delay) around `git fetch` calls in `cnf-tests/hack/init-git-submodules.sh`
- Fixes transient DNS failures (`Could not resolve host: github.com`) that kill the e2e job and require a full re-queue (1+ hour wait)
- Switch `git fetch --all` to `git fetch origin` since only origin refs are used for checkout

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [openshift-kni/cnf-features-deploy#3957](https://github.com/openshift-kni/cnf-features-deploy/pull/3957) | [CNF-22869](https://redhat.atlassian.net/browse/CNF-22869): Fix typos across the codebase | Open |
| [openshift/release#82628](https://github.com/openshift/release/pull/82628) | ci: improve image-based e2e step reliability with retries and validation | Open |
| [palmsoftware/quick-k8s#395](https://github.com/palmsoftware/quick-k8s/pull/395) | refactor: Extract shared retry_with_backoff function for install scripts | Merged |

## Jira
- [CNF-22895](https://issues.redhat.com/browse/CNF-22895) — Add retry logic to git submodule initialization in CI (Code Review)
- Epic: [CNF-23511](https://issues.redhat.com/browse/CNF-23511) — cnf-features-deploy Tuning (In Progress)

## Test Plan
- [ ] CI passes
- [ ] Verify `init-git-submodules.sh` still works when fetch succeeds on first try
- [ ] Verify retry logic triggers on transient failures
