### PR TITLE
infra: renovate: bump NTO submodule at any time

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,9 @@
                 "matchFileNames": [
                     "cnf-tests/submodules/**"
                 ],
+                "schedule": [
+                    "at any time"
+                ],
                 "additionalBranchPrefix": "cnf-tests/submodules-"
             },
             {


### PR DESCRIPTION
This is currently done on weekly schedule, but it is not sufficient when there are updates that need to be consumed say at the 8th day (1 day after the last bump). Update the schedule to bump the submodule at any time.