### PR TITLE
ztp: CNF-23556: CNF-23557: adapt to telco-reference restructure of telco-ran

### DIFF
--- a/ztp/gitops-subscriptions/Makefile
+++ b/ztp/gitops-subscriptions/Makefile
@@ -2,9 +2,9 @@
 export KUSTOMIZE_PLUGIN_HOME=$(PWD)/.config/kustomize/plugin
 export XDG_CONFIG_HOME=$(KUSTOMIZE_PLUGIN_HOME)
 
-ACM_POLICYGEN_EX_DIR=../resource-generator/telco-reference/telco-ran/configuration/argocd/example/acmpolicygenerator
+ACM_POLICYGEN_EX_DIR=../resource-generator/telco-reference/telco-ran/configuration/acmpolicygenerator
 ACM_POLICYGEN_KUSTOMIZE_DIR=$(XDG_CONFIG_HOME)/policy.open-cluster-management.io/v1/policygenerator
-POLICYGEN_EX_DIR=../resource-generator/telco-reference/telco-ran/configuration/argocd/example/policygentemplates
+POLICYGEN_EX_DIR=../resource-generator/telco-reference/telco-ran/configuration/policygentemplates
 POLICYGEN_KUSTOMIZE_DIR=$(XDG_CONFIG_HOME)/ran.openshift.io/v1/policygentemplate
 KUSTOMIZE_DIR=/tmp
 KUSTOMIZE_BIN=$(KUSTOMIZE_DIR)/kustomize
@@ -14,7 +14,7 @@ POLICYGEN_DIR := ../policygenerator
 SOURCE_CRS_DIR := ../resource-generator/telco-reference/telco-ran/configuration/source-crs
 PGT2ACMPG_TOOL_DIR := ../tools/pgt2acmpg
 # pgt2acmpg
-ACMPG_FROM_PGT_DIR=../resource-generator/telco-reference/telco-ran/configuration/argocd/example/acmpgfrompgt
+ACMPG_FROM_PGT_DIR=../resource-generator/telco-reference/telco-ran/configuration/acmpgfrompgt
 
 .PHONY: build test gen-files clean
 

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -51,7 +51,13 @@ ENV TELCO_REF=resource-generator/telco-reference/telco-ran/configuration
 COPY --from=builder $BUILDER_ZTP/$TELCO_REF/source-crs source-crs
 COPY --from=builder $BUILDER_ZTP/$TELCO_REF/source-crs/extra-manifest extra-manifest
 COPY --from=builder $BUILDER_ZTP/$TELCO_REF/argocd argocd
+COPY --from=builder $BUILDER_ZTP/$TELCO_REF/acmpolicygenerator acmpolicygenerator
+COPY --from=builder $BUILDER_ZTP/$TELCO_REF/policygentemplates policygentemplates
+COPY --from=builder $BUILDER_ZTP/$TELCO_REF/template-values template-values
 COPY --from=builder $BUILDER_ZTP/$TELCO_REF/kube-compare-reference reference
+# Backward-compat symlinks: old paths still work after directory restructure
+RUN ln -s ../../acmpolicygenerator argocd/example/acmpolicygenerator \
+ && ln -s ../../policygentemplates argocd/example/policygentemplates
 RUN chown -R 1001:1001 $ZTP_HOME
 # Copy in the entrypoint scripts
 COPY --from=builder $BUILDER_ZTP/resource-generator/entrypoints/* /usr/bin

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -56,7 +56,8 @@ COPY --from=builder $BUILDER_ZTP/$TELCO_REF/policygentemplates policygentemplate
 COPY --from=builder $BUILDER_ZTP/$TELCO_REF/template-values template-values
 COPY --from=builder $BUILDER_ZTP/$TELCO_REF/kube-compare-reference reference
 # Backward-compat symlinks: old paths still work after directory restructure
-RUN ln -s ../../acmpolicygenerator argocd/example/acmpolicygenerator \
+RUN rm -rf argocd/example/acmpolicygenerator argocd/example/policygentemplates \
+ && ln -s ../../acmpolicygenerator argocd/example/acmpolicygenerator \
  && ln -s ../../policygentemplates argocd/example/policygentemplates
 RUN chown -R 1001:1001 $ZTP_HOME
 # Copy in the entrypoint scripts

--- a/ztp/resource-generator/README.md
+++ b/ztp/resource-generator/README.md
@@ -1,7 +1,10 @@
 ## Building the container
-The ztp-site-generator container image contains the kustomize plugin binaries SiteConfig and PolicyGenTemplate under /kustomize/plugin directory.
+The ztp-site-generator container image contains the kustomize plugin binaries SiteConfig and PolicyGenerator under /kustomize/plugin directory.
 AND contains the mandatory patch files to configure the hub cluster for ztp deployment. The files exist under following directories :
-  - /home/ztp/source-crs: contain the source CRs files that SiteConfig and PolicyGenTemplate use to generate the custom resources.
+  - /home/ztp/acmpolicygenerator: PolicyGenerator CRs for all supported DU configurations (recommended).
+  - /home/ztp/policygentemplates: deprecated PolicyGenTemplate CRs (use PolicyGenerator instead).
+  - /home/ztp/template-values: ConfigMaps for hub-side templating (hardware-types, zones, site-data).
+  - /home/ztp/source-crs: contain the source CRs files that PolicyGenerator uses to generate the custom resources.
   - /home/ztp/argocd: check the argocd readme for more info on how to configure ArgoCD in the hub cluster.
   - Run ``` $make build ``` to build ztp-site-generator container image.
 
@@ -13,8 +16,11 @@ $ tree out/ -L 2
 out/
 ├── exportkustomize.sh
 ├── kustomize
-│   └── plugin
+│   └── plugin
 └── ztp
+    ├── acmpolicygenerator
+    ├── policygentemplates
+    ├── template-values
     ├── argocd
     ├── extra-manifest
     └── source-crs

--- a/ztp/resource-generator/entrypoints/entrypoints
+++ b/ztp/resource-generator/entrypoints/entrypoints
@@ -12,16 +12,26 @@ template and example distribution
 ---------------------------------
 
 /home/ztp
+  ├── acmpolicygenerator
+  │   - PolicyGenerator CRs for all supported DU configurations (recommended)
+  ├── policygentemplates
+  │   - Deprecated PolicyGenTemplate CRs (use PolicyGenerator instead)
+  ├── template-values
+  │   - ConfigMaps for hub-side templating (hardware-types, zones, site-data)
   ├── argocd
-  │   ├── deployment
-  │   │   - Yaml files that configure the hub cluster and ArgoCD with our kustomize plugins
-  │   └── example
-  │       ├── policygentemplates
-  │       │   - Example PolicyGenTemplate files for all supported DU configurations
+  │   ├── deployment
+  │   │   - Yaml files that configure the hub cluster and ArgoCD with our kustomize plugins
+  │   └── example
+  │       ├── acmpolicygenerator -> ../../acmpolicygenerator (symlink)
+  │       ├── policygentemplates -> ../../policygentemplates (symlink)
+  │       ├── clusterinstance
+  │       ├── image-based-upgrades
+  │       ├── optional-extra-manifest
+  │       └── siteconfig
   ├── extra-manifest
   │   - The set of extra manifests that are applied at day-0 by ClusterInstance
   └── source-crs
-      - The set of CRs that are available to be configured via PolicyGenTemplate
+      - The set of CRs that are available to be configured via PolicyGenerator
 
 You can export these templates and examples by running the following commands:
 

--- a/ztp/tools/pgt2acmpg/README.md
+++ b/ztp/tools/pgt2acmpg/README.md
@@ -46,9 +46,28 @@ so for instance, an example to generate policies for PGT and ACMPG would be:
 
 ```
 
-## Running from official ztp container
+## Running from the ztp-site-generator container
 
-The pgt2acmpg executable is also part of the official ZTP container. To run the pgt2acmpg tool run the following podmand command:
+The ztp-site-generator container bundles the pgt2acmpg binary and the source CRs. To convert a local PGT directory, mount only the input and output directories:
+
+```
+podman run --rm \
+  -v $(pwd)/policygentemplates:/input:Z \
+  -v $(pwd)/acmpg-output:/output:Z \
+  quay.io/openshift-kni/ztp-site-generator:latest \
+  pgt2acmpg \
+  -i /input \
+  -o /output \
+  -c /home/ztp/source-crs
+```
+
+`-v $(pwd)/policygentemplates:/input:Z`: mount for input PGT directory
+`-v $(pwd)/acmpg-output:/output:Z`: mount for output ACM PolicyGenerator directory
+`-c /home/ztp/source-crs`: source CRs bundled in the container
+
+### Running with an external PolicyGenerator plugin
+
+If you need to use a specific version of the PolicyGenerator plugin instead of the one bundled in the container:
 
 ```
 podman run \
@@ -66,20 +85,18 @@ pgt2acmpg \
 -g
 ```
 
-`--user root:root` : overwrides the default container UID  
+`--user root:root` : overrides the default container UID
 `-e KUSTOMIZE_PLUGIN_HOME=/kustomize-pgt2acmpg`: environment variable indicating the location of the kustomize plugins  
-`-v $(pwd)/output:/home/ztp:Z`: the output directoy to retrieve the acmpg-out.yaml and pgt-out.yaml generated ACM policies
-`-v $(pwd)/PolicyGenerator:/kustomize-pgt2acmpg/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator:Z`: mount the PolicyGenerator plugin executable see [Getting the PolicyGennerator executable](#getting-the-policygennerator-executable) on how to download it.
+`-v $(pwd)/output:/home/ztp:Z`: the output directory to retrieve the acmpg-out.yaml and pgt-out.yaml generated ACM policies
+`-v $(pwd)/PolicyGenerator:/kustomize-pgt2acmpg/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator:Z`: mount the PolicyGenerator plugin executable see [Getting the PolicyGenerator executable](#getting-the-policygenerator-executable) on how to download it.
 `-v $(pwd)/policygentemplates:/policygentemplates:Z`: mount for input PGT directory  
 `-v $(pwd)/acmpg:/acmpg:Z`: mount for output ACM Policy Gen directory  
-`quay.io/openshift-kni/ztp-site-generator:latest`: Official ZTP image   
-`pgt2acmpg`: pgt2acmpg executable  
 `-i /policygentemplates`: PGT directory  
 `-o /acmpg`: ACM Policy Gen directory  
 `-c /policygentemplates/source-crs`: source CRs directory  
 `-g`: option to render ACM policies for PGT and ACMPG  
 
-### Getting the PolicyGennerator executable
+### Getting the PolicyGenerator executable
 
 Run the multicluster-operators-subscription image with podman
 ```podman run --name test registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.11 ```

--- a/ztp/tools/pgt2acmpg/README.md
+++ b/ztp/tools/pgt2acmpg/README.md
@@ -46,6 +46,69 @@ so for instance, an example to generate policies for PGT and ACMPG would be:
 
 ```
 
+## OpenAPI schema and merge key injection
+
+The ACM PolicyGenerator plugin uses kustomize strategic merge patch to apply
+patches to source CRs. For CRDs with list fields that merge by a key (e.g.,
+`spec.filters` in ClusterLogForwarder merges by `name`), kustomize needs the
+merge key present in the patch to match the correct list item.
+
+PGT patches typically omit merge keys because the PGT plugin uses its own
+patching strategy. When converting, pgt2acmpg automatically injects the missing
+merge keys by:
+
+1. Reading the OpenAPI schema (`-s` flag) to find which list fields have merge
+   keys (e.g., `x-kubernetes-patch-merge-key: name`)
+2. Reading the source CR to find the merge key value for each list item
+   (e.g., `name: ran-du-labels` from the ClusterLogForwarder source CR)
+3. Adding the merge key to the converted patch so kustomize can match items
+   correctly
+
+The schema also gets copied to the output directory and referenced via
+`openapi.path` in each manifest entry, so the ACM PolicyGenerator plugin
+uses the correct merge strategy at build time.
+
+The recommended schema file is `schema.openapi` from the
+`acmpolicygenerator/` directory in the telco-reference repository.
+
+## Success paths and limitations
+
+### What works
+
+- **Hub-side-templated PGTs**: PGTs using `{{hub ... hub}}` template expressions
+  are converted correctly. Hub templates are preserved as opaque strings in the
+  generated ACMPG output and pass through to the final ACM Policy as-is.
+- **Source CR placeholder handling**: `$variable` placeholders in source CRs
+  (scalars like `$name`, list items like `- $pfNames`, and bare values like
+  `$bbDevConfig`) are commented out in the generated `-MCP-*` source CR variants,
+  along with their parent keys when applicable, to avoid type conflicts during
+  kustomize patching.
+- **Merge key injection**: When an OpenAPI schema is provided (`-s`), merge keys
+  missing from PGT patches are automatically injected from the source CR using
+  positional matching (matching how PGT merges list items by position).
+- **Directory resources in kustomization.yaml**: Resources that reference
+  directories (e.g., `../template-values`) are copied correctly.
+
+### Limitations
+
+- **`-g` flag does not work from the container**: The ztp-site-generator
+  container does not bundle the ACM PolicyGenerator kustomize plugin binary. The
+  `-g` flag (which runs `kustomize build` on the output) only works in CI or
+  locally when the plugin is installed separately. Omit `-g` when running from
+  the container.
+- **OpenAPI schema required for CRDs with list merge keys**: Without `-s`, CRDs
+  like ClusterLogForwarder (which merge `filters`/`outputs` by `name`) will
+  produce incorrect patches. Always provide the schema for accurate conversion.
+- **Patching strategy differences**: PGT uses its own overlay merge (by position,
+  no OpenAPI awareness). ACMPG uses kustomize strategic merge patch (by merge
+  key, schema-aware). In some cases, converted patches may need manual addition
+  of `$patch: replace` directives for fields where kustomize's default merge
+  strategy differs from PGT's overlay behavior.
+- **Non-PGT files**: Files in the kustomization.yaml that are not
+  PolicyGenTemplate CRs (e.g., raw ACM Policy manifests) are copied as resources
+  but not converted. They must be listed under `resources:` (not `generators:`)
+  in the input kustomization.yaml.
+
 ## Running from the ztp-site-generator container
 
 The ztp-site-generator container bundles the pgt2acmpg binary and the source CRs. To convert a local PGT directory, mount only the input and output directories:
@@ -74,7 +137,7 @@ podman run \
 --user root:root \
 -e KUSTOMIZE_PLUGIN_HOME=/kustomize-pgt2acmpg \
 -v $(pwd)/output:/home/ztp:Z \
--v $(pwd)/PolicyGenerator:/kustomize-pgt2acmpg/policy.open-cluster-management.io/PolicyGenerator:Z \
+-v $(pwd)/PolicyGenerator:/kustomize-pgt2acmpg/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator:Z \
 -v $(pwd)/policygentemplates:/policygentemplates:Z \
 -v $(pwd)/acmpg:/acmpg:Z \
 quay.io/openshift-kni/ztp-site-generator:latest \

--- a/ztp/tools/pgt2acmpg/main.go
+++ b/ztp/tools/pgt2acmpg/main.go
@@ -228,7 +228,58 @@ func convertPGTtoACM(outputDir, baseDir, inputFile, outputFile, schema string, p
 			}
 		}
 	}
+	// Set openapi schema path on all manifests that have patches, and inject merge keys
+	if schema != "" {
+		const schemaFileName = "schema.openapi"
+		mergeKeyMap, schemaErr := fileutils.ParseOpenAPISchema(schema)
+		if schemaErr != nil {
+			fmt.Printf("Warning: could not parse schema for merge key injection: %s\n", schemaErr)
+		}
+		for policyIndex := range acmPGTempConversion.Policies {
+			for manifestIndex := range acmPGTempConversion.Policies[policyIndex].Manifests {
+				manifest := &acmPGTempConversion.Policies[policyIndex].Manifests[manifestIndex]
+				if len(manifest.Patches) > 0 {
+					manifest.OpenAPI.Path = schemaFileName
+					// Inject merge keys from source CR for schema-defined list fields
+					if mergeKeyMap != nil {
+						sourceCRPath := filepath.Join(filepath.Dir(outputFile), manifest.Path)
+						kind, kindErr := getKindFromSourceCR(sourceCRPath)
+						if kindErr != nil {
+							fmt.Printf("Warning: could not read kind from %s: %s\n", manifest.Path, kindErr)
+						} else if mergeKeys, ok := mergeKeyMap[kind]; ok {
+							if err := fileutils.InjectMergeKeys(manifest.Patches, sourceCRPath, mergeKeys); err != nil {
+								fmt.Printf("Warning: could not inject merge keys for %s: %s\n", manifest.Path, err)
+							}
+						}
+					}
+				}
+			}
+		}
+		schemaDestPath := filepath.Join(filepath.Dir(outputFile), schemaFileName)
+		schemaData, readErr := os.ReadFile(schema)
+		if readErr != nil {
+			return fmt.Errorf("failed to read schema file %s, err: %w", schema, readErr)
+		}
+		if writeErr := os.WriteFile(schemaDestPath, schemaData, fileutils.DefaultFileWritePermissions); writeErr != nil {
+			return fmt.Errorf("failed to copy schema file to %s, err: %w", schemaDestPath, writeErr)
+		}
+		fmt.Printf("Copied schema file to %s\n", schemaDestPath)
+	}
 	return writeConvertedTemplateToFile(&policyGenTemp, &acmPGTempConversion, outputFile)
+}
+
+func getKindFromSourceCR(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+	var cr struct {
+		Kind string `yaml:"kind"`
+	}
+	if err := yaml.Unmarshal(data, &cr); err != nil {
+		return "", fmt.Errorf("failed to unmarshal: %w", err)
+	}
+	return cr.Kind, nil
 }
 
 // writeConvertedTemplateToFile write the ACM Policy Generator object to a yaml file

--- a/ztp/tools/pgt2acmpg/packages/fileutils/fileutils.go
+++ b/ztp/tools/pgt2acmpg/packages/fileutils/fileutils.go
@@ -202,12 +202,22 @@ func RenameACMPGsInKustomization(relativeFilePath, inputDir, outputDir string) (
 	updatedKustomization.Bases = append(updatedKustomization.Bases, kustomization.Bases...)
 	// Copy all resources to destination directory
 	for _, r := range kustomization.Resources {
-		_, err = Copy(filepath.Join(inputDir, filepath.Dir(relativeFilePath), r), filepath.Join(outputDir, filepath.Dir(relativeFilePath), r))
+		src := filepath.Join(inputDir, filepath.Dir(relativeFilePath), r)
+		dst := filepath.Join(outputDir, filepath.Dir(relativeFilePath), r)
+		srcInfo, statErr := os.Stat(src)
+		if statErr != nil {
+			return fmt.Errorf("could not stat resource %s, err: %s", src, statErr)
+		}
+		if srcInfo.IsDir() {
+			err = CopyDirectory(src, dst)
+		} else {
+			_, err = Copy(src, dst)
+		}
 		if err != nil {
-			return fmt.Errorf("could not copy file from %s to %s, err:%s", filepath.Join(inputDir, r), filepath.Join(outputDir, r), err)
+			return fmt.Errorf("could not copy resource from %s to %s, err:%s", src, dst, err)
 		}
 		updatedKustomization.Resources = append(updatedKustomization.Resources, r)
-		fmt.Printf("Wrote Kustomization resource: %s\n", filepath.Join(outputDir, r))
+		fmt.Printf("Wrote Kustomization resource: %s\n", dst)
 	}
 	// Marshal the struct back to YAML
 	outputContent, err := yaml.Marshal(updatedKustomization)

--- a/ztp/tools/pgt2acmpg/packages/fileutils/fileutils.go
+++ b/ztp/tools/pgt2acmpg/packages/fileutils/fileutils.go
@@ -32,37 +32,85 @@ spec:
 `
 )
 
-// CommentOutMCPLines Comments out lines containing the "$mcp" keyword
+var (
+	scalarPlaceholderPattern   = regexp.MustCompile(`^(\s*)\S+: \$\S*`)
+	listItemPlaceholderPattern = regexp.MustCompile(`^(\s*)- \$\S*`)
+	barePlaceholderPattern     = regexp.MustCompile(`^\s+\$\S+\s*$`)
+)
+
+// CommentOutLinesWithPlaceholders comments out lines containing $variable placeholders.
+// When a placeholder is a list item or bare value, the parent key is also commented out
+// if the placeholder was its only child.
 func CommentOutLinesWithPlaceholders(inputFile string) error {
 	contents, err := os.ReadFile(inputFile)
 	if err != nil {
 		return fmt.Errorf("unable to open file: %s, err: %s ", inputFile, err)
 	}
 
-	pattern := regexp.MustCompile(`.*: \$\S*`)
-
-	// Split the file contents into lines
 	lines := strings.Split(string(contents), "\n")
 
-	// comment out every lines matching pattern
 	var modifiedLines []string
-	for _, line := range lines {
-		if pattern.MatchString(line) {
-			// Comment out the line by adding "//" at the beginning
+	for i, line := range lines {
+		if scalarPlaceholderPattern.MatchString(line) {
 			line = "# " + line
+		} else if barePlaceholderPattern.MatchString(line) {
+			line = "# " + line
+			commentOutParentKeyIfSoleChild(lines, modifiedLines, i)
+		} else if listItemPlaceholderPattern.MatchString(line) {
+			line = "# " + line
+			commentOutParentKeyIfSoleChild(lines, modifiedLines, i)
 		}
 
-		// Add the processed line to the result
 		modifiedLines = append(modifiedLines, line)
 	}
 
-	// Join the modified lines
 	modifiedString := strings.Join(modifiedLines, "\n")
 	err = os.WriteFile(inputFile, []byte(modifiedString), DefaultFileWritePermissions)
 	if err != nil {
 		return fmt.Errorf("error writing to file: %s, err: %s", inputFile, err)
 	}
 	return nil
+}
+
+// commentOutParentKeyIfSoleChild looks backward from lineIndex to find the parent key
+// (a line ending with ":"), then scans forward to verify there are no other non-placeholder
+// children. Only comments out the parent if the placeholder is its sole child.
+func commentOutParentKeyIfSoleChild(lines []string, modifiedLines []string, lineIndex int) {
+	parentIdx := -1
+	for j := lineIndex - 1; j >= 0; j-- {
+		trimmed := strings.TrimSpace(lines[j])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasSuffix(trimmed, ":") {
+			parentIdx = j
+		}
+		break
+	}
+	if parentIdx < 0 {
+		return
+	}
+
+	// Scan forward from the parent to check for non-placeholder siblings
+	for k := lineIndex + 1; k < len(lines); k++ {
+		trimmed := strings.TrimSpace(lines[k])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// If next non-empty line is a sibling list item or value, the parent has other children
+		if listItemPlaceholderPattern.MatchString(lines[k]) || barePlaceholderPattern.MatchString(lines[k]) {
+			continue
+		}
+		// Check if still indented under the parent (deeper than parent indentation)
+		parentIndent := len(lines[parentIdx]) - len(strings.TrimLeft(lines[parentIdx], " \t"))
+		lineIndent := len(lines[k]) - len(strings.TrimLeft(lines[k], " \t"))
+		if lineIndent > parentIndent {
+			return
+		}
+		break
+	}
+
+	modifiedLines[parentIdx] = "# " + modifiedLines[parentIdx]
 }
 
 // RenderMCPLines Replaces the "$mcp" keyword with the mcp string (worker or master)
@@ -204,6 +252,13 @@ func RenameACMPGsInKustomization(relativeFilePath, inputDir, outputDir string) (
 	for _, r := range kustomization.Resources {
 		src := filepath.Join(inputDir, filepath.Dir(relativeFilePath), r)
 		dst := filepath.Join(outputDir, filepath.Dir(relativeFilePath), r)
+		absSrc, _ := filepath.Abs(src)
+		absDst, _ := filepath.Abs(dst)
+		if absSrc == absDst {
+			fmt.Printf("Skipping resource %s: source and destination are the same path\n", r)
+			updatedKustomization.Resources = append(updatedKustomization.Resources, r)
+			continue
+		}
 		srcInfo, statErr := os.Stat(src)
 		if statErr != nil {
 			return fmt.Errorf("could not stat resource %s, err: %s", src, statErr)

--- a/ztp/tools/pgt2acmpg/packages/fileutils/fileutils.go
+++ b/ztp/tools/pgt2acmpg/packages/fileutils/fileutils.go
@@ -33,9 +33,10 @@ spec:
 )
 
 var (
-	scalarPlaceholderPattern   = regexp.MustCompile(`^(\s*)\S+: \$\S*`)
-	listItemPlaceholderPattern = regexp.MustCompile(`^(\s*)- \$\S*`)
-	barePlaceholderPattern     = regexp.MustCompile(`^\s+\$\S+\s*$`)
+	scalarPlaceholderPattern         = regexp.MustCompile(`^(\s*)\S+: \$\S*`)
+	listItemPlaceholderPattern       = regexp.MustCompile(`^(\s*)- \$\S*`)
+	listItemScalarPlaceholderPattern = regexp.MustCompile(`^(\s*)- \S+: \$\S*`)
+	barePlaceholderPattern           = regexp.MustCompile(`^\s+\$\S+\s*$`)
 )
 
 // CommentOutLinesWithPlaceholders comments out lines containing $variable placeholders.
@@ -51,7 +52,10 @@ func CommentOutLinesWithPlaceholders(inputFile string) error {
 
 	var modifiedLines []string
 	for i, line := range lines {
-		if scalarPlaceholderPattern.MatchString(line) {
+		if listItemScalarPlaceholderPattern.MatchString(line) {
+			line = "# " + line
+			commentOutParentKeyIfSoleChild(lines, modifiedLines, i)
+		} else if scalarPlaceholderPattern.MatchString(line) {
 			line = "# " + line
 		} else if barePlaceholderPattern.MatchString(line) {
 			line = "# " + line
@@ -98,7 +102,7 @@ func commentOutParentKeyIfSoleChild(lines []string, modifiedLines []string, line
 			continue
 		}
 		// If next non-empty line is a sibling list item or value, the parent has other children
-		if listItemPlaceholderPattern.MatchString(lines[k]) || barePlaceholderPattern.MatchString(lines[k]) {
+		if listItemPlaceholderPattern.MatchString(lines[k]) || listItemScalarPlaceholderPattern.MatchString(lines[k]) || barePlaceholderPattern.MatchString(lines[k]) {
 			continue
 		}
 		// Check if still indented under the parent (deeper than parent indentation)

--- a/ztp/tools/pgt2acmpg/packages/fileutils/fileutils_test.go
+++ b/ztp/tools/pgt2acmpg/packages/fileutils/fileutils_test.go
@@ -1,0 +1,89 @@
+package fileutils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCommentOutLinesWithPlaceholders(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "scalar placeholder",
+			input:    "apiVersion: v1\nmetadata:\n  name: $name\n",
+			expected: "apiVersion: v1\nmetadata:\n#   name: $name\n",
+		},
+		{
+			name:     "list item placeholder",
+			input:    "items:\n  - $item\n",
+			expected: "# items:\n#   - $item\n",
+		},
+		{
+			name:     "bare placeholder",
+			input:    "parent:\n  $value\n",
+			expected: "# parent:\n#   $value\n",
+		},
+		{
+			name: "list item with key-value placeholder",
+			input: `status:
+  conditions:
+    - reason: $reason
+      status: $status
+      type: $type
+`,
+			expected: `status:
+  conditions:
+#     - reason: $reason
+#       status: $status
+#       type: $type
+`,
+		},
+		{
+			name: "mixed list items with and without placeholders",
+			input: `spec:
+  ports:
+    - name: http
+      port: 80
+    - name: $portName
+`,
+			expected: `spec:
+  ports:
+    - name: http
+      port: 80
+#     - name: $portName
+`,
+		},
+		{
+			name:     "no placeholders unchanged",
+			input:    "apiVersion: v1\nkind: ConfigMap\n",
+			expected: "apiVersion: v1\nkind: ConfigMap\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.yaml")
+			if err := os.WriteFile(tmpFile, []byte(tt.input), 0o600); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+
+			if err := CommentOutLinesWithPlaceholders(tmpFile); err != nil {
+				t.Fatalf("CommentOutLinesWithPlaceholders returned error: %v", err)
+			}
+
+			got, err := os.ReadFile(tmpFile)
+			if err != nil {
+				t.Fatalf("failed to read result file: %v", err)
+			}
+
+			if string(got) != tt.expected {
+				t.Errorf("mismatch\ngot:\n%s\nexpected:\n%s", string(got), tt.expected)
+			}
+		})
+	}
+}

--- a/ztp/tools/pgt2acmpg/packages/fileutils/mergekeys.go
+++ b/ztp/tools/pgt2acmpg/packages/fileutils/mergekeys.go
@@ -1,0 +1,170 @@
+package fileutils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type schemaProperty struct {
+	Type                       string                    `json:"type"`
+	PatchStrategy              string                    `json:"x-kubernetes-patch-strategy"`
+	PatchMergeKey              string                    `json:"x-kubernetes-patch-merge-key"`
+	Properties                 map[string]schemaProperty `json:"properties"`
+	KubernetesGroupVersionKind []struct {
+		Group   string `json:"group"`
+		Kind    string `json:"kind"`
+		Version string `json:"version"`
+	} `json:"x-kubernetes-group-version-kind"`
+}
+
+type openAPISchema struct {
+	Definitions map[string]schemaProperty `json:"definitions"`
+}
+
+// mergeKeyInfo maps a dotted field path (e.g., "spec.filters") to the merge key name (e.g., "name")
+type mergeKeyInfo struct {
+	fieldPath string
+	mergeKey  string
+}
+
+// ParseOpenAPISchema reads a schema.openapi file and returns a map of Kind → []mergeKeyInfo
+func ParseOpenAPISchema(schemaPath string) (map[string][]mergeKeyInfo, error) {
+	data, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read schema file %s: %w", schemaPath, err)
+	}
+
+	var schema openAPISchema
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return nil, fmt.Errorf("failed to parse schema file %s: %w", schemaPath, err)
+	}
+
+	result := make(map[string][]mergeKeyInfo)
+	for _, def := range schema.Definitions {
+		if len(def.KubernetesGroupVersionKind) == 0 {
+			continue
+		}
+		kind := def.KubernetesGroupVersionKind[0].Kind
+		var mergeKeys []mergeKeyInfo
+		collectMergeKeys(def.Properties, "", &mergeKeys)
+		if len(mergeKeys) > 0 {
+			result[kind] = mergeKeys
+		}
+	}
+	return result, nil
+}
+
+// collectMergeKeys recursively walks schema properties to find list fields with merge keys
+func collectMergeKeys(props map[string]schemaProperty, prefix string, result *[]mergeKeyInfo) {
+	for fieldName, prop := range props {
+		path := fieldName
+		if prefix != "" {
+			path = prefix + "." + fieldName
+		}
+		if prop.Type == "array" && prop.PatchStrategy == "merge" && prop.PatchMergeKey != "" {
+			*result = append(*result, mergeKeyInfo{fieldPath: path, mergeKey: prop.PatchMergeKey})
+		}
+		if prop.Properties != nil {
+			collectMergeKeys(prop.Properties, path, result)
+		}
+	}
+}
+
+// InjectMergeKeys adds missing merge keys to patch list items by looking them up in the source CR.
+// It uses the OpenAPI schema to know which list fields have merge keys.
+func InjectMergeKeys(patches []map[string]interface{}, sourceCRPath string, mergeKeys []mergeKeyInfo) error {
+	if len(patches) == 0 || len(mergeKeys) == 0 {
+		return nil
+	}
+
+	sourceCRData, err := os.ReadFile(sourceCRPath)
+	if err != nil {
+		return fmt.Errorf("failed to read source CR %s: %w", sourceCRPath, err)
+	}
+
+	var sourceCR map[string]interface{}
+	if err := yaml.Unmarshal(sourceCRData, &sourceCR); err != nil {
+		return fmt.Errorf("failed to unmarshal source CR %s: %w", sourceCRPath, err)
+	}
+
+	for _, patch := range patches {
+		for _, mk := range mergeKeys {
+			injectMergeKeyAtPath(patch, sourceCR, mk.fieldPath, mk.mergeKey)
+		}
+	}
+	return nil
+}
+
+// injectMergeKeyAtPath walks a dotted path in both patch and sourceCR, and injects merge keys
+func injectMergeKeyAtPath(patch, sourceCR map[string]interface{}, fieldPath, mergeKey string) {
+	parts := strings.Split(fieldPath, ".")
+	patchNode := navigateToParent(patch, parts)
+	sourceCRNode := navigateToParent(sourceCR, parts)
+	if patchNode == nil || sourceCRNode == nil {
+		return
+	}
+
+	lastField := parts[len(parts)-1]
+	patchList, ok := toSliceOfMaps(patchNode[lastField])
+	if !ok || len(patchList) == 0 {
+		return
+	}
+	sourceCRList, ok := toSliceOfMaps(sourceCRNode[lastField])
+	if !ok || len(sourceCRList) == 0 {
+		return
+	}
+
+	// PGT merges list items by position, so patch item [i] corresponds to source CR item [i]
+	for i, patchItem := range patchList {
+		if _, hasMergeKey := patchItem[mergeKey]; hasMergeKey {
+			continue
+		}
+		if i < len(sourceCRList) {
+			if val, ok := sourceCRList[i][mergeKey]; ok {
+				patchItem[mergeKey] = val
+			}
+		}
+	}
+}
+
+func navigateToParent(node map[string]interface{}, parts []string) map[string]interface{} {
+	current := node
+	// Navigate to the parent of the last part
+	for _, part := range parts[:len(parts)-1] {
+		next, ok := current[part]
+		if !ok {
+			return nil
+		}
+		nextMap, ok := next.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		current = nextMap
+	}
+	return current
+}
+
+func toSliceOfMaps(val interface{}) ([]map[string]interface{}, bool) {
+	if val == nil {
+		return nil, false
+	}
+	switch v := val.(type) {
+	case []interface{}:
+		var result []map[string]interface{}
+		for _, item := range v {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				return nil, false
+			}
+			result = append(result, m)
+		}
+		return result, true
+	case []map[string]interface{}:
+		return v, true
+	}
+	return nil, false
+}


### PR DESCRIPTION
Description:
- Update paths after acmpolicygenerator/ and policygentemplates/ moved from argocd/example/ up to telco-ran/configuration/ root, and template-values/ was extracted as a new shared directory.
- Container layout places the moved dirs at /home/ztp root with backward-compat symlinks from the old argocd/example/ paths.

Co-Authored-By: Claude Opus 4.6 (1M context)

Depends on: https://github.com/openshift-kni/telco-reference/pull/849
