### PR TITLE
Restrict MintMaker submodule updates to NTO

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,7 +77,7 @@
                     "allow-automatic-merge"
                 ],
                 "matchFileNames": [
-                    "cnf-tests/submodules/**"
+                    "cnf-tests/submodules/cluster-node-tuning-operator"
                 ],
                 "additionalBranchPrefix": "cnf-tests/submodules-"
             },


### PR DESCRIPTION
Disable Renovate updates for all submodules under cnf-tests/submodules/ and re-enable only cluster-node-tuning-operator. This stops unwanted PRs for sriov-network-operator and metallb-operator.