### PR TITLE
infra: add allow-automatic-merge label to git-submodule PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -61,6 +61,9 @@
         "enabled": true,
         "packageRules": [
             {
+                "addLabels": [
+                    "allow-automatic-merge"
+                ],
                 "matchFileNames": [
                     "ztp/resource-generator/**"
                 ],
@@ -70,10 +73,25 @@
                 "additionalBranchPrefix": "ztp/resource-generator-"
             },
             {
+                "addLabels": [
+                    "allow-automatic-merge"
+                ],
                 "matchFileNames": [
                     "cnf-tests/submodules/**"
                 ],
                 "additionalBranchPrefix": "cnf-tests/submodules-"
+            },
+            {
+                "addLabels": [
+                    "allow-automatic-merge"
+                ],
+                "matchPackageNames": [
+                    "https://github.com/openshift-kni/telco5g-konflux.git"
+                ],
+                "schedule": [
+                    "at any time"
+                ],
+                "additionalBranchPrefix": "telco5g-konflux-"
             }
         ]
     }


### PR DESCRIPTION
Add the allow-automatic-merge label to all git-submodule package rules so that Renovate/Mintmaker PRs for submodule updates can be automatically merged, matching the pattern used in other repos like lifecycle-agent.

Also add a dedicated rule for the telco5g-konflux submodule which was previously missing from the renovate configuration.