### PR TITLE
cnf-tests: Fix primary NIC detection in knmstate SR-IOV test

### DIFF
--- a/cnf-tests/testsuites/e2esuite/knmstate/knmstate_sriov.go
+++ b/cnf-tests/testsuites/e2esuite/knmstate/knmstate_sriov.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
+	"strings"
 	"time"
 
 	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
@@ -211,12 +211,7 @@ func getPrimaryNICForNode(node string) (string, error) {
 		return "", err
 	}
 
-	exp, err := regexp.Compile("\r\n")
-	if err != nil {
-		return "", err
-	}
-
-	return exp.ReplaceAllString(string(buf), ""), nil
+	return strings.TrimSpace(string(buf)), nil
 }
 
 func waitForNMStatePolicyToBeStable(nmstatePolicyName string) {

--- a/cnf-tests/testsuites/pkg/utils/reporter.go
+++ b/cnf-tests/testsuites/pkg/utils/reporter.go
@@ -7,6 +7,8 @@ import (
 	gkopv1alpha "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
 	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	sriovNamespaces "github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/namespaces"
+	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
+	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
 	gkv1alpha "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/v1alpha1"
 	ocpbuildv1 "github.com/openshift/api/build/v1"
 	ocpv1 "github.com/openshift/api/config/v1"
@@ -77,6 +79,14 @@ func NewReporter(reportPath string) (*k8sreporter.KubernetesReporter, error) {
 		if err != nil {
 			return err
 		}
+		err = nmstatev1.AddToScheme(s)
+		if err != nil {
+			return err
+		}
+		err = nmstatev1beta1.AddToScheme(s)
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -136,6 +146,9 @@ func NewReporter(reportPath string) (*k8sreporter.KubernetesReporter, error) {
 		{Cr: &ocpbuildv1.BuildList{}, Namespace: &namespaces.SroTestNamespace},
 		{Cr: &multinetpolicyv1.MultiNetworkPolicyList{}},
 		{Cr: &netattdefv1.NetworkAttachmentDefinitionList{}},
+		{Cr: &nmstatev1.NodeNetworkConfigurationPolicyList{}},
+		{Cr: &nmstatev1beta1.NodeNetworkConfigurationEnactmentList{}},
+		{Cr: &nmstatev1beta1.NodeNetworkStateList{}},
 	}
 
 	namespaceToLog := func(ns string) bool {


### PR DESCRIPTION
The \r\n regex didn't strip Unix-style \n line endings from the
ovs-vsctl output, causing the primary NIC to not be excluded.