### PR TITLE
fix(ci): use Fedora 44 instead of 45 for CI build root

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,5 +1,5 @@
 # The fedora version used should provide the golang version that matches $GOVERSION
-FROM quay.io/fedora/fedora:45
+FROM quay.io/fedora/fedora:44
 
 ENV GOPATH /go
 ENV GOBIN /go/bin


### PR DESCRIPTION
## Summary
- Switch CI build root base image from Fedora 45 to Fedora 44
- Fedora 45 is still in rawhide/pre-release and its mirrors are unavailable, causing `dnf` metadata download failures that break the `root` image build for all CI jobs (`ztp-ci`, `ci`, etc.)
- Fedora 44 is the current stable release and provides Go 1.26, which is compatible with the `go.mod` requirement of Go 1.25

## Test plan
- [ ] Verify `ztp-ci` job passes with the updated base image
- [ ] Verify `ci` job passes

Made with [Cursor](https://cursor.com)