### PR TITLE
CNF-24997: Add OLM annotation linting workflow

### DIFF
--- a/.github/workflows/olm-lint.yaml
+++ b/.github/workflows/olm-lint.yaml
@@ -1,0 +1,17 @@
+name: OLM Lint
+on:
+  pull_request:
+    paths:
+      - '**.yaml'
+      - '**.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: openshift-kni/olm-annotation-lint@v1
+        with:
+          path: "."
+          exclude: "vendor,testdata,submodules,telco-reference,reference-crs-kube-compare"
+          format: "github"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ export FEATURES_ENVIRONMENT?=deploy
 	ci-job \
 	feature-deploy \
 	cnf-tests-local \
-	test-bin
+	test-bin \
+	olm-annotation-lint
 
 TARGET_GOOS=linux
 TARGET_GOARCH=amd64
@@ -26,6 +27,19 @@ CACHE_DIR="_cache"
 TOOLS_DIR="$(CACHE_DIR)/tools"
 
 $(shell mkdir -p $(TOOLS_DIR))
+
+OAL_OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+OAL_ARCH := $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+OAL_BIN := _cache/tools/olm-annotation-lint
+OAL_URL := https://github.com/openshift-kni/olm-annotation-lint/releases/latest/download/olm-annotation-lint-$(OAL_OS)-$(OAL_ARCH)
+
+$(OAL_BIN):
+	@echo "Downloading olm-annotation-lint ($(OAL_OS)/$(OAL_ARCH))..."
+	@curl -sfL $(OAL_URL) -o $(OAL_BIN) && chmod +x $(OAL_BIN) \
+		|| (echo "Failed to download olm-annotation-lint for $(OAL_OS)/$(OAL_ARCH)"; rm -f $(OAL_BIN); exit 1)
+
+olm-annotation-lint: $(OAL_BIN)
+	@echo "olm-annotation-lint available at $(OAL_BIN)"
 
 # Export GO111MODULE=on to enable project to be built from within GOPATH/src
 export GO111MODULE=on

--- a/feature-configs/deploy/gatekeeper/operatorGroup.yaml
+++ b/feature-configs/deploy/gatekeeper/operatorGroup.yaml
@@ -1,8 +1,6 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  annotations:
-    olm.providedAPIs: Gatekeeper.v1alpha1.operator.gatekeeper.sh
   name: global-operators
   namespace: openshift-operators
 spec: {}

--- a/feature-configs/deploy/knmstate/operator_operatorgroup.yaml
+++ b/feature-configs/deploy/knmstate/operator_operatorgroup.yaml
@@ -1,8 +1,6 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  annotations:
-    olm.providedAPIs: NMState.v1.nmstate.io
   name: openshift-nmstate
   namespace: openshift-nmstate
 spec:


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs [olm-annotation-lint](https://github.com/openshift-kni/olm-annotation-lint) on PRs touching YAML files
- Adds a `make olm-annotation-lint` target that downloads the latest release binary (auto-detects OS/arch, cached in `_cache/tools/`)
- Catches invalid, misspelled, or misused OLM annotations before they reach the cluster
- Removes `olm.providedAPIs` annotations from two OperatorGroup manifests — this annotation is controller-managed and OLM overwrites it on reconciliation, so the manually-set values had no effect at runtime
- Excludes `vendor`, `testdata`, `submodules` (linted in their own repos), `telco-reference` (submodule), and `reference-crs-kube-compare` (contains Go templates)

## Files fixed

- `feature-configs/deploy/knmstate/operator_operatorgroup.yaml` — removed `olm.providedAPIs: NMState.v1.nmstate.io`
- `feature-configs/deploy/gatekeeper/operatorGroup.yaml` — removed `olm.providedAPIs: Gatekeeper.v1alpha1.operator.gatekeeper.sh`

These were likely copy-pasted from a running cluster where OLM had already populated the annotation. Removing them has no functional impact since OLM sets this annotation automatically during OperatorGroup reconciliation.

## Related to

- openshift-kni/telco-reference#760

## Test plan

- [x] Ran `olm-annotation-lint` locally against the repo with these excludes — 0 errors, 0 actionable warnings
- [x] The two removed annotations are controller-managed and have no effect on deployment
- [x] `make olm-annotation-lint` downloads the binary and caches it in `_cache/tools/`

Ref: [CNF-24997](https://redhat.atlassian.net/browse/CNF-24997)