### PR TITLE
CNF-22668: Replace centos references with ubi

### DIFF
--- a/cnf-tests/GATEKEEPER.md
+++ b/cnf-tests/GATEKEEPER.md
@@ -80,7 +80,7 @@ metadata:
 spec:
   containers:
   - name: main
-    image: centos
+    image: ubi9
     command: ["/bin/bash", "-c", "sleep INF"]
 EOF    
 ```
@@ -107,7 +107,7 @@ spec:
     operator: Exists
   containers:
   - name: main
-    image: centos
+    image: ubi9
     command: ["/bin/bash", "-c", "sleep INF"]
 EOF
 ```
@@ -134,7 +134,7 @@ spec:
   - operator: "Exists"
   containers:
   - name: podexample
-    image: centos
+    image: ubi9
     command: ["/bin/bash", "-c", "sleep INF"]
 EOF
 ```

--- a/tools/s2i-dpdk/Dockerfile
+++ b/tools/s2i-dpdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 LABEL maintainer="Sebastian Scheinkman <sebassch@gmail.com>"
 LABEL io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"


### PR DESCRIPTION
We should not be using centos at this point, so instead use ubi