### PR TITLE
infra: Bump Fedora to 44 and Go to 1.26 in CI Dockerfile

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,11 +1,11 @@
 # The fedora version used should provide the golang version that matches $GOVERSION
-FROM quay.io/fedora/fedora:42
+FROM quay.io/fedora/fedora:44
 
 ENV GOPATH /go
 ENV GOBIN /go/bin
 ENV GOCACHE /go/.cache
 # This should match the version in go.mod
-ENV GOVERSION=1.25
+ENV GOVERSION=1.26
 ENV PATH=$PATH:$GOBIN
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/cnf-features-deploy
 


### PR DESCRIPTION
The sriov-network-operator submodule's go.mod requires go >= 1.26.5, which is not available in Fedora 42 (ships go 1.25.x). Bump the base image to Fedora 44 to pick up go 1.26.