### PR TITLE
ztp: update container for telco-reference manifest layout

### DIFF
--- a/ztp/gitops-subscriptions/Makefile
+++ b/ztp/gitops-subscriptions/Makefile
@@ -22,11 +22,11 @@ build:
 	@echo "ZTP: Build policy generator kustomize plugin"
 	$(MAKE) -C $(POLICYGEN_DIR) build
 	mkdir -p $(POLICYGEN_KUSTOMIZE_DIR)
-	cp -r $(SOURCE_CRS_DIR) $(POLICYGEN_EX_DIR)/
+	cp -rL $(SOURCE_CRS_DIR) $(POLICYGEN_EX_DIR)/
 	cp $(POLICYGEN_DIR)/policygenerator $(POLICYGEN_KUSTOMIZE_DIR)/PolicyGenTemplate
 	@echo "ZTP: setup ACM policyGenerator kustomize plugin"
 	mkdir -p $(ACM_POLICYGEN_KUSTOMIZE_DIR)
-	cp -r $(SOURCE_CRS_DIR) $(ACM_POLICYGEN_EX_DIR)
+	cp -rL $(SOURCE_CRS_DIR) $(ACM_POLICYGEN_EX_DIR)
 	$(PGT2ACMPG_TOOL_DIR)/scripts/build-acmpg-plugin.sh "$(ACM_POLICYGEN_KUSTOMIZE_DIR)"
 
 $(KUSTOMIZE_BIN):

--- a/ztp/policygenerator-kustomize-plugin/Makefile
+++ b/ztp/policygenerator-kustomize-plugin/Makefile
@@ -15,7 +15,7 @@ build:
 	@echo "ZTP: Build policy generator kustomize plugin"
 	$(MAKE) -C $(POLICYGEN_DIR) build
 	mkdir -p $(POLICYGEN_KUSTOMIZE_DIR)
-	cp -r $(SOURCE_CRS_DIR) $(POLICYGEN_KUSTOMIZE_DIR)/
+	cp -rL $(SOURCE_CRS_DIR) $(POLICYGEN_KUSTOMIZE_DIR)/
 	cp $(POLICYGEN_DIR)/policygenerator $(POLICYGEN_KUSTOMIZE_DIR)/PolicyGenTemplate
 
 $(KUSTOMIZE_BIN):

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -16,7 +16,9 @@ RUN ./tools/patchImageReference.sh ../gitops-subscriptions $IMAGE_REF
 
 # This enforces that we create legacy symlinks that match the given snapshot
 # Note: Consider removing this after an appropriate deprecation period (introduced in 4.20)
-RUN ./tools/create_legacy_source-crs_symlinks.sh ./source-crs_layout_4.19.txt \
+RUN cp -r telco-reference/telco-ran/install/clusterinstance/extra-manifests \
+    telco-reference/telco-ran/configuration/source-crs/extra-manifest && \
+    ./tools/create_legacy_source-crs_symlinks.sh ./source-crs_layout_4.19.txt \
     ./telco-reference/telco-ran/configuration/source-crs/
 
 WORKDIR $PGT_ROOT

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -16,11 +16,7 @@ RUN ./tools/patchImageReference.sh ../gitops-subscriptions $IMAGE_REF
 
 # This enforces that we create legacy symlinks that match the given snapshot
 # Note: Consider removing this after an appropriate deprecation period (introduced in 4.20)
-RUN cp -r telco-reference/telco-ran/install/clusterinstance/extra-manifests \
-    telco-reference/telco-ran/configuration/source-crs/extra-manifest && \
-    cp -r telco-reference/telco-ran/install/custom-manifests \
-    telco-reference/telco-ran/configuration/source-crs/optional-extra-manifest && \
-    ./tools/create_legacy_source-crs_symlinks.sh ./source-crs_layout_4.19.txt \
+RUN ./tools/create_legacy_source-crs_symlinks.sh ./source-crs_layout_4.19.txt \
     ./telco-reference/telco-ran/configuration/source-crs/
 
 WORKDIR $PGT_ROOT

--- a/ztp/resource-generator/Containerfile
+++ b/ztp/resource-generator/Containerfile
@@ -16,11 +16,14 @@ RUN ./tools/patchImageReference.sh ../gitops-subscriptions $IMAGE_REF
 
 # This enforces that we create legacy symlinks that match the given snapshot
 # Note: Consider removing this after an appropriate deprecation period (introduced in 4.20)
-RUN ./tools/create_legacy_source-crs_symlinks.sh ./source-crs_layout_4.19.txt ./telco-reference/telco-ran/configuration/source-crs/
+RUN cp -r telco-reference/telco-ran/install/clusterinstance/extra-manifests \
+    telco-reference/telco-ran/configuration/source-crs/extra-manifest && \
+    cp -r telco-reference/telco-ran/install/custom-manifests \
+    telco-reference/telco-ran/configuration/source-crs/optional-extra-manifest && \
+    ./tools/create_legacy_source-crs_symlinks.sh ./source-crs_layout_4.19.txt \
+    ./telco-reference/telco-ran/configuration/source-crs/
 
 WORKDIR $PGT_ROOT
-RUN make build
-WORKDIR $SC_ROOT
 RUN make build
 # Build pgt2acmpg
 WORKDIR $PGT2ACMPG_ROOT
@@ -28,9 +31,6 @@ RUN make build
 RUN make build-pgt-plugin
 # Build siteconfig-converter
 WORKDIR $SITECONFIG_CONVERTER_ROOT
-RUN make build
-
-WORKDIR $SITECONFIG_GENERATOR_ROOT
 RUN make build
 
 # Container image

--- a/ztp/resource-generator/source-crs_layout_4.19.txt
+++ b/ztp/resource-generator/source-crs_layout_4.19.txt
@@ -18,8 +18,6 @@ ibu/ImageBasedUpgradeStatus.yaml
 ibu/PlatformBackupRestore.yaml
 ibu/PlatformBackupRestoreLvms.yaml
 ibu/PlatformBackupRestoreWithIBGU.yaml
-optional-extra-manifest/enable-crun-master.yaml
-optional-extra-manifest/enable-crun-worker.yaml
 validatorCRs/informDuValidator.yaml
 validatorCRs/informDuValidatorMaster.yaml
 validatorCRs/informDuValidatorWorker.yaml
@@ -42,7 +40,6 @@ ClusterLogServiceAccount.yaml
 ClusterLogServiceAccountAuditBinding.yaml
 ClusterLogServiceAccountInfrastructureBinding.yaml
 ClusterLogSubscription.yaml
-ClusterLogging5Cleanup.yaml
 ClusterVersion.yaml
 ConfigMapGeneric.yaml
 ConsoleOperatorDisable.yaml


### PR DESCRIPTION
Copy relocated install manifests into the preserved source-crs layout before generating legacy symlinks. Remove obsolete siteconfig-generator build steps and dereference source-crs symlinks when packaging policy plugins.