### PR TITLE
chore: update Telco component URLs from /openshift4/ to /openshift5/ for OCP 5.0

### DIFF
--- a/.tekton/ztp-site-generate-5-0-pull-request.yaml
+++ b/.tekton/ztp-site-generate-5-0-pull-request.yaml
@@ -291,7 +291,7 @@ spec:
         - description=Container Image for Argo CD integration with ACM
         - distribution-scope=public
         - io.k8s.description=ztp-site-generate
-        - name=openshift4/ztp-site-generate-rhel8
+        - name=openshift5/ztp-site-generate-rhel8
         - release=5.0
         - url=https://github.com/openshift-kni/cnf-features-deploy
         - vendor=Red Hat, Inc.

--- a/.tekton/ztp-site-generate-5-0-push.yaml
+++ b/.tekton/ztp-site-generate-5-0-push.yaml
@@ -288,7 +288,7 @@ spec:
         - description=Container Image for Argo CD integration with ACM
         - distribution-scope=public
         - io.k8s.description=ztp-site-generate
-        - name=openshift4/ztp-site-generate-rhel8
+        - name=openshift5/ztp-site-generate-rhel8
         - release=5.0
         - url=https://github.com/openshift-kni/cnf-features-deploy
         - vendor=Red Hat, Inc.

--- a/cnf-tests/.konflux/Dockerfile
+++ b/cnf-tests/.konflux/Dockerfile
@@ -64,19 +64,19 @@ COPY --from=builder-stresser /stresser /usr/bin/stresser
 COPY --from=builder-sctptester /sctptest /usr/bin/sctptest
 COPY --from=builder-hugepages-allocator /hugepages-allocator /usr/bin/hugepages-allocator
 
-RUN sed -i 's/quay.io\/openshift-kni\//registry.redhat.io\/openshift4\//g' /usr/local/etc/cnf/images.json
+RUN sed -i 's/quay.io\/openshift-kni\//registry.redhat.io\/openshift5\//g' /usr/local/etc/cnf/images.json
 RUN sed -i 's/cnf-tests:5.0/cnf-tests-rhel9:v5.0/g' /usr/local/etc/cnf/images.json
 RUN sed -i 's/dpdk:5.0/dpdk-base-rhel9:v5.0/g' /usr/local/etc/cnf/images.json
 
 ENV OCP_VERSION=5.0
-ENV IMAGE_REGISTRY=registry.redhat.io/openshift4/
+ENV IMAGE_REGISTRY=registry.redhat.io/openshift5/
 ENV CNF_TESTS_IMAGE=cnf-tests-rhel9:v${OCP_VERSION}
 ENV DPDK_TESTS_IMAGE=dpdk-base-rhel9:v${OCP_VERSION}
 
 CMD ["/usr/bin/test-run.sh"]
 
 LABEL com.redhat.component="cnf-tests-container" \
-      name="openshift4/cnf-tests-rhel9" \
+      name="openshift5/cnf-tests-rhel9" \
       cpe="cpe:/a:redhat:openshift:5.0::el9" \
       summary="Cluster verification tests image" \
       io.openshift.expose-services="" \

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -73,7 +73,7 @@ USER 1001
 CMD entrypoints
 
 LABEL com.redhat.component="openshift-ztp-site-generate" \
-    name="openshift4/ztp-site-generate-rhel8" \
+    name="openshift5/ztp-site-generate-rhel8" \
     cpe="cpe:/a:redhat:openshift:5.0::el8" \
     summary="ZTP Site Generate" \
     io.openshift.expose-services="" \


### PR DESCRIPTION
## Summary

- Update all `registry.redhat.io/openshift4/` namespace references to `registry.redhat.io/openshift5/` in Telco component Dockerfiles, Containerfiles, and Tekton pipeline configs for OCP 5.0
- Covers cnf-tests, ztp-site-generate labels, IMAGE_REGISTRY env var, and images.json sed replacement

## Context

Per [CNF-26586](https://redhat.atlassian.net/browse/CNF-26586) and [RELENG-536](https://redhat.atlassian.net/browse/RELENG-536), the `openshift5` registry namespace has been created and all Telco components must reference it before OCP 5.0 ships.

## Files changed

| File | Change |
|---|---|
| `cnf-tests/.konflux/Dockerfile` | `sed` replacement target, `IMAGE_REGISTRY` env var, and `name` label |
| `.tekton/ztp-site-generate-5-0-pull-request.yaml` | `name` label |
| `.tekton/ztp-site-generate-5-0-push.yaml` | `name` label |
| `ztp/resource-generator/Containerfile` | `name` label |

## Test plan

- [ ] Verify cnf-tests container image builds successfully with the new registry paths
- [ ] Verify ztp-site-generate container image builds successfully
- [ ] Confirm images resolve correctly from `registry.redhat.io/openshift5/`


Made with [Cursor](https://cursor.com)