### PR TITLE
fix(renovate): prefix git-submodule branches with {{baseBranch}}

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,7 +72,7 @@
                 "schedule": [
                     "at any time"
                 ],
-                "additionalBranchPrefix": "ztp/resource-generator-"
+                "additionalBranchPrefix": "{{baseBranch}}/ztp/resource-generator-"
             },
             {
                 "addLabels": [
@@ -85,7 +85,7 @@
                 "schedule": [
                     "at any time"
                 ],
-                "additionalBranchPrefix": "cnf-tests/submodules-"
+                "additionalBranchPrefix": "{{baseBranch}}/cnf-tests/submodules-"
             },
             {
                 "addLabels": [
@@ -97,7 +97,7 @@
                 "schedule": [
                     "at any time"
                 ],
-                "additionalBranchPrefix": "telco5g-konflux-"
+                "additionalBranchPrefix": "{{baseBranch}}/telco5g-konflux-"
             }
         ]
     }


### PR DESCRIPTION
## Summary
- Prefix renovate git-submodule branch names with `{{baseBranch}}/` so updates for `telco-reference`, cnf-tests submodules, and `telco5g-konflux` stay unique per target branch (`master`, `release-*`, etc.).
- Avoids mintmaker branch collisions when the same submodule bump is opened against more than one base branch.

## Test plan
- [ ] Confirm `renovate.json` still validates against the renovate schema
- [ ] After merge, check that new mintmaker PRs for these submodules use branch names like `master/ztp/resource-generator-...` and `release-4.22/ztp/resource-generator-...`


Made with [Cursor](https://cursor.com)