### PR TITLE
cnf-tests: remove unused fmt.Sprintln in dpdk getHugePages

### DIFF
--- a/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
+++ b/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go
@@ -1205,7 +1205,6 @@ func getHugePages(pod *corev1.Pod) string {
 			b := r.FindAllString(line, -1)
 			num := path.Join(b...)
 			number, _ := strconv.ParseInt(num, 10, 0)
-			fmt.Sprintln(number)
 			mb = number / 1024 / 1024
 		}
 	}


### PR DESCRIPTION
## Summary
- Remove dead `fmt.Sprintln(number)` call in `getHugePages()` that causes `go vet` `unusedresult` failures in CI (`result of fmt.Sprintln call not used`).
- Same fix as openshift-kni/cnf-features-deploy#3025 / commit `189a0c22e` on master and release-4.22.

## Context
This unblocks PRs targeting `release-4.21`  where `make ci-job` fails on `govet` despite unrelated changes.

Changes done by Cursor.

## Test plan
- [ ] `go vet -mod=vendor ./cnf-tests/testsuites/...` passes
- [ ] `make ci-job` / `ci/prow/ci` passes


Made with [Cursor](https://cursor.com)