### PR TITLE
infra: replace approved/lgtm labels with allow-automatic-merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,18 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles"
-    ],
     "automergeStrategy": "rebase",
     "automergeType": "pr",
     "prConcurrentLimit": 0,
+    "packageRules": [
+        {
+            "addLabels": [
+                "allow-automatic-merge"
+            ],
+            "matchFileNames": [
+                "**/rpms.lock.yaml"
+            ]
+        }
+    ],
     "dockerfile": {
         "enabled": true,
         "ignoreTests": false,

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles"
+    ],
     "automergeStrategy": "rebase",
     "automergeType": "pr",
     "prConcurrentLimit": 0,
@@ -13,10 +16,8 @@
             {
                 "matchPackageNames": ["*"],
                 "addLabels": [
-                    "approved",
-                    "lgtm"
-                ],
-                "automerge": true
+                    "allow-automatic-merge"
+                ]
             }
         ]
     },
@@ -35,17 +36,14 @@
         "includePaths": [
             ".tekton/**"
         ],
-        "platformAutomerge": true,
         "schedule": [
             "at any time"
         ],
         "packageRules": [
             {
                 "addLabels": [
-                    "approved",
-                    "lgtm"
+                    "allow-automatic-merge"
                 ],
-                "automerge": true,
                 "matchUpdateTypes": [
                     "digest"
                 ]


### PR DESCRIPTION
Replace approved/lgtm labels with the new allow-automatic-merge label so Tide controls the merge flow. Remove automerge from dockerfile packageRules.


Ref: [CNF-22981](https://redhat.atlassian.net/browse/CNF-22981)